### PR TITLE
blockchain: Add invalidateblock method to BlockChain

### DIFF
--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -187,6 +187,16 @@ func (node *blockNode) Ancestor(height int32) *blockNode {
 	return n
 }
 
+// IsAncestor returns if the other node is an ancestor of this block node.
+func (node *blockNode) IsAncestor(otherNode *blockNode) bool {
+	ancestor := node.Ancestor(otherNode.height)
+	if ancestor == node {
+		return false
+	}
+
+	return ancestor == otherNode
+}
+
 // RelativeAncestor returns the ancestor block node a relative 'distance' blocks
 // before this node.  This is equivalent to calling Ancestor with the node's
 // height minus provided distance.

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1881,6 +1881,142 @@ func (b *BlockChain) LocateHeaders(locator BlockLocator, hashStop *chainhash.Has
 	return headers
 }
 
+// InvalidateBlock invalidates the requested block and all its descedents.  If a block
+// in the best chain is invalidated, the active chain tip will be the parent of the
+// invalidated block.
+//
+// This function is safe for concurrent access.
+func (b *BlockChain) InvalidateBlock(hash *chainhash.Hash) error {
+	b.chainLock.Lock()
+	defer b.chainLock.Unlock()
+
+	node := b.index.LookupNode(hash)
+	if node == nil {
+		// Return an error if the block doesn't exist.
+		return fmt.Errorf("Requested block hash of %s is not found "+
+			"and thus cannot be invalidated.", hash)
+	}
+	if node.height == 0 {
+		return fmt.Errorf("Requested block hash of %s is a at height 0 "+
+			"and is thus a genesis block and cannot be invalidated.",
+			node.hash)
+	}
+
+	// Nothing to do if the given block is already invalid.
+	if node.status.KnownInvalid() {
+		return nil
+	}
+
+	// Set the status of the block being invalidated.
+	b.index.SetStatusFlags(node, statusValidateFailed)
+	b.index.UnsetStatusFlags(node, statusValid)
+
+	// If the block we're invalidating is not on the best chain, we simply
+	// mark the block and all its descendants as invalid and return.
+	if !b.bestChain.Contains(node) {
+		// Grab all the tips excluding the active tip.
+		tips := b.index.InactiveTips(b.bestChain)
+		for _, tip := range tips {
+			// Continue if the given inactive tip is not a descendant of the block
+			// being invalidated.
+			if !tip.IsAncestor(node) {
+				continue
+			}
+
+			// Keep going back until we get to the block being invalidated.
+			// For each of the parent, we'll unset valid status and set invalid
+			// ancestor status.
+			for n := tip; n != nil && n != node; n = n.parent {
+				// Continue if it's already invalid.
+				if n.status.KnownInvalid() {
+					continue
+				}
+				b.index.SetStatusFlags(n, statusInvalidAncestor)
+				b.index.UnsetStatusFlags(n, statusValid)
+			}
+		}
+
+		if writeErr := b.index.flushToDB(); writeErr != nil {
+			log.Warnf("Error flushing block index changes to disk: %v", writeErr)
+		}
+
+		// Return since the block being invalidated is on a side branch.
+		// Nothing else left to do.
+		return nil
+	}
+
+	// If we're here, it means a block from the active chain tip is getting
+	// invalidated.
+	//
+	// Grab all the nodes to detach from the active chain.
+	detachNodes := list.New()
+	for n := b.bestChain.Tip(); n != nil && n != node; n = n.parent {
+		// Continue if it's already invalid.
+		if n.status.KnownInvalid() {
+			continue
+		}
+
+		// Change the status of the block node.
+		b.index.SetStatusFlags(n, statusInvalidAncestor)
+		b.index.UnsetStatusFlags(n, statusValid)
+		detachNodes.PushBack(n)
+	}
+	// Push back the block node being invalidated.
+	detachNodes.PushBack(node)
+
+	// Reorg back to the parent of the block being invalidated.
+	// Nothing to attach so just pass an empty list.
+	err := b.reorganizeChain(detachNodes, list.New())
+	if err != nil {
+		return err
+	}
+
+	if writeErr := b.index.flushToDB(); writeErr != nil {
+		log.Warnf("Error flushing block index changes to disk: %v", writeErr)
+	}
+
+	// Grab all the tips.
+	tips := b.index.InactiveTips(b.bestChain)
+	tips = append(tips, b.bestChain.Tip())
+
+	// Here we'll check if the invalidation of the block in the active tip
+	// changes the status of the chain tips.  If a side branch now has more
+	// worksum, it becomes the active chain tip.
+	var bestTip *blockNode
+	for _, tip := range tips {
+		// Skip invalid tips as they cannot become the active tip.
+		if tip.status.KnownInvalid() {
+			continue
+		}
+
+		// If we have no best tips, then set this tip as the best tip.
+		if bestTip == nil {
+			bestTip = tip
+		} else {
+			// If there is an existing best tip, then compare it
+			// against the current tip.
+			if tip.workSum.Cmp(bestTip.workSum) == 1 {
+				bestTip = tip
+			}
+		}
+	}
+
+	// Return if the best tip is the current tip.
+	if bestTip == b.bestChain.Tip() {
+		return nil
+	}
+
+	// Reorganize to the best tip if a side branch is now the most work tip.
+	detachNodes, attachNodes := b.getReorganizeNodes(bestTip)
+	err = b.reorganizeChain(detachNodes, attachNodes)
+
+	if writeErr := b.index.flushToDB(); writeErr != nil {
+		log.Warnf("Error flushing block index changes to disk: %v", writeErr)
+	}
+
+	return err
+}
+
 // IndexManager provides a generic interface that the is called when blocks are
 // connected and disconnected to and from the tip of the main chain for the
 // purpose of supporting optional indexes.

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -1154,3 +1154,159 @@ func TestChainTips(t *testing.T) {
 		}
 	}
 }
+
+func TestIsAncestor(t *testing.T) {
+	// Construct a synthetic block chain with a block index consisting of
+	// the following structure.
+	// 	genesis -> 1  -> 2  -> 3 (active)
+	//            \ -> 1a (valid-fork)
+	//            \ -> 1b (invalid)
+	tip := tstTip
+	chain := newFakeChain(&chaincfg.MainNetParams)
+	branch0Nodes := chainedNodes(chain.bestChain.Genesis(), 3)
+	for _, node := range branch0Nodes {
+		chain.index.SetStatusFlags(node, statusDataStored)
+		chain.index.SetStatusFlags(node, statusValid)
+		chain.index.AddNode(node)
+	}
+	chain.bestChain.SetTip(tip(branch0Nodes))
+
+	branch1Nodes := chainedNodes(chain.bestChain.Genesis(), 1)
+	for _, node := range branch1Nodes {
+		chain.index.SetStatusFlags(node, statusDataStored)
+		chain.index.SetStatusFlags(node, statusValid)
+		chain.index.AddNode(node)
+	}
+
+	branch2Nodes := chainedNodes(chain.bestChain.Genesis(), 1)
+	for _, node := range branch2Nodes {
+		chain.index.SetStatusFlags(node, statusDataStored)
+		chain.index.SetStatusFlags(node, statusValidateFailed)
+		chain.index.AddNode(node)
+	}
+
+	// Is 1 an ancestor of 3?
+	//
+	// 	genesis -> 1  -> 2  -> 3 (active)
+	//            \ -> 1a (valid-fork)
+	//            \ -> 1b (invalid)
+	shouldBeTrue := branch0Nodes[2].IsAncestor(branch0Nodes[0])
+	if !shouldBeTrue {
+		t.Errorf("TestIsAncestor fail. Node %s is an ancestor of node %s but got false",
+			branch0Nodes[0].hash.String(), branch0Nodes[2].hash.String())
+	}
+
+	// Is 1 an ancestor of 2?
+	//
+	// 	genesis -> 1  -> 2  -> 3 (active)
+	//            \ -> 1a (valid-fork)
+	//            \ -> 1b (invalid)
+	shouldBeTrue = branch0Nodes[1].IsAncestor(branch0Nodes[0])
+	if !shouldBeTrue {
+		t.Errorf("TestIsAncestor fail. Node %s is an ancestor of node %s but got false",
+			branch0Nodes[1].hash.String(), branch0Nodes[2].hash.String())
+	}
+
+	// Is the genesis an ancestor of 1?
+	//
+	// 	genesis -> 1  -> 2  -> 3 (active)
+	//            \ -> 1a (valid-fork)
+	//            \ -> 1b (invalid)
+	shouldBeTrue = branch0Nodes[0].IsAncestor(chain.bestChain.Genesis())
+	if !shouldBeTrue {
+		t.Errorf("TestIsAncestor fail. The genesis block is an ancestor of all blocks "+
+			"but got false for node %s",
+			branch0Nodes[0].hash.String())
+	}
+
+	// Is the genesis an ancestor of 1a?
+	//
+	// 	genesis -> 1  -> 2  -> 3 (active)
+	//            \ -> 1a (valid-fork)
+	//            \ -> 1b (invalid)
+	shouldBeTrue = branch1Nodes[0].IsAncestor(chain.bestChain.Genesis())
+	if !shouldBeTrue {
+		t.Errorf("TestIsAncestor fail. The genesis block is an ancestor of all blocks "+
+			"but got false for node %s",
+			branch1Nodes[0].hash.String())
+	}
+
+	// Is the genesis an ancestor of 1b?
+	//
+	// 	genesis -> 1  -> 2  -> 3 (active)
+	//            \ -> 1a (valid-fork)
+	//            \ -> 1b (invalid)
+	shouldBeTrue = branch2Nodes[0].IsAncestor(chain.bestChain.Genesis())
+	if !shouldBeTrue {
+		t.Errorf("TestIsAncestor fail. The genesis block is an ancestor of all blocks "+
+			"but got false for node %s",
+			branch2Nodes[0].hash.String())
+	}
+
+	// Is 1 an ancestor of 1a?
+	//
+	// 	genesis -> 1  -> 2  -> 3 (active)
+	//            \ -> 1a (valid-fork)
+	//            \ -> 1b (invalid)
+	shouldBeFalse := branch1Nodes[0].IsAncestor(branch0Nodes[0])
+	if shouldBeFalse {
+		t.Errorf("TestIsAncestor fail. Node %s is in a different branch than "+
+			"node %s but got true", branch1Nodes[0].hash.String(),
+			branch0Nodes[0].hash.String())
+	}
+
+	// Is 1 an ancestor of 1b?
+	//
+	// 	genesis -> 1  -> 2  -> 3 (active)
+	//            \ -> 1a (valid-fork)
+	//            \ -> 1b (invalid)
+	shouldBeFalse = branch2Nodes[0].IsAncestor(branch0Nodes[0])
+	if shouldBeFalse {
+		t.Errorf("TestIsAncestor fail. Node %s is in a different branch than "+
+			"node %s but got true", branch2Nodes[0].hash.String(),
+			branch0Nodes[0].hash.String())
+	}
+
+	// Is 1a an ancestor of 1b?
+	//
+	// 	genesis -> 1  -> 2  -> 3 (active)
+	//            \ -> 1a (valid-fork)
+	//            \ -> 1b (invalid)
+	shouldBeFalse = branch2Nodes[0].IsAncestor(branch1Nodes[0])
+	if shouldBeFalse {
+		t.Errorf("TestIsAncestor fail. Node %s is in a different branch than "+
+			"node %s but got true", branch2Nodes[0].hash.String(),
+			branch1Nodes[0].hash.String())
+	}
+
+	// Is 1 an ancestor of 1?
+	//
+	// 	genesis -> 1  -> 2  -> 3 (active)
+	//            \ -> 1a (valid-fork)
+	//            \ -> 1b (invalid)
+	shouldBeFalse = branch0Nodes[0].IsAncestor(branch0Nodes[0])
+	if shouldBeFalse {
+		t.Errorf("TestIsAncestor fail. Node is not an ancestor of itself but got true for node %s",
+			branch0Nodes[0].hash.String())
+	}
+
+	// Is the geneis an ancestor of genesis?
+	//
+	// 	genesis -> 1  -> 2  -> 3 (active)
+	//            \ -> 1a (valid-fork)
+	//            \ -> 1b (invalid)
+	shouldBeFalse = chain.bestChain.Genesis().IsAncestor(chain.bestChain.Genesis())
+	if shouldBeFalse {
+		t.Errorf("TestIsAncestor fail. Node is not an ancestor of itself but got true for node %s",
+			chain.bestChain.Genesis().hash.String())
+	}
+
+	// Is a block from another chain an ancestor of 1b?
+	fakeChain := newFakeChain(&chaincfg.TestNet3Params)
+	shouldBeFalse = branch2Nodes[0].IsAncestor(fakeChain.bestChain.Genesis())
+	if shouldBeFalse {
+		t.Errorf("TestIsAncestor fail. Node %s is in a different chain than "+
+			"node %s but got true", fakeChain.bestChain.Genesis().hash.String(),
+			branch2Nodes[0].hash.String())
+	}
+}

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -6,6 +6,7 @@ package blockchain
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
 	"testing"
 	"time"
@@ -1308,5 +1309,354 @@ func TestIsAncestor(t *testing.T) {
 		t.Errorf("TestIsAncestor fail. Node %s is in a different chain than "+
 			"node %s but got true", fakeChain.bestChain.Genesis().hash.String(),
 			branch2Nodes[0].hash.String())
+	}
+}
+
+func TestInvalidateBlock(t *testing.T) {
+	tests := []struct {
+		name     string
+		chainGen func() (*BlockChain, []*chainhash.Hash, func())
+	}{
+		{
+			name: "One branch, invalidate once",
+			chainGen: func() (*BlockChain, []*chainhash.Hash, func()) {
+				source := rand.NewSource(time.Now().UnixNano())
+				rand := rand.New(source)
+
+				chain, params, tearDown := utxoCacheTestChain("TestInvalidateBlock-one-branch-invalidate-once")
+				tip := btcutil.NewBlock(params.GenesisBlock)
+
+				// Create block at height 1.
+				var emptySpendableOuts []*SpendableOut
+				b1, spendableOuts1 := AddBlock(chain, tip, emptySpendableOuts)
+
+				var allSpends []*SpendableOut
+				nextBlock := b1
+				nextSpends := spendableOuts1
+
+				var invalidateHash *chainhash.Hash
+
+				// Create a chain with 11 blocks.
+				for b := 0; b < 10; b++ {
+					newBlock, newSpendableOuts := AddBlock(chain, nextBlock, nextSpends)
+					nextBlock = newBlock
+
+					if newBlock.Height() == 5 {
+						invalidateHash = newBlock.Hash()
+					}
+
+					allSpends = append(allSpends, newSpendableOuts...)
+
+					var nextSpendsTmp []*SpendableOut
+					for i := 0; i < len(allSpends); i++ {
+						randIdx := rand.Intn(len(allSpends))
+
+						spend := allSpends[randIdx]                                       // get
+						allSpends = append(allSpends[:randIdx], allSpends[randIdx+1:]...) // delete
+						nextSpendsTmp = append(nextSpendsTmp, spend)
+					}
+					nextSpends = nextSpendsTmp
+
+					if b%10 == 0 {
+						// Commit the two base blocks to DB
+						if err := chain.FlushCachedState(FlushRequired); err != nil {
+							t.Fatalf("unexpected error while flushing cache: %v", err)
+						}
+					}
+				}
+
+				return chain, []*chainhash.Hash{invalidateHash}, tearDown
+			},
+		},
+		{
+			name: "invalidate twice",
+			chainGen: func() (*BlockChain, []*chainhash.Hash, func()) {
+				source := rand.NewSource(0)
+				rand := rand.New(source)
+
+				chain, params, tearDown := utxoCacheTestChain("TestInvalidateBlock-invalidate-twice")
+				tip := btcutil.NewBlock(params.GenesisBlock)
+
+				// Create block at height 1.
+				var emptySpendableOuts []*SpendableOut
+				b1, spendableOuts1 := AddBlock(chain, tip, emptySpendableOuts)
+
+				var allSpends []*SpendableOut
+				nextBlock := b1
+				nextSpends := spendableOuts1
+
+				var invalidateHash *chainhash.Hash
+
+				// Create a chain with 11 blocks.
+				for b := 0; b < 10; b++ {
+					newBlock, newSpendableOuts := AddBlock(chain, nextBlock, nextSpends)
+					nextBlock = newBlock
+
+					if newBlock.Height() == 5 {
+						invalidateHash = newBlock.Hash()
+					}
+
+					allSpends = append(allSpends, newSpendableOuts...)
+
+					var nextSpendsTmp []*SpendableOut
+					for i := 0; i < len(allSpends); i++ {
+						randIdx := rand.Intn(len(allSpends))
+
+						spend := allSpends[randIdx]                                       // get
+						allSpends = append(allSpends[:randIdx], allSpends[randIdx+1:]...) // delete
+						nextSpendsTmp = append(nextSpendsTmp, spend)
+					}
+					nextSpends = nextSpendsTmp
+
+					if b%10 == 0 {
+						// Commit the two base blocks to DB
+						if err := chain.FlushCachedState(FlushRequired); err != nil {
+							t.Fatalf("unexpected error while flushing cache: %v", err)
+						}
+					}
+				}
+
+				// Create a side chain with 7 blocks that builds on block 1.
+				var altSpends []*SpendableOut
+				altNextSpends := spendableOuts1
+				altNextBlock := b1
+				var invalidateHash2 *chainhash.Hash
+				for b := 0; b < 6; b++ {
+					altNewBlock, newSpends := AddBlock(chain, altNextBlock, altNextSpends)
+					altNextBlock = altNewBlock
+
+					altSpends = append(altSpends, newSpends...)
+
+					if altNewBlock.Height() == 5 {
+						invalidateHash2 = altNewBlock.Hash()
+					}
+
+					var nextSpendsTmp []*SpendableOut
+					for i := 0; i < len(altSpends); i++ {
+						randIdx := rand.Intn(len(altSpends))
+
+						spend := altSpends[randIdx]                                       // get
+						altSpends = append(altSpends[:randIdx], altSpends[randIdx+1:]...) // delete
+						nextSpendsTmp = append(nextSpendsTmp, spend)
+					}
+					altNextSpends = nextSpendsTmp
+
+					if b%10 == 0 {
+						// Commit the two base blocks to DB
+						if err := chain.FlushCachedState(FlushRequired); err != nil {
+							t.Fatalf("unexpected error while flushing cache: %v", err)
+						}
+					}
+				}
+
+				return chain, []*chainhash.Hash{invalidateHash, invalidateHash2}, tearDown
+			},
+		},
+		{
+			name: "invalidate a side branch",
+			chainGen: func() (*BlockChain, []*chainhash.Hash, func()) {
+				source := rand.NewSource(0)
+				rand := rand.New(source)
+
+				chain, params, tearDown := utxoCacheTestChain("TestInvalidateBlock-invalidate-side-branch")
+				tip := btcutil.NewBlock(params.GenesisBlock)
+
+				// Create block at height 1.
+				var emptySpendableOuts []*SpendableOut
+				b1, spendableOuts1 := AddBlock(chain, tip, emptySpendableOuts)
+
+				var allSpends []*SpendableOut
+				nextBlock := b1
+				nextSpends := spendableOuts1
+
+				// Create a chain with 11 blocks.
+				for b := 0; b < 10; b++ {
+					newBlock, newSpendableOuts := AddBlock(chain, nextBlock, nextSpends)
+					nextBlock = newBlock
+
+					allSpends = append(allSpends, newSpendableOuts...)
+
+					var nextSpendsTmp []*SpendableOut
+					for i := 0; i < len(allSpends); i++ {
+						randIdx := rand.Intn(len(allSpends))
+
+						spend := allSpends[randIdx]                                       // get
+						allSpends = append(allSpends[:randIdx], allSpends[randIdx+1:]...) // delete
+						nextSpendsTmp = append(nextSpendsTmp, spend)
+					}
+					nextSpends = nextSpendsTmp
+
+					if b%10 == 0 {
+						// Commit the two base blocks to DB
+						if err := chain.FlushCachedState(FlushRequired); err != nil {
+							t.Fatalf("unexpected error while flushing cache: %v", err)
+						}
+					}
+				}
+
+				// Create a side chain with 7 blocks that builds on block 1.
+				var altSpends []*SpendableOut
+				altNextSpends := spendableOuts1
+				altNextBlock := b1
+				var invalidateHash *chainhash.Hash
+				for b := 0; b < 6; b++ {
+					altNewBlock, newSpends := AddBlock(chain, altNextBlock, altNextSpends)
+					altNextBlock = altNewBlock
+
+					altSpends = append(altSpends, newSpends...)
+
+					if altNewBlock.Height() == 4 {
+						invalidateHash = altNewBlock.Hash()
+					}
+
+					var nextSpendsTmp []*SpendableOut
+					for i := 0; i < len(altSpends); i++ {
+						randIdx := rand.Intn(len(altSpends))
+
+						spend := altSpends[randIdx]                                       // get
+						altSpends = append(altSpends[:randIdx], altSpends[randIdx+1:]...) // delete
+						nextSpendsTmp = append(nextSpendsTmp, spend)
+					}
+					altNextSpends = nextSpendsTmp
+
+					if b%10 == 0 {
+						// Commit the two base blocks to DB
+						if err := chain.FlushCachedState(FlushRequired); err != nil {
+							t.Fatalf("unexpected error while flushing cache: %v", err)
+						}
+					}
+				}
+
+				return chain, []*chainhash.Hash{invalidateHash}, tearDown
+			},
+		},
+	}
+
+	for _, test := range tests {
+		chain, invalidateHashes, tearDown := test.chainGen()
+		func() {
+			defer tearDown()
+			for _, invalidateHash := range invalidateHashes {
+				chainTipsBefore := chain.ChainTips()
+
+				// Mark if we're invalidating a block that's a part of the best chain.
+				var bestChainBlock bool
+				node := chain.IndexLookupNode(invalidateHash)
+				if chain.bestChain.Contains(node) {
+					bestChainBlock = true
+				}
+
+				// Actual invalidation.
+				err := chain.InvalidateBlock(invalidateHash)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				chainTipsAfter := chain.ChainTips()
+
+				// Create a map for easy lookup.
+				chainTipMap := make(map[chainhash.Hash]ChainTip, len(chainTipsAfter))
+				activeTipCount := 0
+				for _, chainTip := range chainTipsAfter {
+					chainTipMap[chainTip.BlockHash] = chainTip
+
+					if chainTip.Status == StatusActive {
+						activeTipCount++
+					}
+				}
+				if activeTipCount != 1 {
+					t.Fatalf("TestInvalidateBlock fail. Expected "+
+						"1 active chain tip but got %d", activeTipCount)
+				}
+
+				bestTip := chain.bestChain.Tip()
+
+				validForkCount := 0
+				for _, tip := range chainTipsBefore {
+					// If the chaintip was an active tip and we invalidated a block
+					// in the active tip, assert that it's invalid now.
+					if bestChainBlock && tip.Status == StatusActive {
+						gotTip, found := chainTipMap[tip.BlockHash]
+						if !found {
+							t.Fatalf("TestInvalidateBlock fail. Expected "+
+								"block %s not found in chaintips after "+
+								"invalidateblock", tip.BlockHash.String())
+						}
+
+						if gotTip.Status != StatusInvalid {
+							t.Fatalf("TestInvalidateBlock fail. "+
+								"Expected block %s to be invalid, got status: %s",
+								gotTip.BlockHash.String(), gotTip.Status)
+						}
+					}
+
+					if !bestChainBlock && tip.Status != StatusActive {
+						gotTip, found := chainTipMap[tip.BlockHash]
+						if !found {
+							t.Fatalf("TestInvalidateBlock fail. Expected "+
+								"block %s not found in chaintips after "+
+								"invalidateblock", tip.BlockHash.String())
+						}
+
+						if gotTip.BlockHash == *invalidateHash && gotTip.Status != StatusInvalid {
+							t.Fatalf("TestInvalidateBlock fail. "+
+								"Expected block %s to be invalid, got status: %s",
+								gotTip.BlockHash.String(), gotTip.Status)
+						}
+					}
+
+					// If we're not invalidating the branch with an active tip,
+					// we expect the active tip to remain the same.
+					if !bestChainBlock && tip.Status == StatusActive && tip.BlockHash != bestTip.hash {
+						t.Fatalf("TestInvalidateBlock fail. Expected block %s as the tip but got %s",
+							tip.BlockHash.String(), bestTip.hash.String())
+					}
+
+					// If this tip is not invalid and not active, it should be
+					// lighter than the current best tip.
+					if tip.Status != StatusActive && tip.Status != StatusInvalid &&
+						tip.Height > bestTip.height {
+
+						tipNode := chain.IndexLookupNode(&tip.BlockHash)
+						if bestTip.workSum.Cmp(tipNode.workSum) == -1 {
+							t.Fatalf("TestInvalidateBlock fail. Expected "+
+								"block %s to be the active tip but block %s "+
+								"was", tipNode.hash.String(), bestTip.hash.String())
+						}
+					}
+
+					if tip.Status == StatusValidFork {
+						validForkCount++
+					}
+				}
+
+				// If there are no other valid chain tips besides the active chaintip,
+				// we expect to have one more chain tip after the invalidate.
+				if validForkCount == 0 && len(chainTipsAfter) != len(chainTipsBefore)+1 {
+					t.Fatalf("TestInvalidateBlock fail. Expected %d chaintips but got %d",
+						len(chainTipsBefore)+1, len(chainTipsAfter))
+				}
+			}
+
+			// Try to invaliate the already invalidated hash.
+			err := chain.InvalidateBlock(invalidateHashes[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Try to invaliate a genesis block
+			err = chain.InvalidateBlock(chain.chainParams.GenesisHash)
+			if err == nil {
+				t.Fatalf("TestInvalidateBlock fail. Expected to err when trying to" +
+					"invalidate a genesis block.")
+			}
+
+			// Try to invaliate a block that doesn't exist.
+			err = chain.InvalidateBlock(chaincfg.MainNetParams.GenesisHash)
+			if err == nil {
+				t.Fatalf("TestInvalidateBlock fail. Expected to err when trying to" +
+					"invalidate a block that doesn't exist.")
+			}
+		}()
 	}
 }


### PR DESCRIPTION
This PR adds the missing `invalidateblock` rpc call. The call is useful for both manually testing changes with the cli or creating automated tests.

The behavior of Bitcoin Core is mimicked. However, since we currently don't keep track of which block was received first, the prioritization of choosing whichever block is received first for the active chain tip is omitted.