### PR TITLE
go.mod, go.sum: Update Utreexo library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jrick/logrotate v1.0.0
 	github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/utreexo/utreexo v0.0.0-20221208080346-7acaf0ad6174
+	github.com/utreexo/utreexo v0.0.0-20230405053506-c2ceb550ae12
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/utreexo/utreexo v0.0.0-20221107064738-9b865117b9e4 h1:OAUOL3/F6V2YYFo
 github.com/utreexo/utreexo v0.0.0-20221107064738-9b865117b9e4/go.mod h1:RT9JpZADhLr2YJVBgp48tmUxVeAHaAbOSr6p6nAEJpI=
 github.com/utreexo/utreexo v0.0.0-20221208080346-7acaf0ad6174 h1:oVVRuSCoFEu1K+0zHwfjij0QTARN+5x7gtBC8neD8ZA=
 github.com/utreexo/utreexo v0.0.0-20221208080346-7acaf0ad6174/go.mod h1:RT9JpZADhLr2YJVBgp48tmUxVeAHaAbOSr6p6nAEJpI=
+github.com/utreexo/utreexo v0.0.0-20230405053506-c2ceb550ae12 h1:kVUdesC4/cGZ9k612QMcXKgQXThgtjD4sw/9VGANgXc=
+github.com/utreexo/utreexo v0.0.0-20230405053506-c2ceb550ae12/go.mod h1:RT9JpZADhLr2YJVBgp48tmUxVeAHaAbOSr6p6nAEJpI=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
The new utreexo library has fixes for GetProofSubset which is critical for the watch only wallet.