### PR TITLE
server: Ask for utreexo enabled nodes when --utreexo flag is on

### DIFF
--- a/blockchain/utreexoviewpoint.go
+++ b/blockchain/utreexoviewpoint.go
@@ -30,6 +30,11 @@ type UtreexoViewpoint struct {
 func (uview *UtreexoViewpoint) ProcessUData(block *btcutil.Block,
 	bestChain *chainView, ud *wire.UData) error {
 
+	if ud == nil {
+		return fmt.Errorf("Utreexo data is nil. Cannot validate block %s",
+			block.Hash())
+	}
+
 	// Extracts the block into additions and deletions that will be processed.
 	// Adds correspond to newly created UTXOs and dels correspond to STXOs.
 	adds, dels, err := ExtractAccumulatorAddDels(block, bestChain, ud.RememberIdx)

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -607,6 +607,12 @@ func (sm *SyncManager) handleTxMsg(tmsg *txMsg) {
 		return
 	}
 
+	if sm.chain.IsUtreexoViewActive() && tmsg.tx.MsgTx().UData == nil {
+		log.Warnf("Is a utreexo node but didn't get udata with the tx")
+		peer.Disconnect()
+		return
+	}
+
 	// Process the transaction to include validation, insertion in the
 	// memory pool, orphan handling, etc.
 	acceptedTxs, err := sm.txMemPool.ProcessTransaction(tmsg.tx,
@@ -721,6 +727,12 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 	// will fail the insert and thus we'll retry next time we get an inv.
 	delete(state.requestedBlocks, *blockHash)
 	delete(sm.requestedBlocks, *blockHash)
+
+	if sm.chain.IsUtreexoViewActive() && bmsg.block.MsgBlock().UData == nil {
+		log.Warnf("Is a utreexo node but didn't get udata with the tx")
+		peer.Disconnect()
+		return
+	}
 
 	// Process the block to include validation, best chain selection, orphan
 	// handling, etc.

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -13,11 +13,7 @@ import (
 // XXX pedro: we will probably need to bump this.
 const (
 	// ProtocolVersion is the latest protocol version this package supports.
-	//
-	// NOTE ProtocolVersion set at 170013 for the moment to mark that it
-	// supports utreexo proof attached blocks.  This is experimental and is
-	// subject to change in the future.
-	ProtocolVersion uint32 = 170013
+	ProtocolVersion uint32 = 70013
 
 	// MultipleAddressVersion is the protocol version which added multiple
 	// addresses per message (pver >= MultipleAddressVersion).


### PR DESCRIPTION
Only utreexo archival nodes should be connected to for node with the
flag --utreexo on (aka CSNs).

There's currently no seeders that are seeding utreexo nodes and that'll
have to be done later.