### PR TITLE
wire/udata: Explicitly serialize the leaf data count.

### DIFF
--- a/blockchain/utreexoviewpoint.go
+++ b/blockchain/utreexoviewpoint.go
@@ -196,14 +196,6 @@ func ProofSanity(ud *wire.UData, outPoints []wire.OutPoint) error {
 		}
 	}
 
-	// Final check.  The length of the targets should be the same as the leafdata
-	// as targets represent the positions of each of the leafdata hash in the
-	// accumulator.
-	if len(ud.AccProof.Targets) != len(ud.LeafDatas) {
-		return fmt.Errorf("ProofSanity err: %d targets but %d leafdatas\n",
-			len(ud.AccProof.Targets), len(ud.LeafDatas))
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
There exists an edge case where the leaf data count will not match the
batchproof target count.  When the leaf being deleted is a root, there
will not be any proof.  However, we still need to provide the leaf data
for that root for utxo validation (validation of the signature, amount,
etc).

The new serialization for both the compact and normal udata will include
a varint serialized count of the leaf data before the actual leaf data.

The check for targets and leaf data count equality in the function
ProofSanity() is now removed as there is no guarantee that they will be
equal.