### PR TITLE
wire/udata: Remove ttl field from UData

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -140,7 +140,7 @@ func (idx *FlatUtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.
 	if err != nil {
 		return err
 	}
-	adds := blockchain.BlockToAddLeaves(block, nil, outskip, outCount)
+	adds := blockchain.BlockToAddLeaves(block, outskip, outCount)
 
 	idx.mtx.RLock()
 	ud, err := wire.GenerateUData(dels, idx.utreexoState.state)
@@ -297,7 +297,7 @@ func (idx *FlatUtreexoProofIndex) MakeMultiBlockProof(currentHeight, proveHeight
 		if err != nil {
 			return err
 		}
-		adds := blockchain.BlockToAddLeaves(blk, nil, outskip, outCount)
+		adds := blockchain.BlockToAddLeaves(blk, outskip, outCount)
 
 		ud, err := wire.GenerateUData(dels, idx.utreexoState.state)
 		if err != nil {
@@ -316,7 +316,7 @@ func (idx *FlatUtreexoProofIndex) MakeMultiBlockProof(currentHeight, proveHeight
 	if err != nil {
 		return err
 	}
-	adds := blockchain.BlockToAddLeaves(block, nil, outskip, outCount)
+	adds := blockchain.BlockToAddLeaves(block, outskip, outCount)
 
 	ud, err = wire.GenerateUData(dels, idx.utreexoState.state)
 	if err != nil {

--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -352,7 +352,7 @@ func testUtreexoProof(block *btcutil.Block, chain *blockchain.BlockChain, indexe
 	}
 
 	_, outCount, inskip, outskip := blockchain.DedupeBlock(block)
-	adds := blockchain.BlockToAddLeaves(block, nil, outskip, outCount)
+	adds := blockchain.BlockToAddLeaves(block, outskip, outCount)
 
 	dels, err := blockchain.BlockToDelLeaves(stxos, chain, block, inskip, -1)
 	if err != nil {

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -133,7 +133,7 @@ func (idx *UtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Bloc
 		return err
 	}
 
-	adds := blockchain.BlockToAddLeaves(block, nil, outskip, outCount)
+	adds := blockchain.BlockToAddLeaves(block, outskip, outCount)
 
 	idx.mtx.RLock()
 	ud, err := wire.GenerateUData(dels, idx.utreexoState.state)

--- a/wire/udata_test.go
+++ b/wire/udata_test.go
@@ -57,8 +57,8 @@ func getLeafDatas() []leafDatas {
 				},
 			},
 			size:          230,
-			sizeCompact:   96,
-			sizeCompactTx: 98,
+			sizeCompact:   95,
+			sizeCompactTx: 97,
 		},
 
 		// Leaves 2
@@ -112,8 +112,8 @@ func getLeafDatas() []leafDatas {
 				},
 			},
 			size:          488,
-			sizeCompact:   218,
-			sizeCompactTx: 222,
+			sizeCompact:   217,
+			sizeCompactTx: 221,
 		},
 	}
 }
@@ -178,13 +178,6 @@ func checkUDEqual(ud, checkUData *UData, isCompact bool, name string) error {
 		if !bytes.Equal(leaf.PkScript[:], checkLeaf.PkScript[:]) {
 			return fmt.Errorf("%s: LeafData pkscript mismatch. expect %x, got %x",
 				name, leaf.PkScript, checkLeaf.PkScript)
-		}
-	}
-
-	for i := range ud.TxoTTLs {
-		if ud.TxoTTLs[i] != checkUData.TxoTTLs[i] {
-			return fmt.Errorf("%s: UData TxoTTL mismatch. expect %v, got %v",
-				name, ud.TxoTTLs[i], checkUData.TxoTTLs[i])
 		}
 	}
 


### PR DESCRIPTION
TTL field is removed in favor of other caching methods as research has
shown that there are better alternative caching methods than ttl based
caching.