### PR TITLE
blockchain/utreexoviewpoint: Refactor Modify() function

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1038,9 +1038,19 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *btcutil.Block, vi
 	// If utreexo accumulators are enabled, then check that the accumulator
 	// proof is ok.  Then convert the msgBlock.UData into UtxoViewpoint.
 	if b.utreexoView != nil {
+		adds, dels, err := ExtractAccumulatorAddDels(block, b.bestChain)
+		if err != nil {
+			return err
+		}
+
+		err = b.utreexoView.IngestProof(false, dels, &block.MsgBlock().UData.AccProof)
+		if err != nil {
+			return err
+		}
+
 		// Check that the block txOuts are valid by checking the utreexo proof and
 		// extra data.
-		err := b.utreexoView.Modify(block, b.bestChain)
+		err = b.utreexoView.Modify(block.MsgBlock().UData, adds)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Functionality that was included in Modify() is now refactored into 3
separate functions: Modify(), IngestProof(), and ExtractAccumulatorAddDels().

Modify now only modifies the accumulator without any other checks.
IngestProof validates and ingests the proof so that the caller can call
Modify().
ExtractAccumulatorAddDels now does the proof sanity checks and extracts
the additions and deletions from the block that was passed in.