### PR TITLE
indexers/flatutreexoproofindex: Initial Multi-block proof

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -272,6 +272,27 @@ func (b *BlockChain) FetchSpendJournal(targetBlock *btcutil.Block) ([]SpentTxOut
 	return spendEntries, nil
 }
 
+// FetchSpendJournalUnsafe attempts to retrieve the spend journal, or the set of
+// outputs spent for the target block. This provides a view of all the outputs
+// that will be consumed once the target block is connected to the end of the
+// main chain.
+//
+// This function is NOT safe for concurrent access.
+func (b *BlockChain) FetchSpendJournalUnsafe(targetBlock *btcutil.Block) ([]SpentTxOut, error) {
+	var spendEntries []SpentTxOut
+	err := b.db.View(func(dbTx database.Tx) error {
+		var err error
+
+		spendEntries, err = dbFetchSpendJournalEntry(dbTx, targetBlock)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return spendEntries, nil
+}
+
 // spentTxOutHeaderCode returns the calculated header code to be used when
 // serializing the provided stxo entry.
 func spentTxOutHeaderCode(stxo *SpentTxOut) uint64 {

--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -72,7 +72,9 @@ func createDB(dbName string) (database.DB, string, error) {
 func initIndexes(dbPath string, db *database.DB, params *chaincfg.Params) (
 	*Manager, []Indexer, error) {
 
-	flatUtreexoProofIndex, err := NewFlatUtreexoProofIndex(dbPath, params)
+	proofGenInterval := new(int32)
+	*proofGenInterval = int32(1)
+	flatUtreexoProofIndex, err := NewFlatUtreexoProofIndex(dbPath, params, proofGenInterval)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -352,7 +354,7 @@ func testUtreexoProof(block *btcutil.Block, chain *blockchain.BlockChain, indexe
 	_, outCount, inskip, outskip := blockchain.DedupeBlock(block)
 	adds := blockchain.BlockToAddLeaves(block, nil, outskip, outCount)
 
-	dels, err := blockchain.BlockToDelLeaves(stxos, chain, block, inskip)
+	dels, err := blockchain.BlockToDelLeaves(stxos, chain, block, inskip, -1)
 	if err != nil {
 		return err
 	}

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -128,7 +128,7 @@ func (idx *UtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Bloc
 	}
 
 	_, outCount, inskip, outskip := blockchain.DedupeBlock(block)
-	dels, err := blockchain.BlockToDelLeaves(stxos, idx.chain, block, inskip)
+	dels, err := blockchain.BlockToDelLeaves(stxos, idx.chain, block, inskip, -1)
 	if err != nil {
 		return err
 	}

--- a/blockchain/utreexoviewpoint.go
+++ b/blockchain/utreexoviewpoint.go
@@ -353,9 +353,22 @@ func BlockToAddLeaves(block *btcutil.Block,
 	return
 }
 
-// BlockToDelLeaves takes a non-utreexo block and stxos and turns the block into leaves that are to be deleted.
-func BlockToDelLeaves(stxos []SpentTxOut, chain *BlockChain, block *btcutil.Block, inskip []uint32) (
-	delLeaves []wire.LeafData, err error) {
+// BlockToDelLeaves takes a non-utreexo block and stxos and turns the block into
+// leaves that are to be deleted.
+//
+// inskip and excludeAfter are optional arguments. inskip will skip indexes of the
+// txIns that match with the ones included in the slice. For example, if [0, 3, 11]
+// is given as the inskip list, then txIns that appear in the 0th, 3rd, and 11th in
+// the block will be skipped over.
+//
+// excludeAfter will exclude all txIns that were created after a certain block height.
+// For example, 1000 as the excludeAfter value will skip the generation of leaf datas
+// for txIns that reference utxos created on and after the height 1000.
+//
+// NOTE To opt out of the optional arguments inskip and excludeAfter, just pass nil
+// for inskip and -1 for excludeAfter.
+func BlockToDelLeaves(stxos []SpentTxOut, chain *BlockChain, block *btcutil.Block,
+	inskip []uint32, excludeAfter int32) (delLeaves []wire.LeafData, err error) {
 
 	if chain == nil {
 		return nil, fmt.Errorf("Passed in chain is nil. Cannot make delLeaves")
@@ -383,6 +396,13 @@ func BlockToDelLeaves(stxos []SpentTxOut, chain *BlockChain, block *btcutil.Bloc
 			}
 
 			stxo := stxos[blockInIdx-1]
+
+			// Skip all those that have heights greater and equal to
+			// the excludeAfter height.
+			if excludeAfter >= 0 && stxo.Height >= excludeAfter {
+				continue
+			}
+
 			blockHash, err := chain.BlockHashByHeight(stxo.Height)
 			if err != nil {
 				return nil, err

--- a/server.go
+++ b/server.go
@@ -3007,9 +3007,13 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 	if cfg.FlatUtreexoProofIndex {
 		indxLog.Info("Flat Utreexo Proof index is enabled")
 
+		// Create interval to pass to the flat utreexo proof index.
+		interval := new(int32)
+		*interval = 1
+
 		var err error
 		s.flatUtreexoProofIndex, err = indexers.NewFlatUtreexoProofIndex(
-			cfg.DataDir, chainParams)
+			cfg.DataDir, chainParams, interval)
 		if err != nil {
 			return nil, err
 		}

--- a/wire/udata.go
+++ b/wire/udata.go
@@ -363,12 +363,14 @@ func GenerateUData(txIns []LeafData, forest *accumulator.Forest) (
 			if err != nil {
 				ld := ud.LeafDatas[i]
 				return nil,
-					fmt.Errorf("LeafData couldn't be proven. "+
+					fmt.Errorf("LeafData hash %s couldn't be proven. "+
 						"BlockHash %s, Outpoint %s, height %v, "+
-						"IsCoinbase %v, Amount %v, PkScript %s",
+						"IsCoinbase %v, Amount %v, PkScript %s. "+
+						"err: %s",
+						hex.EncodeToString(delHash[:]),
 						ld.BlockHash.String(), ld.OutPoint.String(),
 						ld.Height, ld.IsCoinBase, ld.Amount,
-						hex.EncodeToString(ld.PkScript))
+						hex.EncodeToString(ld.PkScript), err.Error())
 			}
 		}
 		return nil, err


### PR DESCRIPTION
Implement initial multi-block proof support.  The flatutreexoproofindex
behaves the same as before and the new code is not used during ibd.

There's no guarantee that the multiblockproof is correct.  Currently it
syncs ok but there isn't code where the CSNs use the proof.