### PR TITLE
Add watchonly wallet

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -946,6 +946,15 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 				return nil
 			})
 
+			// This adds the update data and the utreexo adds to the
+			// block.  The added data here is needed to undo utreexo
+			// proofs.
+			copyuView := uView.Copy()
+			err = copyuView.ProcessUData(block, b.bestChain, block.MsgBlock().UData)
+			if err != nil {
+				return err
+			}
+
 			// Set the utreexo view to the previous block.
 			b.utreexoView = uView
 

--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -770,6 +770,15 @@ func NewGetWorkCmd(data *string) *GetWorkCmd {
 	}
 }
 
+// GetWatchOnlyBalanceCmd defines the getwatchonlybalance JSON-RPC command.
+type GetWatchOnlyBalanceCmd struct{}
+
+// NewGetWatchOnlyBalanceCmd returns a new instance which can be used to issue a
+// getwatchonlybalance JSON-RPC command.
+func NewGetWatchOnlyBalanceCmd() *GetWatchOnlyBalanceCmd {
+	return &GetWatchOnlyBalanceCmd{}
+}
+
 // HelpCmd defines the help JSON-RPC command.
 type HelpCmd struct {
 	Command *string
@@ -839,6 +848,12 @@ func NewProveUtxoChainTipInclusionCmd(txids []string, vouts []uint32, verbosity 
 	}
 }
 
+// ProveWatchOnlyChainTipInclusionCmd defines the provewatchonlychaintipinclusion JSON-RPC
+// command.
+type ProveWatchOnlyChainTipInclusionCmd struct {
+	Verbosity *int `jsonrpcdefault:"1"`
+}
+
 // ReconsiderBlockCmd defines the reconsiderblock JSON-RPC command.
 type ReconsiderBlockCmd struct {
 	BlockHash string
@@ -849,6 +864,20 @@ type ReconsiderBlockCmd struct {
 func NewReconsiderBlockCmd(blockHash string) *ReconsiderBlockCmd {
 	return &ReconsiderBlockCmd{
 		BlockHash: blockHash,
+	}
+}
+
+// RegisterAddressToWatchOnlyWalletCmd defines the registeraddresstowatchonlywallet JSON-RPC
+// command.
+type RegisterAddressToWatchOnlyWalletCmd struct {
+	Address string
+}
+
+// NewRegisterAddressToWatchOnlyWalletCmd returns a new instance which can be used to issue a
+// registeraddresstowatchonlywallet JSON-RPC command.
+func NewRegisterAddressToWatchOnlyWalletCmd(address string) *RegisterAddressToWatchOnlyWalletCmd {
+	return &RegisterAddressToWatchOnlyWalletCmd{
+		Address: address,
 	}
 }
 
@@ -1155,11 +1184,14 @@ func init() {
 	MustRegisterCmd("gettxoutsetinfo", (*GetTxOutSetInfoCmd)(nil), flags)
 	MustRegisterCmd("getutreexoproof", (*GetUtreexoProofCmd)(nil), flags)
 	MustRegisterCmd("getwork", (*GetWorkCmd)(nil), flags)
+	MustRegisterCmd("getwatchonlybalance", (*GetWatchOnlyBalanceCmd)(nil), flags)
 	MustRegisterCmd("help", (*HelpCmd)(nil), flags)
 	MustRegisterCmd("invalidateblock", (*InvalidateBlockCmd)(nil), flags)
 	MustRegisterCmd("ping", (*PingCmd)(nil), flags)
 	MustRegisterCmd("preciousblock", (*PreciousBlockCmd)(nil), flags)
 	MustRegisterCmd("proveutxochaintipinclusion", (*ProveUtxoChainTipInclusionCmd)(nil), flags)
+	MustRegisterCmd("provewatchonlychaintipinclusion", (*ProveWatchOnlyChainTipInclusionCmd)(nil), flags)
+	MustRegisterCmd("registeraddresstowatchonlywallet", (*RegisterAddressToWatchOnlyWalletCmd)(nil), flags)
 	MustRegisterCmd("reconsiderblock", (*ReconsiderBlockCmd)(nil), flags)
 	MustRegisterCmd("searchrawtransactions", (*SearchRawTransactionsCmd)(nil), flags)
 	MustRegisterCmd("sendrawtransaction", (*SendRawTransactionCmd)(nil), flags)

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -882,3 +882,15 @@ type GetUtreexoProofVerboseResult struct {
 	TargetPreimages []string `json:"targetpreimages"`
 	ProofTargets    []uint64 `json:"prooftargets"`
 }
+
+// ProveWatchOnlyChainTipInclusionVerboseResult models the data from the
+// provewatchonlychaintipinclusion command when the verbose flag is set.  When the
+// verbose flag is not set, just the hex-encoded string of the entire proof
+// is returned.
+type ProveWatchOnlyChainTipInclusionVerboseResult struct {
+	ProvedAtHash string   `json:"provedathash"`
+	ProofHashes  []string `json:"proofhashes"`
+	ProofTargets []uint64 `json:"prooftargets"`
+	HashesProven []string `json:"hashesproven"`
+	Hex          string   `json:"hex"`
+}

--- a/btcutil/block.go
+++ b/btcutil/block.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/utreexo/utreexo"
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
 	"github.com/utreexo/utreexod/wire"
 )
@@ -32,13 +33,15 @@ func (e OutOfRangeError) Error() string {
 // transactions on their first access so subsequent accesses don't have to
 // repeat the relatively expensive hashing operations.
 type Block struct {
-	msgBlock                 *wire.MsgBlock  // Underlying MsgBlock
-	serializedBlock          []byte          // Serialized bytes for the block
-	serializedBlockNoWitness []byte          // Serialized bytes for block w/o witness data
-	blockHash                *chainhash.Hash // Cached block hash
-	blockHeight              int32           // Height in the main block chain
-	transactions             []*Tx           // Transactions
-	txnsGenerated            bool            // ALL wrapped transactions generated
+	msgBlock                 *wire.MsgBlock      // Underlying MsgBlock
+	serializedBlock          []byte              // Serialized bytes for the block
+	serializedBlockNoWitness []byte              // Serialized bytes for block w/o witness data
+	blockHash                *chainhash.Hash     // Cached block hash
+	blockHeight              int32               // Height in the main block chain
+	transactions             []*Tx               // Transactions
+	txnsGenerated            bool                // ALL wrapped transactions generated
+	utreexoUpdateData        *utreexo.UpdateData // Utreexo update data for this block
+	utreexoAdds              []utreexo.Hash      // Hashes of the utreexo leaves being added
 }
 
 // MsgBlock returns the underlying wire.MsgBlock for the Block.
@@ -214,6 +217,30 @@ func (b *Block) Height() int32 {
 // SetHeight sets the height of the block in the block chain.
 func (b *Block) SetHeight(height int32) {
 	b.blockHeight = height
+}
+
+// SetUtreexoUpdateData sets the utreexo update data of the block in the block chain.
+func (b *Block) SetUtreexoUpdateData(data *utreexo.UpdateData) {
+	b.utreexoUpdateData = data
+}
+
+// UtreexoUpdateData returns the utreexo update data for the block in the block chain.
+func (b *Block) UtreexoUpdateData() *utreexo.UpdateData {
+	return b.utreexoUpdateData
+}
+
+// SetUtreexoAdds sets the hashes of the utreexo leaves being added in this block.
+func (b *Block) SetUtreexoAdds(adds []utreexo.Leaf) {
+	addHashes := make([]utreexo.Hash, 0, len(adds))
+	for _, add := range adds {
+		addHashes = append(addHashes, add.Hash)
+	}
+	b.utreexoAdds = addHashes
+}
+
+// UtreexoAdds returns the hashes of the utreexo leaves added in this block.
+func (b *Block) UtreexoAdds() []utreexo.Hash {
+	return b.utreexoAdds
 }
 
 // NewBlock returns a new instance of a bitcoin block given an underlying

--- a/config.go
+++ b/config.go
@@ -193,19 +193,21 @@ type config struct {
 	BlockPrioritySize uint32   `long:"blockprioritysize" description:"Size in bytes for high-priority/low-fee transactions when creating a block"`
 
 	// Indexing options.
-	AddrIndex                 bool `long:"addrindex" description:"Maintain a full address-based transaction index which makes the searchrawtransactions RPC available"`
-	TxIndex                   bool `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
-	TTLIndex                  bool `long:"ttlindex" description:"Maintain a full time to live index for all stxos available via the getttl RPC"`
-	UtreexoProofIndex         bool `long:"utreexoproofindex" description:"Maintain a utreexo proof for all blocks"`
-	FlatUtreexoProofIndex     bool `long:"flatutreexoproofindex" description:"Maintain a utreexo proof for all blocks in flat files"`
-	NoCFilters                bool `long:"nocfilters" description:"Disable committed filtering (CF) support"`
-	NoPeerBloomFilters        bool `long:"nopeerbloomfilters" description:"Disable bloom filtering support"`
-	DropAddrIndex             bool `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up and then exits."`
-	DropCfIndex               bool `long:"dropcfindex" description:"Deletes the index used for committed filtering (CF) support from the database on start up and then exits."`
-	DropTxIndex               bool `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
-	DropTTLIndex              bool `long:"dropttlindex" description:"Deletes the time to live index from the database on start up and then exits."`
-	DropUtreexoProofIndex     bool `long:"droputreexoproofindex" description:"Deletes the utreexo proof index from the database on start up and then exits."`
-	DropFlatUtreexoProofIndex bool `long:"dropflatutreexoproofindex" description:"Deletes the flat utreexo proof index from the database on start up and then exits."`
+	AddrIndex                        bool     `long:"addrindex" description:"Maintain a full address-based transaction index which makes the searchrawtransactions RPC available"`
+	TxIndex                          bool     `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
+	TTLIndex                         bool     `long:"ttlindex" description:"Maintain a full time to live index for all stxos available via the getttl RPC"`
+	UtreexoProofIndex                bool     `long:"utreexoproofindex" description:"Maintain a utreexo proof for all blocks"`
+	FlatUtreexoProofIndex            bool     `long:"flatutreexoproofindex" description:"Maintain a utreexo proof for all blocks in flat files"`
+	NoCFilters                       bool     `long:"nocfilters" description:"Disable committed filtering (CF) support"`
+	NoPeerBloomFilters               bool     `long:"nopeerbloomfilters" description:"Disable bloom filtering support"`
+	DropAddrIndex                    bool     `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up and then exits."`
+	DropCfIndex                      bool     `long:"dropcfindex" description:"Deletes the index used for committed filtering (CF) support from the database on start up and then exits."`
+	DropTxIndex                      bool     `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
+	DropTTLIndex                     bool     `long:"dropttlindex" description:"Deletes the time to live index from the database on start up and then exits."`
+	DropUtreexoProofIndex            bool     `long:"droputreexoproofindex" description:"Deletes the utreexo proof index from the database on start up and then exits."`
+	DropFlatUtreexoProofIndex        bool     `long:"dropflatutreexoproofindex" description:"Deletes the flat utreexo proof index from the database on start up and then exits."`
+	WatchOnlyWallet                  bool     `long:"watchonlywallet" description:"Enable the watch only wallet with utreexo proofs. Must have --utreexo enabled"`
+	RegisterAddressToWatchOnlyWallet []string `long:"registeraddresstowatchonlywallet" description:"Registers addresses to be watched to the watch only wallet. Must have --watchonlywallet enabled"`
 
 	// Cooked options ready for use.
 	lookup         func(string) ([]net.IP, error)
@@ -1211,6 +1213,14 @@ func loadConfig() (*config, []string, error) {
 		cfg.oniondial = func(a, b string, t time.Duration) (net.Conn, error) {
 			return nil, errors.New("tor has been disabled")
 		}
+	}
+
+	if cfg.WatchOnlyWallet && !cfg.Utreexo {
+		err := fmt.Errorf("%s: the --watchonlywallet requires the --utreexo option on "+
+			"at the same time", funcName)
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, usageMessage)
+		return nil, nil, err
 	}
 
 	// Warn about missing config file only after all other configuration is

--- a/log.go
+++ b/log.go
@@ -21,6 +21,7 @@ import (
 	"github.com/utreexo/utreexod/netsync"
 	"github.com/utreexo/utreexod/peer"
 	"github.com/utreexo/utreexod/txscript"
+	"github.com/utreexo/utreexod/wallet"
 
 	"github.com/btcsuite/btclog"
 	"github.com/jrick/logrotate/rotator"
@@ -69,6 +70,7 @@ var (
 	srvrLog = backendLog.Logger("SRVR")
 	syncLog = backendLog.Logger("SYNC")
 	txmpLog = backendLog.Logger("TXMP")
+	wlltLog = backendLog.Logger("WLLT")
 )
 
 // Initialize package-global logger variables.
@@ -84,6 +86,7 @@ func init() {
 	txscript.UseLogger(scrpLog)
 	netsync.UseLogger(syncLog)
 	mempool.UseLogger(txmpLog)
+	wallet.UseLogger(wlltLog)
 }
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.
@@ -103,6 +106,7 @@ var subsystemLoggers = map[string]btclog.Logger{
 	"SRVR": srvrLog,
 	"SYNC": syncLog,
 	"TXMP": txmpLog,
+	"WLLT": wlltLog,
 }
 
 // initLogRotator initializes the logging rotater to write logs to logFile and

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -567,6 +567,10 @@ var helpDescsEnUS = map[string]string{
 	"getutreexoproofverboseresult-prooftargets": "One half of the utreexo accumulator proof (the other half being proofhashes).\n" +
 		"The locations of the given UTXOs in the accumulator.",
 
+	// GetWatchOnlyBalanceCmd help.
+	"getwatchonlybalance--synopsis": "Returns the total balance of the watch only wallet",
+	"getwatchonlybalance--result0":  "The total balance of the watch only wallet in satoshis",
+
 	// HelpCmd help.
 	"help--synopsis":   "Returns a list of all commands or help for a specified command.",
 	"help-command":     "The command to retrieve help for",
@@ -594,6 +598,21 @@ var helpDescsEnUS = map[string]string{
 	"proveutxochaintipinclusionverboseresult-hashesproven": "The hashes of the UTXOs that are committed in the accumulator.\n" +
 		"Note that these are not purely hashes of txid:vout. The preimage also include Amount, PkScript, and other parts of the UTXO",
 	"proveutxochaintipinclusionverboseresult-hex": "The raw hash of the entire chain-tip inclusion proof",
+
+	// ProveWatchOnlyChainTipInclusionCmd help.
+	"provewatchonlychaintipinclusion--synopsis": "Returns a chaintip proof of all the relevant utxos of the watch only wallet.",
+	"provewatchonlychaintipinclusion-verbosity": "Specifies the returned proof as a JSON object instead of an hex-encoded string",
+	"provewatchonlychaintipinclusion--result0":  "Hex-encoded serialized chaintip proof of all the relevant utxos of the watch only wallet",
+
+	// ProveWatchOnlyChainTipInclusionVerboseResult help.
+	"provewatchonlychaintipinclusionverboseresult-provedathash": "The blockhash at which the proof was generated at. The proof will not verify if the blockhash is different",
+	"provewatchonlychaintipinclusionverboseresult-proofhashes": "One half of the utreexo accumulator proof (the other half being prooftargets).\n" +
+		"The proof hashes for the utreexo accumulator proof of the given UTXOs.",
+	"provewatchonlychaintipinclusionverboseresult-prooftargets": "One half of the utreexo accumulator proof (the other half being proofhashes).\n" +
+		"The locations of the given UTXOs in the accumulator.",
+	"provewatchonlychaintipinclusionverboseresult-hashesproven": "The hashes of the UTXOs that are committed in the accumulator.\n" +
+		"Note that these are not purely hashes of txid:vout. The preimage also include Amount, PkScript, and other parts of the UTXO",
+	"provewatchonlychaintipinclusionverboseresult-hex": "The raw hash of the entire chain-tip inclusion proof",
 
 	// SearchRawTransactionsCmd help.
 	"searchrawtransactions--synopsis": "Returns raw data for transactions involving the passed address.\n" +
@@ -725,6 +744,9 @@ var helpDescsEnUS = map[string]string{
 	"loadtxfilter-addresses": "Array of addresses to add to the transaction filter",
 	"loadtxfilter-outpoints": "Array of outpoints to add to the transaction filter",
 
+	"registeraddresstowatchonlywallet--synopsis": "Registers an address to the watch only wallet.",
+	"registeraddresstowatchonlywallet-address":   "Address to keep track of",
+
 	// Rescan help.
 	"rescan--synopsis": "Rescan block chain for transactions to addresses.\n" +
 		"When the endblock parameter is omitted, the rescan continues through the best block in the main chain.\n" +
@@ -797,6 +819,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getnettotals":                     {(*btcjson.GetNetTotalsResult)(nil)},
 	"gettxtotals":                      {(*btcjson.GetTxTotalsResult)(nil)},
 	"getutreexoproof":                  {(*btcjson.GetUtreexoProofVerboseResult)(nil)},
+	"getwatchonlybalance":              {(*int64)(nil)},
 	"getnetworkhashps":                 {(*int64)(nil)},
 	"getnodeaddresses":                 {(*[]btcjson.GetNodeAddressesResult)(nil)},
 	"getpeerinfo":                      {(*[]btcjson.GetPeerInfoResult)(nil)},
@@ -808,6 +831,8 @@ var rpcResultTypes = map[string][]interface{}{
 	"help":                             {(*string)(nil), (*string)(nil)},
 	"ping":                             nil,
 	"proveutxochaintipinclusion":       {(*btcjson.ProveUtxoChainTipInclusionVerboseResult)(nil)},
+	"provewatchonlychaintipinclusion":  {(*btcjson.ProveWatchOnlyChainTipInclusionVerboseResult)(nil)},
+	"registeraddresstowatchonlywallet": nil,
 	"searchrawtransactions":            {(*string)(nil), (*[]btcjson.SearchRawTransactionsResult)(nil)},
 	"sendrawtransaction":               {(*string)(nil)},
 	"setgenerate":                      nil,

--- a/wallet/log.go
+++ b/wallet/log.go
@@ -1,0 +1,24 @@
+package wallet
+
+import "github.com/btcsuite/btclog"
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	DisableLog()
+}
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	log = btclog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/wallet/watchonly.go
+++ b/wallet/watchonly.go
@@ -1,0 +1,687 @@
+// Copyright (c) 2022 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+package wallet
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	"github.com/utreexo/utreexo"
+	"github.com/utreexo/utreexod/blockchain"
+	"github.com/utreexo/utreexod/btcutil"
+	"github.com/utreexo/utreexod/btcutil/hdkeychain"
+	"github.com/utreexo/utreexod/chaincfg"
+	"github.com/utreexo/utreexod/chaincfg/chainhash"
+	"github.com/utreexo/utreexod/mempool"
+	"github.com/utreexo/utreexod/txscript"
+	"github.com/utreexo/utreexod/wire"
+)
+
+var (
+	defaultWalletPath       = "watchonlywallet"
+	defaultWalletConfigName = "watchonlywalletconfig.json"
+	defaultWalletName       = "watchonlywallet.json"
+)
+
+// WalletState keeps track of all the current relevant utxos.  It includes a batched
+// utreexo proof of all the relevant utxos.
+type WalletState struct {
+	BestHash      chainhash.Hash
+	RelevantUtxos map[wire.OutPoint]wire.LeafData `json:"relevantutxos"`
+	UtreexoLeaves []utreexo.Hash                  `json:"utreexoleaves"`
+	UtreexoProof  utreexo.Proof                   `json:"utreexoproof"`
+}
+
+func (wp *WalletState) MarshalJSON() ([]byte, error) {
+	utxos := make([]wire.LeafData, 0, len(wp.RelevantUtxos))
+	for _, v := range wp.RelevantUtxos {
+		utxos = append(utxos, v)
+	}
+
+	leaves := make([]string, len(wp.UtreexoLeaves))
+	for i := range wp.UtreexoLeaves {
+		leaves[i] = hex.EncodeToString(wp.UtreexoLeaves[i][:])
+	}
+
+	// Convert the hashes to string.
+	proofString := make([]string, len(wp.UtreexoProof.Proof))
+	for i := range wp.UtreexoProof.Proof {
+		proofString[i] = hex.EncodeToString(wp.UtreexoProof.Proof[i][:])
+	}
+
+	s := struct {
+		RelevantUtxos  []wire.LeafData `json:"relevantutxos"`
+		UtreexoLeaves  []string        `json:"utreexoleaves"`
+		UtreexoTargets []uint64        `json:"utreexotargets"`
+		UtreexoProof   []string        `json:"utreexoproof"`
+	}{
+		RelevantUtxos:  utxos,
+		UtreexoLeaves:  leaves,
+		UtreexoTargets: wp.UtreexoProof.Targets,
+		UtreexoProof:   proofString,
+	}
+
+	return json.Marshal(s)
+}
+
+func (wp *WalletState) UnmarshalJSON(data []byte) error {
+	s := struct {
+		RelevantUtxos  []wire.LeafData `json:"relevantutxos"`
+		UtreexoLeaves  []string        `json:"utreexoleaves"`
+		UtreexoTargets []uint64        `json:"utreexotargets"`
+		UtreexoProof   []string        `json:"utreexoproof"`
+	}{}
+
+	err := json.Unmarshal(data, &s)
+	if err != nil {
+		return err
+	}
+
+	wp.RelevantUtxos = make(map[wire.OutPoint]wire.LeafData, len(s.RelevantUtxos))
+	for _, utxo := range s.RelevantUtxos {
+		wp.RelevantUtxos[utxo.OutPoint] = utxo
+	}
+
+	wp.UtreexoLeaves = make([]utreexo.Hash, len(s.UtreexoLeaves))
+	for i := range wp.UtreexoLeaves {
+		hash, err := hex.DecodeString(s.UtreexoLeaves[i])
+		if err != nil {
+			return fmt.Errorf("Failed to decode leaf string of %s. "+
+				"Error: %v", s.UtreexoLeaves[i], err)
+		}
+
+		wp.UtreexoLeaves[i] = (*(*[32]byte)(hash))
+	}
+	wp.UtreexoProof.Targets = s.UtreexoTargets
+	wp.UtreexoProof.Proof = make([]utreexo.Hash, len(s.UtreexoProof))
+	for i := range wp.UtreexoProof.Proof {
+		hash, err := hex.DecodeString(s.UtreexoProof[i])
+		if err != nil {
+			return fmt.Errorf("Failed to decode utreexo proof string of %s. "+
+				"Error: %v", s.UtreexoProof[i], err)
+		}
+
+		wp.UtreexoProof.Proof[i] = (*(*[32]byte)(hash))
+	}
+
+	return nil
+}
+
+// WalletConfig defines the config for the wallet.
+type WalletConfig struct {
+	Net          string
+	ExtendedKeys []*hdkeychain.ExtendedKey
+	Addresses    map[string]struct{}
+	GapLimit     int32
+}
+
+func (ws *WalletConfig) MarshalJSON() ([]byte, error) {
+	xKeys := make([]string, 0, len(ws.ExtendedKeys))
+	for i := range xKeys {
+		xKeys[i] = ws.ExtendedKeys[i].String()
+	}
+
+	s := struct {
+		Net          string              `json:"net"`
+		ExtendedKeys []string            `json:"extendedkeys"`
+		Addresses    map[string]struct{} `json:"addresses"`
+		GapLimit     int32               `json:"gaplimit"`
+	}{
+		Net:          ws.Net,
+		ExtendedKeys: xKeys,
+		GapLimit:     ws.GapLimit,
+		Addresses:    ws.Addresses,
+	}
+
+	return json.Marshal(s)
+}
+
+func (ws *WalletConfig) UnmarshalJSON(data []byte) error {
+	s := struct {
+		Net          string              `json:"net"`
+		ExtendedKeys []string            `json:"extendedkeys"`
+		Addresses    map[string]struct{} `json:"addresses"`
+		GapLimit     int32               `json:"gaplimit"`
+	}{}
+	err := json.Unmarshal(data, &s)
+	if err != nil {
+		return err
+	}
+
+	ws.Net = s.Net
+
+	for _, extendedKey := range s.ExtendedKeys {
+		xkey, err := hdkeychain.NewKeyFromString(extendedKey)
+		if err != nil {
+			return fmt.Errorf("Failed to parse the passed in key. Error: %v", err)
+		}
+
+		ws.ExtendedKeys = append(ws.ExtendedKeys, xkey)
+	}
+
+	var params chaincfg.Params
+	switch ws.Net {
+	case chaincfg.MainNetParams.Name:
+		params = chaincfg.MainNetParams
+	case chaincfg.TestNet3Params.Name:
+		params = chaincfg.TestNet3Params
+	case chaincfg.RegressionNetParams.Name:
+		params = chaincfg.RegressionNetParams
+	case chaincfg.SimNetParams.Name:
+		params = chaincfg.SimNetParams
+	case chaincfg.SigNetParams.Name:
+		params = chaincfg.SigNetParams
+	default:
+		params = chaincfg.MainNetParams
+	}
+	for address := range s.Addresses {
+		addr, err := btcutil.DecodeAddress(address, &params)
+		if err != nil {
+			return fmt.Errorf("Failed to parse the passed in key. Error: %v", err)
+		}
+
+		ws.Addresses[addr.String()] = struct{}{}
+	}
+	ws.GapLimit = s.GapLimit
+
+	return nil
+}
+
+// WatchOnlyWalletManager is used to keep track of utxos and the utreexo proofs for
+// those utxos.
+type WatchOnlyWalletManager struct {
+	started int32
+	stopped int32
+	wg      sync.WaitGroup
+
+	config *Config
+
+	// walletLock locks the below wallet related fields.
+	walletLock   sync.RWMutex
+	wallet       WalletState
+	walletConfig WalletConfig
+}
+
+// Getbalance totals up the balance in the utxos it's keeping track of.
+func (wm *WatchOnlyWalletManager) Getbalance() int64 {
+	totalAmount := int64(0)
+	for _, out := range wm.wallet.RelevantUtxos {
+		totalAmount += out.Amount
+	}
+
+	return totalAmount
+}
+
+// filterBlock filters the passed in block for inputs or outputs that is relevant
+// to this wallet. It returns the indexes of the new outputs that is relevant for
+// this wallet.
+func (wm *WatchOnlyWalletManager) filterBlock(block *btcutil.Block) []uint32 {
+	_, _, inskip, outskip := blockchain.DedupeBlock(block)
+
+	remembers := []uint32{}
+
+	var txonum uint32
+	for idx, tx := range block.Transactions() {
+		for outIdx, out := range tx.MsgTx().TxOut {
+			outPoint := wire.OutPoint{
+				Hash:  *tx.Hash(),
+				Index: uint32(outIdx),
+			}
+			// Skip all the OP_RETURNs
+			if blockchain.IsUnspendable(out) {
+				txonum++
+				continue
+			}
+			// Skip txos on the skip list
+			if len(outskip) > 0 && outskip[0] == txonum {
+				outskip = outskip[1:]
+				txonum++
+				continue
+			}
+
+			_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+				out.PkScript, wm.config.ChainParams,
+			)
+			if err != nil {
+				log.Warnf("Could not parse output script in %s:%d: %v",
+					tx.Hash(), outIdx, err)
+				continue
+			}
+
+			var found bool
+			for _, addr := range addrs {
+				addrString := addr.String()
+				_, f := wm.walletConfig.Addresses[addrString]
+				if f {
+					found = f
+				}
+			}
+			if !found {
+				continue
+			}
+			remembers = append(remembers, uint32(outIdx))
+
+			leaf := wire.LeafData{
+				BlockHash:  *block.Hash(),
+				OutPoint:   outPoint,
+				Amount:     out.Value,
+				PkScript:   out.PkScript,
+				Height:     block.Height(),
+				IsCoinBase: idx == 0,
+			}
+			wm.wallet.RelevantUtxos[outPoint] = leaf
+		}
+
+		var inIdx uint32
+		for _, in := range tx.MsgTx().TxIn {
+			if idx == 0 {
+				// coinbase can have many inputs
+				inIdx += uint32(len(tx.MsgTx().TxIn))
+				continue
+			}
+
+			// Skip txos on the skip list
+			if len(inskip) > 0 && inskip[0] == inIdx {
+				inskip = inskip[1:]
+				inIdx++
+				continue
+			}
+
+			_, found := wm.wallet.RelevantUtxos[in.PreviousOutPoint]
+			if !found {
+				continue
+			}
+
+			delete(wm.wallet.RelevantUtxos, in.PreviousOutPoint)
+		}
+	}
+
+	return remembers
+}
+
+// filterBlockForUndo filters the block to undo that block. The returned indexes are
+// of the targets that were deleted in the block that needs to be re-added as this
+// watch only wallet controlls it.
+func (wm *WatchOnlyWalletManager) filterBlockForUndo(block *btcutil.Block) []uint64 {
+	_, _, inskip, outskip := blockchain.DedupeBlock(block)
+
+	var targetsToProve []uint64
+
+	var txonum uint32
+	for idx, tx := range block.Transactions() {
+		for outIdx, out := range tx.MsgTx().TxOut {
+			outPoint := wire.OutPoint{
+				Hash:  *tx.Hash(),
+				Index: uint32(outIdx),
+			}
+
+			// Skip all the OP_RETURNs
+			if blockchain.IsUnspendable(out) {
+				txonum++
+				continue
+			}
+			// Skip txos on the skip list
+			if len(outskip) > 0 && outskip[0] == txonum {
+				outskip = outskip[1:]
+				txonum++
+				continue
+			}
+
+			_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+				out.PkScript, wm.config.ChainParams,
+			)
+			if err != nil {
+				log.Warnf("Could not parse output script in %s:%d: %v",
+					tx.Hash(), outIdx, err)
+				continue
+			}
+
+			for _, addr := range addrs {
+				addrString := addr.String()
+				_, f := wm.walletConfig.Addresses[addrString]
+				if f {
+					delete(wm.wallet.RelevantUtxos, outPoint)
+				}
+			}
+		}
+
+		var inIdx uint32
+		var leafIdx int
+		for _, in := range tx.MsgTx().TxIn {
+			if idx == 0 {
+				// coinbase can have many inputs
+				inIdx += uint32(len(tx.MsgTx().TxIn))
+				continue
+			}
+
+			// Skip txos on the skip list
+			if len(inskip) > 0 && inskip[0] == inIdx {
+				inskip = inskip[1:]
+				inIdx++
+				continue
+			}
+
+			target := block.MsgBlock().UData.AccProof.Targets[leafIdx]
+			targetsToProve = append(targetsToProve, target)
+
+			_, found := wm.wallet.RelevantUtxos[in.PreviousOutPoint]
+			if !found {
+				leafIdx++
+				continue
+			}
+			ld := block.MsgBlock().UData.LeafDatas[leafIdx]
+
+			wm.wallet.RelevantUtxos[in.PreviousOutPoint] = ld
+			leafIdx++
+		}
+	}
+
+	return targetsToProve
+}
+
+// handleBlockchainNotification is the main workhorse for updating the utreexo proofs
+// for the wallet. It handles new blocks as well as reorgs.
+func (wm *WatchOnlyWalletManager) handleBlockchainNotification(notification *blockchain.Notification) {
+	wm.walletLock.Lock()
+	defer wm.walletLock.Unlock()
+
+	switch notification.Type {
+	// A block has been accepted into the block chain.
+	case blockchain.NTBlockConnected:
+		block, ok := notification.Data.(*btcutil.Block)
+		if !ok {
+			log.Warnf("Chain connected notification is not a block.")
+			break
+		}
+
+		remembers := wm.filterBlock(block)
+
+		ud := block.MsgBlock().UData
+		targets := ud.AccProof.Targets
+		adds := block.UtreexoAdds()
+		updateData := block.UtreexoUpdateData()
+
+		var err error
+		wm.wallet.UtreexoLeaves, err = wm.wallet.UtreexoProof.Update(
+			wm.wallet.UtreexoLeaves, adds, targets, remembers, *updateData)
+		if err != nil {
+			log.Criticalf("Couldn't update utreexo proof for block %s.", block.Hash())
+			break
+		}
+		wm.wallet.BestHash = *block.Hash()
+
+	// A block has been disconnected from the main block chain.
+	case blockchain.NTBlockDisconnected:
+		block, ok := notification.Data.(*btcutil.Block)
+		if !ok {
+			log.Warnf("Chain disconnected notification is not a block.")
+			break
+		}
+
+		ud := block.MsgBlock().UData
+		targets := ud.AccProof.Targets
+		updateData := block.UtreexoUpdateData()
+		numAdds := uint64(len(block.UtreexoAdds()))
+		numLeaves := updateData.PrevNumLeaves
+
+		delHashes := make([]utreexo.Hash, 0, len(ud.LeafDatas))
+		for _, ld := range ud.LeafDatas {
+			delHashes = append(delHashes, ld.LeafHash())
+		}
+
+		var err error
+		wm.wallet.UtreexoLeaves, err = wm.wallet.UtreexoProof.Undo(numAdds,
+			numLeaves, targets, delHashes, wm.wallet.UtreexoLeaves,
+			updateData.ToDestroy, ud.AccProof)
+		if err != nil {
+			log.Criticalf("Couldn't undo utreexo proof for block %s.", block.Hash())
+			break
+		}
+
+		targetsToProve := wm.filterBlockForUndo(block)
+
+		hashes, proof, err := utreexo.GetProofSubset(
+			ud.AccProof, delHashes, targetsToProve, updateData.PrevNumLeaves)
+		if err != nil {
+			log.Criticalf("Couldn't grab the utreexo proof for previous "+
+				"spends %s.", block.Hash())
+			break
+		}
+
+		wm.wallet.UtreexoLeaves, wm.wallet.UtreexoProof = utreexo.AddProof(
+			wm.wallet.UtreexoProof, proof, wm.wallet.UtreexoLeaves,
+			hashes, updateData.PrevNumLeaves)
+
+		// Write the new state to the disk to overwrite the older state.
+		err = wm.writeToDisk()
+		if err != nil {
+			log.Criticalf("Couldn't write to the wallet file after undoing block %s",
+				block.Hash().String())
+			break
+		}
+	}
+}
+
+// writeToDisk writes the entire wallet state to disk in json.
+func (m *WatchOnlyWalletManager) writeToDisk() error {
+	walletBytes, err := json.Marshal(&m.wallet)
+	if err != nil {
+		return fmt.Errorf("Cannot serialize the wallet state. Error: %v", err)
+	}
+
+	configBytes, err := json.Marshal(&m.walletConfig)
+	if err != nil {
+		return fmt.Errorf("Cannot serialize the wallet state. Error: %v", err)
+	}
+
+	basePath := filepath.Join(m.config.DataDir, defaultWalletPath)
+	if _, err := os.Stat(basePath); err != nil {
+		os.MkdirAll(basePath, os.ModePerm)
+	}
+	walletConfigName := filepath.Join(basePath, defaultWalletConfigName)
+	configFile, err := os.OpenFile(walletConfigName, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return fmt.Errorf("Cannot open file to write watch only wallet. Error: %v", err)
+	}
+	walletName := filepath.Join(basePath, defaultWalletName)
+	walletFile, err := os.OpenFile(walletName, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return fmt.Errorf("Cannot open file to write watch only wallet. Error: %v", err)
+	}
+
+	err = configFile.Truncate(0)
+	if err != nil {
+		return fmt.Errorf("Failed to write to the watch only wallet. Error: %v", err)
+	}
+	err = walletFile.Truncate(0)
+	if err != nil {
+		return fmt.Errorf("Failed to write to the watch only wallet. Error: %v", err)
+	}
+
+	_, err = configFile.WriteAt(configBytes, 0)
+	if err != nil {
+		return fmt.Errorf("Failed to write to the watch only wallet. Error: %v", err)
+	}
+
+	_, err = walletFile.WriteAt(walletBytes, 0)
+	if err != nil {
+		return fmt.Errorf("Failed to write to the watch only wallet. Error: %v", err)
+	}
+	return nil
+}
+
+// RegisterExtendedPubkey registers an extended pubkey for the watch only wallet to keep track of.
+func (wm *WatchOnlyWalletManager) RegisterExtendedPubkey(extendedKey string) error {
+	xkey, err := hdkeychain.NewKeyFromString(extendedKey)
+	if err != nil {
+		return fmt.Errorf("Failed to parse the passed in key. Error: %v", err)
+	}
+
+	if xkey.IsPrivate() {
+		return fmt.Errorf("Registering private keys are not supported")
+	}
+
+	wm.walletConfig.ExtendedKeys = append(wm.walletConfig.ExtendedKeys, xkey)
+
+	return nil
+}
+
+// RegisterAddress registers an address for the watch only wallet to keep track of.
+func (wm *WatchOnlyWalletManager) RegisterAddress(address string) error {
+	addr, err := btcutil.DecodeAddress(address, wm.config.ChainParams)
+	if err != nil {
+		return fmt.Errorf("Failed to parse the passed in address. Error: %v", err)
+	}
+
+	_, exists := wm.walletConfig.Addresses[addr.String()]
+	if !exists {
+		log.Infof("Registered address: %s", addr.String())
+		wm.walletConfig.Addresses[addr.String()] = struct{}{}
+	} else {
+		log.Infof("Address: %s is already registered", addr.String())
+	}
+
+	return nil
+}
+
+// GetProof returns a proof that can be used to verify the utreexo leaves.
+func (wm *WatchOnlyWalletManager) GetProof() blockchain.ChainTipProof {
+	wm.walletLock.RLock()
+	defer wm.walletLock.RUnlock()
+
+	return blockchain.ChainTipProof{
+		ProvedAtHash: &wm.wallet.BestHash,
+		AccProof:     &wm.wallet.UtreexoProof,
+		HashesProven: wm.wallet.UtreexoLeaves,
+	}
+}
+
+// Start starts the watch only wallet manager.
+func (m *WatchOnlyWalletManager) Start() {
+	// Already started?
+	if atomic.AddInt32(&m.started, 1) != 1 {
+		return
+	}
+
+	log.Infof("Watch only wallet started")
+}
+
+// Stop stops the watch only wallet manager.
+func (m *WatchOnlyWalletManager) Stop() {
+	if atomic.AddInt32(&m.stopped, 1) != 1 {
+		log.Warnf("Watch only wallet manager already stopped")
+		return
+	}
+
+	m.wg.Wait()
+
+	err := m.writeToDisk()
+	if err != nil {
+		log.Criticalf("Cannot write the wallet state. Error: %v", err)
+		return
+	}
+
+	log.Info("Watch only wallet stopped")
+}
+
+// Config is a configuration struct used to initialize a new WatchOnlyWalletManager.
+type Config struct {
+	Chain       *blockchain.BlockChain
+	TxMemPool   *mempool.TxPool
+	ChainParams *chaincfg.Params
+	DataDir     string
+	GapLimit    int32
+}
+
+// New constructs a new instance of the watch-only wallet manager.
+func New(config *Config) (*WatchOnlyWalletManager, error) {
+	wm := WatchOnlyWalletManager{
+		config: config,
+	}
+
+	walletDir := filepath.Join(config.DataDir, defaultWalletPath)
+
+	walletConfig := WalletConfig{
+		Net:       config.ChainParams.Name,
+		Addresses: make(map[string]struct{}),
+		GapLimit:  20,
+	}
+
+	// Check if the wallet config already exists on disk.
+	walletConfigName := filepath.Join(walletDir, defaultWalletConfigName)
+	_, err := os.Stat(walletConfigName)
+	if err != nil && os.IsNotExist(err) {
+	} else if err != nil {
+		return nil, err
+	} else {
+		// If the wallet config already exists on disk, read/load it.
+		data, err := os.ReadFile(walletConfigName)
+		if err != nil {
+			return nil, fmt.Errorf("Couldn't read wallet config at %s. Error: %v",
+				walletConfigName, err)
+		}
+
+		err = json.Unmarshal(data, &walletConfig)
+		if err != nil {
+			return nil, fmt.Errorf("Couldn't unmarshal contents from "+
+				"wallet at %s. Error: %v", walletConfigName, err)
+		}
+
+		// Give a warning if the gaplimit requested is smaller than the gaplimit
+		// previously saved.
+		if config.GapLimit != 0 && config.GapLimit < walletConfig.GapLimit {
+			log.Infof("Gap limit saved in config file is %d but the requested "+
+				"gap limit is %d. This smaller gap limit may result in funds "+
+				"not showing up", walletConfig.GapLimit, config.GapLimit)
+
+			walletConfig.GapLimit = config.GapLimit
+		}
+	}
+	wm.walletConfig = walletConfig
+
+	wallet := WalletState{
+		BestHash:      *config.ChainParams.GenesisHash,
+		RelevantUtxos: make(map[wire.OutPoint]wire.LeafData),
+	}
+	// Check if the wallet state exists on disk.
+	walletName := filepath.Join(walletDir, defaultWalletName)
+	_, err = os.Stat(walletName)
+	if !os.IsNotExist(err) {
+		data, err := os.ReadFile(walletName)
+		if err != nil {
+			return nil, fmt.Errorf("Couldn't read wallet at %s. Error: %v",
+				walletConfigName, err)
+		}
+
+		err = json.Unmarshal(data, &wallet)
+		if err != nil {
+			return nil, fmt.Errorf("Couldn't unmarshal contents from "+
+				"wallet at %s. Error: %v", walletName, err)
+		}
+	}
+	wm.wallet = wallet
+
+	// Print out the addresses tracked to the log.
+	addrStr := ""
+	addrIdx := 0
+	for address := range walletConfig.Addresses {
+		if len(walletConfig.Addresses)-1 == addrIdx {
+			addrStr += address
+		} else {
+			addrStr += address + ", "
+		}
+		addrIdx++
+	}
+	log.Infof("Keeping track of these addresses: %s", addrStr)
+
+	// Subscribe to new blocks/reorged blocks.
+	wm.config.Chain.Subscribe(wm.handleBlockchainNotification)
+
+	return &wm, nil
+}


### PR DESCRIPTION
The watch only wallet keeps supports registering addresses and xpubs and it keeps track of relevant utxos and the utreexo proof for those utxos.

This allows users running Utreexo compact state nodes to keep track of the proofs for their own utxos, allowing the compact state nodes to prove txs to each other.

The watch only wallet is currently a work in progress ands registering xpubs are not supported yet. However, it can keep track of relevant utxos and the utreexo proof and supports handling reorgs as well.