### PR TITLE
main: Remove cfilters as a default index

### DIFF
--- a/config.go
+++ b/config.go
@@ -200,7 +200,7 @@ type config struct {
 	TTLIndex                         bool     `long:"ttlindex" description:"Maintain a full time to live index for all stxos available via the getttl RPC"`
 	UtreexoProofIndex                bool     `long:"utreexoproofindex" description:"Maintain a utreexo proof for all blocks"`
 	FlatUtreexoProofIndex            bool     `long:"flatutreexoproofindex" description:"Maintain a utreexo proof for all blocks in flat files"`
-	NoCFilters                       bool     `long:"nocfilters" description:"Disable committed filtering (CF) support"`
+	CFilters                         bool     `long:"cfilters" description:"Enable committed filtering (CF) support"`
 	NoPeerBloomFilters               bool     `long:"nopeerbloomfilters" description:"Disable bloom filtering support"`
 	DropAddrIndex                    bool     `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up and then exits."`
 	DropCfIndex                      bool     `long:"dropcfindex" description:"Deletes the index used for committed filtering (CF) support from the database on start up and then exits."`

--- a/server.go
+++ b/server.go
@@ -45,7 +45,7 @@ const (
 	// defaultServices describes the default services that are supported by
 	// the server.
 	defaultServices = wire.SFNodeNetwork | wire.SFNodeNetworkLimited |
-		wire.SFNodeBloom | wire.SFNodeWitness | wire.SFNodeCF
+		wire.SFNodeBloom | wire.SFNodeWitness
 
 	// defaultRequiredServices describes the default services that are
 	// required to be supported by outbound peers.
@@ -2919,8 +2919,8 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 	if cfg.NoPeerBloomFilters {
 		services &^= wire.SFNodeBloom
 	}
-	if cfg.NoCFilters {
-		services &^= wire.SFNodeCF
+	if cfg.CFilters {
+		services |= wire.SFNodeCF
 	}
 	if cfg.Prune != 0 {
 		services &^= wire.SFNodeNetwork
@@ -3000,7 +3000,7 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 		s.addrIndex = indexers.NewAddrIndex(db, chainParams)
 		indexes = append(indexes, s.addrIndex)
 	}
-	if !cfg.NoCFilters {
+	if cfg.CFilters {
 		indxLog.Info("Committed filter index is enabled")
 		s.cfIndex = indexers.NewCfIndex(db, chainParams)
 		indexes = append(indexes, s.cfIndex)


### PR DESCRIPTION
No need to have cfilters as a default index. It adds the overhead of computation and disk space for utreexo nodes. # # #