### PR TITLE
blockchain: Better error message for VerifyUData

### DIFF
--- a/blockchain/utreexoviewpoint.go
+++ b/blockchain/utreexoviewpoint.go
@@ -935,8 +935,9 @@ func (b *BlockChain) VerifyUData(ud *wire.UData, txIns []*wire.TxIn) error {
 	if err != nil {
 		str := "Verify fail. All txIns-leaf datas:\n"
 		for i, txIn := range txIns {
-			str += fmt.Sprintf("txIn: %s, leafdata: %s\n", txIn.PreviousOutPoint.String(),
-				ud.LeafDatas[i].ToString())
+			leafHash := ud.LeafDatas[i].LeafHash()
+			str += fmt.Sprintf("txIn: %s, leafdata: %s, hash %s\n", txIn.PreviousOutPoint.String(),
+				ud.LeafDatas[i].ToString(), hex.EncodeToString(leafHash[:]))
 		}
 		str += fmt.Sprintf("err: %s", err.Error())
 		return fmt.Errorf(str)


### PR DESCRIPTION
VerifyUData now includes the leafhash in the error message.