### PR TITLE
btcjson: Omit empty error for btcjson.Response

### DIFF
--- a/btcjson/example_test.go
+++ b/btcjson/example_test.go
@@ -107,7 +107,7 @@ func ExampleMarshalResponse() {
 	fmt.Printf("%s\n", marshalledBytes)
 
 	// Output:
-	// {"jsonrpc":"1.0","result":350001,"error":null,"id":1}
+	// {"jsonrpc":"1.0","result":350001,"id":1}
 }
 
 // This example demonstrates how to unmarshal a JSON-RPC response and then

--- a/btcjson/jsonrpc.go
+++ b/btcjson/jsonrpc.go
@@ -192,7 +192,7 @@ func NewRequest(rpcVersion RPCVersion, id interface{}, method string, params []i
 type Response struct {
 	Jsonrpc RPCVersion      `json:"jsonrpc"`
 	Result  json.RawMessage `json:"result"`
-	Error   *RPCError       `json:"error"`
+	Error   *RPCError       `json:"error,omitempty"`
 	ID      *interface{}    `json:"id"`
 }
 

--- a/btcjson/jsonrpc_test.go
+++ b/btcjson/jsonrpc_test.go
@@ -68,7 +68,7 @@ func TestMarshalResponse(t *testing.T) {
 			name:     "ordinary bool result with no error",
 			result:   true,
 			jsonErr:  nil,
-			expected: []byte(`{"jsonrpc":"1.0","result":true,"error":null,"id":1}`),
+			expected: []byte(`{"jsonrpc":"1.0","result":true,"id":1}`),
 		},
 		{
 			name:   "result with error",


### PR DESCRIPTION
Instead of returning nil for the error field when the error is nil, it is omitted if the error is nil. Having the error field causes error for the electrum protocol as it expects no error fields if the error is nil.