### PR TITLE
blockchain: Add ExtractMerkleBranch and HashMerkleRoot

### DIFF
--- a/blockchain/merkle.go
+++ b/blockchain/merkle.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"math/bits"
 
 	"github.com/utreexo/utreexod/btcutil"
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
@@ -262,4 +263,96 @@ func ValidateWitnessCommitment(blk *btcutil.Block) error {
 	}
 
 	return nil
+}
+
+// treeRows returns the number of rows given n leaves.
+func treeRows(n uint64) uint8 {
+	if n == 0 {
+		return 0
+	}
+
+	return uint8(bits.Len64(n - 1))
+}
+
+// sibling returns the sibling of this node.
+func sibling(pos uint64) uint64 {
+	return pos ^ 1
+}
+
+// parent returns the position of the parent of this position.
+func parent(position uint64, forestRows uint8) uint64 {
+	return (position >> 1) | (1 << forestRows)
+}
+
+// ExtractMerkleBranch returns the merkle branches needed to prove the txHash.
+// The returned merkle branch does not contain the passed in tx hash.
+func ExtractMerkleBranch(merkles []*chainhash.Hash, txHash chainhash.Hash) []*chainhash.Hash {
+	// Since the merkle trees are always a perfect power of 2,
+	// the total length of all the nodes will be:
+	// len(merkles) = (numLeaves * 2) - 1
+	//
+	// This means we can calculate the number of leaves with the
+	// total length of all nodes in the merkle tree.
+	// (len(merkles)+1)/2 = numLeaves
+	numLeaves := (len(merkles) + 1) / 2
+
+	// Look for the tx in the leaves.
+	idx := -1
+	for i := 0; i < numLeaves; i++ {
+		if *merkles[i] == txHash {
+			fmt.Printf("ExtractMerkleBranch found %s at idx %d\n",
+				txHash.String(), i)
+			idx = i
+			break
+		}
+	}
+	// The tx we're looking for is not in the merkles.
+	if idx == -1 {
+		return nil
+	}
+	forestRows := treeRows(uint64(numLeaves))
+	relevantMerkles := make([]*chainhash.Hash, forestRows)
+
+	// Start with the sibling.
+	idx = int(sibling(uint64(idx)))
+	for i := range relevantMerkles {
+		switch {
+		case merkles[idx] == nil:
+			relevantMerkles[i] = merkles[sibling(uint64(idx))]
+		default:
+			relevantMerkles[i] = merkles[idx]
+		}
+
+		// Set the idx as the aunt.
+		idx = int(sibling(parent(uint64(idx), forestRows)))
+	}
+
+	return relevantMerkles
+}
+
+// isLeftNode returns if the position is located on the left.
+func isLeftNode(position int) bool {
+	return position&1 == 0
+}
+
+// HashMerkleRoot calculates the merkle root given the target, its position, and all the
+// branches needed to hash up to the root.
+func HashMerkleRoot(merkles []*chainhash.Hash, target chainhash.Hash, pos int) chainhash.Hash {
+	result := target
+	for i, merkle := range merkles {
+		var hash *chainhash.Hash
+		if merkle != nil {
+			hash = merkle
+		} else {
+			hash = &result
+		}
+
+		if isLeftNode(pos >> i) {
+			result = *HashMerkleBranches(&result, hash)
+		} else {
+			result = *HashMerkleBranches(hash, &result)
+		}
+	}
+
+	return result
 }


### PR DESCRIPTION
Two merkle tree functions are added. ExtractMerkleBranch let's you extract the merkle proof for a single hash in a merkle tree. HashMerkleRoot provides a function for calculating the merkle root given the hash, position, and the merkle branch.

This commit is part of the effort to add electrum server support to utreexod. Electrum protocol requires serving merkle proofs for a given tx and the extract provides that functionality. HashMerkleRoot is added to test that the returned result from ExtractMerkleBranch is correct.