### PR TITLE
go.yml: Fix github workflow and linting errors

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2"
       - name: Build
         env:
           GO111MODULE: "on"

--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -565,8 +565,8 @@ func TestProveUtxos(t *testing.T) {
 		for _, spendable := range spendables {
 			utxo, err := chain.FetchUtxoEntry(spendable.PrevOut)
 			if err != nil {
-				t.Fatal(fmt.Sprintf("TestProveUtxos fail. err: outpoint %s not found.",
-					spendable.PrevOut.String()))
+				t.Fatalf("TestProveUtxos fail. err: outpoint %s not found.",
+					spendable.PrevOut.String())
 			}
 
 			utxos = append(utxos, utxo)
@@ -581,15 +581,15 @@ func TestProveUtxos(t *testing.T) {
 				var err error
 				flatProof, err = idxType.ProveUtxos(utxos, &outpoints)
 				if err != nil {
-					t.Fatal(fmt.Sprintf("TestProveUtxos fail."+
-						"Failed to create proof. err: %v", err))
+					t.Fatalf("TestProveUtxos fail."+
+						"Failed to create proof. err: %v", err)
 				}
 			case *UtreexoProofIndex:
 				var err error
 				proof, err = idxType.ProveUtxos(utxos, &outpoints)
 				if err != nil {
-					t.Fatal(fmt.Sprintf("TestProveUtxos fail."+
-						"Failed to create proof. err: %v", err))
+					t.Fatalf("TestProveUtxos fail."+
+						"Failed to create proof. err: %v", err)
 				}
 			}
 		}
@@ -610,7 +610,7 @@ func TestProveUtxos(t *testing.T) {
 		uView := csnChain.GetUtreexoView()
 		err = uView.VerifyAccProof(proof.HashesProven, proof.AccProof)
 		if err != nil {
-			t.Fatal(fmt.Sprintf("TestProveUtxos fail. Failed to verify proof err: %v", err))
+			t.Fatalf("TestProveUtxos fail. Failed to verify proof err: %v", err)
 		}
 	}
 }
@@ -656,7 +656,7 @@ func TestUtreexoProofIndex(t *testing.T) {
 		// same indexes.
 		err := testUtreexoProof(newBlock, chain, indexes)
 		if err != nil {
-			t.Fatal(fmt.Sprintf("TestUtreexoProofIndex failed testUtreexoProof. err: %v", err))
+			t.Fatalf("TestUtreexoProofIndex failed testUtreexoProof. err: %v", err)
 		}
 
 		if b%10 == 0 {

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -560,7 +560,7 @@ func TestOrphanReject(t *testing.T) {
 
 		// Ensure no transactions were reported as accepted.
 		if len(acceptedTxns) != 0 {
-			t.Fatal("ProcessTransaction: reported %d accepted "+
+			t.Fatalf("ProcessTransaction: reported %d accepted "+
 				"transactions from failed orphan attempt",
 				len(acceptedTxns))
 		}


### PR DESCRIPTION
GoLint was not being installed correctly, so it was throwing error code 127 when we were running the workflow. Fixed that issue, so that it is installed correctly.
Also, there were some linting errors that were arising since now an updated golangci-lint is being used.