### PR TITLE
blockchain, indexers: Add support for proving arbitrary UTXOs with Utreexo proof indexes

### DIFF
--- a/blockchain/common.go
+++ b/blockchain/common.go
@@ -152,19 +152,19 @@ func SolveBlock(header *wire.BlockHeader) bool {
 // SpendableOut represents a transaction output that is spendable along with
 // additional metadata such as the block its in and how much it pays.
 type SpendableOut struct {
-	prevOut wire.OutPoint
-	amount  btcutil.Amount
+	PrevOut wire.OutPoint
+	Amount  btcutil.Amount
 }
 
 // MakeSpendableOutForTx returns a spendable output for the given transaction
 // and transaction output index within the transaction.
 func MakeSpendableOutForTx(tx *wire.MsgTx, txOutIndex uint32) SpendableOut {
 	return SpendableOut{
-		prevOut: wire.OutPoint{
+		PrevOut: wire.OutPoint{
 			Hash:  tx.TxHash(),
 			Index: txOutIndex,
 		},
-		amount: btcutil.Amount(tx.TxOut[txOutIndex].Value),
+		Amount: btcutil.Amount(tx.TxOut[txOutIndex].Value),
 	}
 }
 
@@ -201,11 +201,11 @@ func AddBlock(chain *BlockChain, prev *btcutil.Block, spends []*SpendableOut) (*
 	for _, spend := range spends {
 		spendTx := wire.NewMsgTx(1)
 		spendTx.AddTxIn(&wire.TxIn{
-			PreviousOutPoint: spend.prevOut,
+			PreviousOutPoint: spend.PrevOut,
 			Sequence:         wire.MaxTxInSequenceNum,
 			SignatureScript:  nil,
 		})
-		spendTx.AddTxOut(wire.NewTxOut(int64(spend.amount-lowFee),
+		spendTx.AddTxOut(wire.NewTxOut(int64(spend.Amount-lowFee),
 			opTrueScript))
 		// Add a random (prunable) OP_RETURN output to make the txid unique.
 		spendTx.AddTxOut(wire.NewTxOut(0, uniqueOpReturnScript()))

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -6,6 +6,7 @@ package indexers
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 
 	"github.com/mit-dci/utreexo/accumulator"
@@ -234,6 +235,65 @@ func (idx *UtreexoProofIndex) GenerateUData(dels []wire.LeafData) (*wire.UData, 
 	}
 
 	return ud, nil
+}
+
+// ProveUtxos returns an accumulator proof of the outpoints passed in with
+// respect to the UTXO state at chaintip.
+//
+// NOTE The accumulator state differs at every block height.  The caller must
+// take into consideration that an accumulator proof at block X will not be valid
+// at block height X+1.
+//
+// This function is safe for concurrent access.
+func (idx *UtreexoProofIndex) ProveUtxos(utxos []*blockchain.UtxoEntry,
+	outpoints *[]wire.OutPoint) (*accumulator.BatchProof, []accumulator.Hash, error) {
+
+	// We'll turn the entries and outpoints into leaves that go in
+	// the accumulator.
+	leaves := make([]wire.LeafData, 0, len(utxos))
+	for i, utxo := range utxos {
+		if utxo == nil || utxo.IsSpent() {
+			err := fmt.Errorf("Passed in utxo at index %d is nil or is already spent", i)
+			return nil, nil, err
+		}
+
+		blockHash, err := idx.chain.BlockHashByHeight(utxo.BlockHeight())
+		if err != nil {
+			return nil, nil, err
+		}
+		if blockHash == nil {
+			err := fmt.Errorf("Couldn't find blockhash for height %d",
+				utxo.BlockHeight())
+			return nil, nil, err
+		}
+		leaf := wire.LeafData{
+			BlockHash:  *blockHash,
+			OutPoint:   (*outpoints)[i],
+			Amount:     utxo.Amount(),
+			PkScript:   utxo.PkScript(),
+			Height:     utxo.BlockHeight(),
+			IsCoinBase: utxo.IsCoinBase(),
+		}
+
+		leaves = append(leaves, leaf)
+	}
+
+	// Now we'll turn those leaves into hashes.  These are the hashes that are
+	// commited in the accumulator.
+	hashes := make([]accumulator.Hash, 0, len(leaves))
+	for _, leaf := range leaves {
+		hashes = append(hashes, leaf.LeafHash())
+	}
+
+	// Prove the commited hashes.
+	idx.mtx.RLock()
+	defer idx.mtx.RUnlock()
+	accProof, err := idx.utreexoState.state.ProveBatch(hashes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &accProof, hashes, nil
 }
 
 // SetChain sets the given chain as the chain to be used for blockhash fetching.

--- a/blockchain/utreexoviewpoint.go
+++ b/blockchain/utreexoviewpoint.go
@@ -577,6 +577,20 @@ func (uview *UtreexoViewpoint) Equal(compRoots []*chainhash.Hash) bool {
 	return true
 }
 
+// VerifyAccProof verifies the given accumulator proof.  Returns an error if the
+// verification failed.
+func (uview *UtreexoViewpoint) VerifyAccProof(toProve []accumulator.Hash,
+	proof *accumulator.BatchProof) error {
+	return uview.accumulator.VerifyBatchProof(toProve, *proof)
+}
+
+// ToString outputs a string of the underlying accumulator.  If the accumulator
+// is too big, a message stating that the accumulator is too big to turn into
+// a string will be returned instead.
+func (uview *UtreexoViewpoint) ToString() string {
+	return uview.accumulator.ToString()
+}
+
 // compareRoots is the underlying method that calls the utreexo accumulator code
 func (uview *UtreexoViewpoint) compareRoots(compRoot []accumulator.Hash) bool {
 	uviewRoots := uview.accumulator.GetRoots()
@@ -603,6 +617,11 @@ func NewUtreexoViewpoint() *UtreexoViewpoint {
 	return &UtreexoViewpoint{
 		accumulator: new(accumulator.Pollard),
 	}
+}
+
+// GetUtreexoView returns the underlying utreexo viewpoint.
+func (b *BlockChain) GetUtreexoView() *UtreexoViewpoint {
+	return b.utreexoView
 }
 
 // IsUtreexoViewActive returns true if the node depends on the utreexoView


### PR DESCRIPTION
ProveUtxos() method is defined for the utreexo proof indexes.  Given
arbitrary utxos, it will provide a proof for them with respect to the
current UTXO set state at the chaintip.