### PR TITLE
blockchain: add utxocache/utxoviewpoint code from btcd

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -1359,7 +1359,7 @@ func TestInvalidateBlock(t *testing.T) {
 
 					if b%10 == 0 {
 						// Commit the two base blocks to DB
-						if err := chain.FlushCachedState(FlushRequired); err != nil {
+						if err := chain.FlushUtxoCache(FlushRequired); err != nil {
 							t.Fatalf("unexpected error while flushing cache: %v", err)
 						}
 					}
@@ -1410,7 +1410,7 @@ func TestInvalidateBlock(t *testing.T) {
 
 					if b%10 == 0 {
 						// Commit the two base blocks to DB
-						if err := chain.FlushCachedState(FlushRequired); err != nil {
+						if err := chain.FlushUtxoCache(FlushRequired); err != nil {
 							t.Fatalf("unexpected error while flushing cache: %v", err)
 						}
 					}
@@ -1443,7 +1443,7 @@ func TestInvalidateBlock(t *testing.T) {
 
 					if b%10 == 0 {
 						// Commit the two base blocks to DB
-						if err := chain.FlushCachedState(FlushRequired); err != nil {
+						if err := chain.FlushUtxoCache(FlushRequired); err != nil {
 							t.Fatalf("unexpected error while flushing cache: %v", err)
 						}
 					}
@@ -1488,7 +1488,7 @@ func TestInvalidateBlock(t *testing.T) {
 
 					if b%10 == 0 {
 						// Commit the two base blocks to DB
-						if err := chain.FlushCachedState(FlushRequired); err != nil {
+						if err := chain.FlushUtxoCache(FlushRequired); err != nil {
 							t.Fatalf("unexpected error while flushing cache: %v", err)
 						}
 					}
@@ -1521,7 +1521,7 @@ func TestInvalidateBlock(t *testing.T) {
 
 					if b%10 == 0 {
 						// Commit the two base blocks to DB
-						if err := chain.FlushCachedState(FlushRequired); err != nil {
+						if err := chain.FlushUtxoCache(FlushRequired); err != nil {
 							t.Fatalf("unexpected error while flushing cache: %v", err)
 						}
 					}
@@ -1708,7 +1708,7 @@ func TestReconsiderBlock(t *testing.T) {
 
 					if b%10 == 0 {
 						// Commit the two base blocks to DB
-						if err := chain.FlushCachedState(FlushRequired); err != nil {
+						if err := chain.FlushUtxoCache(FlushRequired); err != nil {
 							t.Fatalf("unexpected error while flushing cache: %v", err)
 						}
 					}
@@ -1758,7 +1758,7 @@ func TestReconsiderBlock(t *testing.T) {
 
 					if b%10 == 0 {
 						// Commit the two base blocks to DB
-						if err := chain.FlushCachedState(FlushRequired); err != nil {
+						if err := chain.FlushUtxoCache(FlushRequired); err != nil {
 							t.Fatalf("unexpected error while flushing cache: %v", err)
 						}
 					}
@@ -1785,7 +1785,7 @@ func TestReconsiderBlock(t *testing.T) {
 
 					if b%10 == 0 {
 						// Commit the two base blocks to DB
-						if err := chain.FlushCachedState(FlushRequired); err != nil {
+						if err := chain.FlushUtxoCache(FlushRequired); err != nil {
 							t.Fatalf("unexpected error while flushing cache: %v", err)
 						}
 					}
@@ -1830,7 +1830,7 @@ func TestReconsiderBlock(t *testing.T) {
 
 					if b%10 == 0 {
 						// Commit the two base blocks to DB
-						if err := chain.FlushCachedState(FlushRequired); err != nil {
+						if err := chain.FlushUtxoCache(FlushRequired); err != nil {
 							t.Fatalf("unexpected error while flushing cache: %v", err)
 						}
 					}
@@ -1862,7 +1862,7 @@ func TestReconsiderBlock(t *testing.T) {
 
 					if b%10 == 0 {
 						// Commit the two base blocks to DB
-						if err := chain.FlushCachedState(FlushRequired); err != nil {
+						if err := chain.FlushUtxoCache(FlushRequired); err != nil {
 							t.Fatalf("unexpected error while flushing cache: %v", err)
 						}
 					}
@@ -1925,7 +1925,7 @@ func TestReconsiderBlock(t *testing.T) {
 
 					if b%10 == 0 {
 						// Commit the two base blocks to DB
-						if err := chain.FlushCachedState(FlushRequired); err != nil {
+						if err := chain.FlushUtxoCache(FlushRequired); err != nil {
 							t.Fatalf("unexpected error while flushing cache: %v", err)
 						}
 					}
@@ -1988,7 +1988,7 @@ func TestReconsiderBlock(t *testing.T) {
 
 					if b%10 == 0 {
 						// Commit the two base blocks to DB
-						if err := chain.FlushCachedState(FlushRequired); err != nil {
+						if err := chain.FlushUtxoCache(FlushRequired); err != nil {
 							t.Fatalf("unexpected error while flushing cache: %v", err)
 						}
 					}
@@ -2029,7 +2029,7 @@ func TestReconsiderBlock(t *testing.T) {
 				for _, gotChainTip := range gotChainTips {
 					testChainTip, found := expectedChainTips[gotChainTip.BlockHash]
 					if !found {
-						t.Errorf("TestReconsiderBlock Failed test \"%s\". Couldn't find an expected "+
+						t.Fatalf("TestReconsiderBlock Failed test \"%s\". Couldn't find an expected "+
 							"chain tip with height %d, hash %s, branchlen %d, status \"%s\"",
 							test.name, testChainTip.Height, testChainTip.BlockHash.String(),
 							testChainTip.BranchLen, testChainTip.Status.String())
@@ -2045,7 +2045,7 @@ func TestReconsiderBlock(t *testing.T) {
 					}
 
 					if !reflect.DeepEqual(testChainTip, gotChainTip) {
-						t.Errorf("TestReconsiderBlock Failed test \"%s\". Expected chain tip with "+
+						t.Fatalf("TestReconsiderBlock Failed test \"%s\". Expected chain tip with "+
 							"height %d, hash %s, branchlen %d, status \"%s\" but got "+
 							"height %d, hash %s, branchlen %d, status \"%s\"", test.name,
 							testChainTip.Height, testChainTip.BlockHash.String(),

--- a/blockchain/chainio_test.go
+++ b/blockchain/chainio_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/utreexo/utreexo"
-	"github.com/utreexo/utreexod/chaincfg/chainhash"
 	"github.com/utreexo/utreexod/database"
 	"github.com/utreexo/utreexod/wire"
 )
@@ -715,115 +714,6 @@ func TestBestChainStateDeserializeErrors(t *testing.T) {
 			tderr := test.errType.(database.Error)
 			if derr.ErrorCode != tderr.ErrorCode {
 				t.Errorf("deserializeBestChainState (%s): "+
-					"wrong  error code got: %v, want: %v",
-					test.name, derr.ErrorCode,
-					tderr.ErrorCode)
-				continue
-			}
-		}
-	}
-}
-
-// TestUtxoConsistencySerialization ensures serializing and deserializing the
-// utxo consistency statuses works as expected.
-func TestUtxoConsistencySerialization(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name       string
-		statusCode byte
-		statusHash *chainhash.Hash
-		serialized []byte
-	}{
-		{
-			name:       "consistent",
-			statusCode: ucsConsistent,
-			statusHash: newHashFromStr("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-			serialized: hexToBytes("016fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000"),
-		},
-		{
-			name:       "flushongoing",
-			statusCode: ucsFlushOngoing,
-			statusHash: newHashFromStr("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
-			serialized: hexToBytes("026fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000"),
-		},
-	}
-
-	for i, test := range tests {
-		// Ensure the state serializes to the expected value.
-		gotBytes := serializeUtxoStateConsistency(test.statusCode, test.statusHash)
-		if !bytes.Equal(gotBytes, test.serialized) {
-			t.Errorf("serializeUtxoStateConsistency #%d (%s): mismatched "+
-				"bytes - got %x, want %x", i, test.name,
-				gotBytes, test.serialized)
-			continue
-		}
-
-		// Ensure the serialized bytes are decoded back to the expected
-		// state.
-		code, hash, err := deserializeUtxoStateConsistency(test.serialized)
-		if err != nil {
-			t.Errorf("deserializeUtxoStateConsistency #%d (%s) "+
-				"unexpected error: %v", i, test.name, err)
-			continue
-		}
-		if code != test.statusCode {
-			t.Errorf("deserializeUtxoStateConsistency #%d (%s) "+
-				"mismatched code - got %v, want %v", i,
-				test.name, code, test.statusCode)
-			continue
-		}
-		if !test.statusHash.IsEqual(hash) {
-			t.Errorf("deserializeUtxoStateConsistency #%d (%s) "+
-				"mismatched hash - got %v, want %v", i,
-				test.name, hash, test.statusHash)
-			continue
-
-		}
-	}
-}
-
-// TestUtxoConsistencyDeserializeErrors performs negative tests against
-// deserializing the utxo consistency status to ensure error paths work as
-// expected.
-func TestUtxoConsistencyDeserializeErrors(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name       string
-		serialized []byte
-		errType    error
-	}{
-		{
-			name:       "nothing serialized",
-			serialized: hexToBytes(""),
-			errType:    database.Error{ErrorCode: database.ErrCorruption},
-		},
-		{
-			name:       "short data in hash",
-			serialized: hexToBytes("0100"),
-			errType:    database.Error{ErrorCode: database.ErrCorruption},
-		},
-		{
-			name:       "inexistent code",
-			serialized: hexToBytes("036fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000"),
-			errType:    database.Error{ErrorCode: database.ErrCorruption},
-		},
-	}
-
-	for _, test := range tests {
-		// Ensure the expected error type and code is returned.
-		_, _, err := deserializeUtxoStateConsistency(test.serialized)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.errType) {
-			t.Errorf("deserializeUtxoStateConsistency (%s): expected "+
-				"error type does not match - got %T, want %T",
-				test.name, err, test.errType)
-			continue
-		}
-		if derr, ok := err.(database.Error); ok {
-			tderr := test.errType.(database.Error)
-			if derr.ErrorCode != tderr.ErrorCode {
-				t.Errorf("deserializeUtxoStateConsistency (%s): "+
 					"wrong  error code got: %v, want: %v",
 					test.name, derr.ErrorCode,
 					tderr.ErrorCode)

--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -534,7 +534,7 @@ func TestProveUtxos(t *testing.T) {
 
 		if i%10 == 0 {
 			// Commit the two base blocks to DB
-			if err := chain.FlushCachedState(blockchain.FlushRequired); err != nil {
+			if err := chain.FlushUtxoCache(blockchain.FlushRequired); err != nil {
 				t.Fatalf("TestProveUtxos fail. Unexpected error while flushing cache: %v", err)
 			}
 		}
@@ -681,7 +681,7 @@ func TestUtreexoProofIndex(t *testing.T) {
 
 		if b%10 == 0 {
 			// Commit the two base blocks to DB
-			if err := chain.FlushCachedState(blockchain.FlushRequired); err != nil {
+			if err := chain.FlushUtxoCache(blockchain.FlushRequired); err != nil {
 				t.Fatalf("unexpected error while flushing cache: %v", err)
 			}
 		}
@@ -784,7 +784,7 @@ func TestMultiBlockProof(t *testing.T) {
 
 		if b%10 == 0 {
 			// Commit the two base blocks to DB
-			if err := chain.FlushCachedState(blockchain.FlushRequired); err != nil {
+			if err := chain.FlushUtxoCache(blockchain.FlushRequired); err != nil {
 				t.Fatalf("unexpected error while flushing cache: %v. Rand source %v",
 					err, source)
 			}

--- a/blockchain/reorg_test.go
+++ b/blockchain/reorg_test.go
@@ -43,7 +43,7 @@ func TestReorg(t *testing.T) {
 
 		if b%10 == 0 {
 			// Commit the two base blocks to DB
-			if err := chain.FlushCachedState(FlushRequired); err != nil {
+			if err := chain.FlushUtxoCache(FlushRequired); err != nil {
 				t.Fatalf("unexpected error while flushing cache: %v", err)
 			}
 		}

--- a/blockchain/sizehelper.go
+++ b/blockchain/sizehelper.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2023 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+package blockchain
+
+import (
+	"math"
+)
+
+// These constants are related to bitcoin.
+const (
+	// outpointSize is the size of an outpoint.
+	//
+	// This value is calculated by running the following:
+	//	unsafe.Sizeof(wire.OutPoint{})
+	outpointSize = 36
+
+	// uint64Size is the size of an uint64 allocated in memory.
+	uint64Size = 8
+
+	// bucketSize is the size of the bucket in the cache map.  Exact
+	// calculation is (16 + keysize*8 + valuesize*8) where for the map of:
+	// map[wire.OutPoint]*UtxoEntry would have a keysize=36 and valuesize=8.
+	//
+	// https://github.com/golang/go/issues/34561#issuecomment-536115805
+	bucketSize = 16 + uint64Size*outpointSize + uint64Size*uint64Size
+
+	// This value is calculated by running the following on a 64-bit system:
+	//   unsafe.Sizeof(UtxoEntry{})
+	baseEntrySize = 40
+
+	// pubKeyHashLen is the length of a P2PKH script.
+	pubKeyHashLen = 25
+
+	// avgEntrySize is how much each entry we expect it to be.  Since most
+	// txs are p2pkh, we can assume the entry to be more or less the size
+	// of a p2pkh tx.  We add on 7 to make it 32 since 64 bit systems will
+	// align by 8 bytes.
+	avgEntrySize = baseEntrySize + (pubKeyHashLen + 7)
+)
+
+// The code here is shamelessely taken from the go runtime package.  All the relevant
+// code and variables are copied to here.  These values are only correct for a 64 bit
+// system.
+
+const (
+	_MaxSmallSize   = 32768
+	smallSizeDiv    = 8
+	smallSizeMax    = 1024
+	largeSizeDiv    = 128
+	_NumSizeClasses = 68
+	_PageShift      = 13
+	_PageSize       = 1 << _PageShift
+
+	MaxUintptr = ^uintptr(0)
+
+	// Maximum number of key/elem pairs a bucket can hold.
+	bucketCntBits = 3
+	bucketCnt     = 1 << bucketCntBits
+
+	// Maximum average load of a bucket that triggers growth is 6.5.
+	// Represent as loadFactorNum/loadFactorDen, to allow integer math.
+	loadFactorNum = 13
+	loadFactorDen = 2
+
+	// maxAlloc is the maximum size of an allocation. On 64-bit,
+	// it's theoretically possible to allocate 1<<heapAddrBits bytes. On
+	// 32-bit, however, this is one less than 1<<32 because the
+	// number of bytes in the address space doesn't actually fit
+	// in a uintptr.
+	//
+	// NOTE (kcalvinalvin): I just took the constant for a 64 bit system.
+	maxAlloc = 281474976710656
+)
+
+var class_to_size = [_NumSizeClasses]uint16{0, 8, 16, 24, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 896, 1024, 1152, 1280, 1408, 1536, 1792, 2048, 2304, 2688, 3072, 3200, 3456, 4096, 4864, 5376, 6144, 6528, 6784, 6912, 8192, 9472, 9728, 10240, 10880, 12288, 13568, 14336, 16384, 18432, 19072, 20480, 21760, 24576, 27264, 28672, 32768}
+var size_to_class8 = [smallSizeMax/smallSizeDiv + 1]uint8{0, 1, 2, 3, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19, 19, 19, 19, 20, 20, 20, 20, 21, 21, 21, 21, 22, 22, 22, 22, 23, 23, 23, 23, 24, 24, 24, 24, 25, 25, 25, 25, 26, 26, 26, 26, 27, 27, 27, 27, 27, 27, 27, 27, 28, 28, 28, 28, 28, 28, 28, 28, 29, 29, 29, 29, 29, 29, 29, 29, 30, 30, 30, 30, 30, 30, 30, 30, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32}
+var size_to_class128 = [(_MaxSmallSize-smallSizeMax)/largeSizeDiv + 1]uint8{32, 33, 34, 35, 36, 37, 37, 38, 38, 39, 39, 40, 40, 40, 41, 41, 41, 42, 43, 43, 44, 44, 44, 44, 44, 45, 45, 45, 45, 45, 45, 46, 46, 46, 46, 47, 47, 47, 47, 47, 47, 48, 48, 48, 49, 49, 50, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 52, 52, 52, 52, 52, 52, 52, 52, 52, 52, 53, 53, 54, 54, 54, 54, 55, 55, 55, 55, 55, 56, 56, 56, 56, 56, 56, 56, 56, 56, 56, 56, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 58, 58, 58, 58, 58, 58, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 61, 61, 61, 61, 61, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67}
+
+// calculateRoughMapSize returns a close enough estimate of the
+// total memory allocated by a map.
+// hint should be the same value as the number you give when
+// making a map with the following syntax: make(map[k]v, hint)
+//
+// bucketsize is (16 + keysize*8 + valuesize*8).  For a map of:
+// map[int64]int64, keysize=8 and valuesize=8.  There are edge cases
+// where the bucket size is different that I can't find the source code
+// for. https://github.com/golang/go/issues/34561#issuecomment-536115805
+//
+// I suspect it's because of alignment and how the compiler handles it but
+// when compared with how much the compiler allocates, it's a couple hundred
+// bytes off.
+func calculateRoughMapSize(hint int, bucketSize uintptr) int {
+	// This code is copied from makemap() in runtime/map.go.
+	//
+	// TODO check once in a while to see if this algorithm gets
+	// changed.
+	mem, overflow := mulUintptr(uintptr(hint), bucketSize)
+	if overflow || mem > maxAlloc {
+		hint = 0
+	}
+
+	// Find the size parameter B which will hold the requested # of elements.
+	// For hint < 0 overLoadFactor returns false since hint < bucketCnt.
+	B := uint8(0)
+	for overLoadFactor(hint, B) {
+		B++
+	}
+
+	// This code is copied from makeBucketArray() in runtime/map.go.
+	//
+	// TODO check once in a while to see if this algorithm gets
+	// changed.
+	//
+	// For small b, overflow buckets are unlikely.
+	// Avoid the overhead of the calculation.
+	base := bucketShift(B)
+	numBuckets := base
+	if B >= 4 {
+		// Add on the estimated number of overflow buckets
+		// required to insert the median number of elements
+		// used with this value of b.
+		numBuckets += bucketShift(B - 4)
+		sz := bucketSize * numBuckets
+		up := roundupsize(sz)
+		if up != sz {
+			numBuckets = up / bucketSize
+		}
+	}
+	total, _ := mulUintptr(bucketSize, numBuckets)
+
+	if base != numBuckets {
+		// Add 24 for mapextra struct overhead. Refer to
+		// runtime/map.go in the std library for the struct.
+		total += 24
+	}
+
+	// 48 is the number of bytes needed for the map header in a
+	// 64 bit system. Refer to hmap in runtime/map.go in the go
+	// standard library.
+	total += 48
+	return int(total)
+}
+
+// calculateMinEntries returns the minimum number of entries that will make the
+// map allocate the given total bytes.  -1 on the returned entry count will
+// make the map allocate half as much total bytes (for returned entry count that's
+// greater than 0).
+func calculateMinEntries(totalBytes int, bucketSize int) int {
+	// 48 is the number of bytes needed for the map header in a
+	// 64 bit system. Refer to hmap in runtime/map.go in the go
+	// standard library.
+	totalBytes -= 48
+
+	numBuckets := totalBytes / bucketSize
+	B := uint8(math.Log2(float64(numBuckets)))
+	if B < 4 {
+		switch B {
+		case 0:
+			return 0
+		case 1:
+			return 9
+		case 2:
+			return 14
+		default:
+			return 27
+		}
+	}
+
+	B -= 1
+
+	return (int(loadFactorNum * (bucketShift(B) / loadFactorDen))) + 1
+}
+
+// mulUintptr returns a * b and whether the multiplication overflowed.
+// On supported platforms this is an intrinsic lowered by the compiler.
+func mulUintptr(a, b uintptr) (uintptr, bool) {
+	if a|b < 1<<(4*8) || a == 0 {
+		return a * b, false
+	}
+	overflow := b > MaxUintptr/a
+	return a * b, overflow
+}
+
+// divRoundUp returns ceil(n / a).
+func divRoundUp(n, a uintptr) uintptr {
+	// a is generally a power of two. This will get inlined and
+	// the compiler will optimize the division.
+	return (n + a - 1) / a
+}
+
+// alignUp rounds n up to a multiple of a. a must be a power of 2.
+func alignUp(n, a uintptr) uintptr {
+	return (n + a - 1) &^ (a - 1)
+}
+
+// Returns size of the memory block that mallocgc will allocate if you ask for the size.
+func roundupsize(size uintptr) uintptr {
+	if size < _MaxSmallSize {
+		if size <= smallSizeMax-8 {
+			return uintptr(class_to_size[size_to_class8[divRoundUp(size, smallSizeDiv)]])
+		} else {
+			return uintptr(class_to_size[size_to_class128[divRoundUp(size-smallSizeMax, largeSizeDiv)]])
+		}
+	}
+	if size+_PageSize < size {
+		return size
+	}
+	return alignUp(size, _PageSize)
+}
+
+// overLoadFactor reports whether count items placed in 1<<B buckets is over loadFactor.
+func overLoadFactor(count int, B uint8) bool {
+	return count > bucketCnt && uintptr(count) > loadFactorNum*(bucketShift(B)/loadFactorDen)
+}
+
+// bucketShift returns 1<<b, optimized for code generation.
+func bucketShift(b uint8) uintptr {
+	// Masking the shift amount allows overflow checks to be elided.
+	return uintptr(1) << (b & (8*8 - 1))
+}

--- a/blockchain/sizehelper_test.go
+++ b/blockchain/sizehelper_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+package blockchain
+
+import (
+	"math"
+	"testing"
+)
+
+// calculateEntries returns a number of entries that will make the map allocate
+// the given total bytes.  The returned number is always the maximum number of
+// entries that will allocate inside the given parameters.
+func calculateEntries(totalBytes int, bucketSize int) int {
+	// 48 is the number of bytes needed for the map header in a
+	// 64 bit system. Refer to hmap in runtime/map.go in the go
+	// standard library.
+	totalBytes -= 48
+
+	numBuckets := totalBytes / bucketSize
+	B := uint8(math.Log2(float64(numBuckets)))
+	if B == 0 {
+		// For 0 buckets, the max is the bucket count.
+		return bucketCnt
+	}
+
+	return int(loadFactorNum * (bucketShift(B) / loadFactorDen))
+}
+
+func TestCalculateEntries(t *testing.T) {
+	for i := 0; i < 10_000_000; i++ {
+		// It's not possible to calculate the exact amount of entries since
+		// the map will only allocate for 2^N where N is the amount of buckets.
+		//
+		// So to see if the calculate entries function is working correctly,
+		// we get the rough map size for i entries, then calculate the entries
+		// for that map size.  If the size is the same, the function is correct.
+		roughMapSize := calculateRoughMapSize(i, bucketSize)
+		entries := calculateEntries(roughMapSize, bucketSize)
+		gotRoughMapSize := calculateRoughMapSize(entries, bucketSize)
+
+		if roughMapSize != gotRoughMapSize {
+			t.Errorf("For hint of %d, expected %v, got %v\n",
+				i, roughMapSize, gotRoughMapSize)
+		}
+
+		// Test that the entries returned are the maximum for the given map size.
+		// If we increment the entries by one, we should get a bigger map.
+		gotRoughMapSizeWrong := calculateRoughMapSize(entries+1, bucketSize)
+		if roughMapSize == gotRoughMapSizeWrong {
+			t.Errorf("For hint %d incremented by 1, expected %v, got %v\n",
+				i, gotRoughMapSizeWrong*2, gotRoughMapSizeWrong)
+		}
+
+		minEntries := calculateMinEntries(roughMapSize, bucketSize)
+		gotMinRoughMapSize := calculateRoughMapSize(minEntries, bucketSize)
+		if roughMapSize != gotMinRoughMapSize {
+			t.Errorf("For hint of %d, expected %v, got %v\n",
+				i, roughMapSize, gotMinRoughMapSize)
+		}
+
+		// Can only test if they'll be half the size if the entries aren't 0.
+		if minEntries > 0 {
+			gotMinRoughMapSizeWrong := calculateRoughMapSize(minEntries-1, bucketSize)
+			if gotMinRoughMapSize == gotMinRoughMapSizeWrong {
+				t.Errorf("For hint %d decremented by 1, expected %v, got %v\n",
+					i, gotRoughMapSizeWrong/2, gotRoughMapSizeWrong)
+			}
+		}
+	}
+}

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -1,15 +1,13 @@
-// Copyright (c) 2015-2018 The btcsuite developers
+// Copyright (c) 2023 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package blockchain
 
 import (
-	"bytes"
 	"container/list"
 	"fmt"
-	"sort"
-	"sync"
+	"time"
 
 	"github.com/utreexo/utreexod/btcutil"
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
@@ -18,195 +16,150 @@ import (
 	"github.com/utreexo/utreexod/wire"
 )
 
+// mapSlice is a slice of maps for utxo entries.  The slice of maps are needed to
+// guarantee that the map will only take up N amount of bytes.  As of v1.20, the
+// go runtime will allocate 2^N + few extra buckets, meaning that for large N, we'll
+// allocate a lot of extra memory if the amount of entries goes over the previously
+// allocated buckets.  A slice of maps allows us to have a better control of how much
+// total memory gets allocated by all the maps.
+type mapSlice struct {
+	maps []map[wire.OutPoint]*UtxoEntry
+
+	// maxEntries is the maximum amount of elemnts that the map is allocated for.
+	maxEntries []int
+
+	// maxTotalMemoryUsage is the maximum memory usage in bytes that the state
+	// should contain in normal circumstances.
+	maxTotalMemoryUsage uint64
+}
+
+// length returns the length of all the maps in the map slice added together.
+func (ms *mapSlice) length() int {
+	var l int
+	for _, m := range ms.maps {
+		l += len(m)
+	}
+
+	return l
+}
+
+// size returns the size of all the maps in the map slice added together.
+func (ms *mapSlice) size() int {
+	var size int
+	for _, num := range ms.maxEntries {
+		size += calculateRoughMapSize(num, bucketSize)
+	}
+
+	return size
+}
+
+// get looks for the outpoint in all the maps in the map slice and returns
+// the entry.  nil and false is returned if the outpoint is not found.
+func (ms *mapSlice) get(op wire.OutPoint) (*UtxoEntry, bool) {
+	var entry *UtxoEntry
+	var found bool
+
+	for _, m := range ms.maps {
+		entry, found = m[op]
+		if found {
+			return entry, found
+		}
+	}
+
+	return entry, found
+}
+
+// put puts the outpoint and the entry into one of the maps in the map slice.  If the
+// existing maps are all full, it will allocate a new map based on how much memory we
+// have left over.  Leftover memory is calculated as:
+// maxTotalMemoryUsage - (totalEntryMemory + mapSlice.size())
+func (ms *mapSlice) put(op wire.OutPoint, entry *UtxoEntry, totalEntryMemory uint64) {
+	for i, maxNum := range ms.maxEntries {
+		m := ms.maps[i]
+		_, found := m[op]
+		if found {
+			// If the key is found, overwrite it.
+			m[op] = entry
+			return // Return as we were successful in adding the entry.
+		}
+		if len(m) >= maxNum {
+			// Don't try to insert if the map already at max since
+			// that'll force the map to allocate double the memory it's
+			// currently taking up.
+			continue
+		}
+
+		m[op] = entry
+		return // Return as we were successful in adding the entry.
+	}
+
+	// We only reach this code if we've failed to insert into the map above as
+	// all the current maps were full.  We thus make a new map and insert into
+	// it.
+	ms.makeNewMap(totalEntryMemory)
+	m := ms.maps[len(ms.maps)-1] // new maps are appended to the map slice.
+	m[op] = entry
+}
+
+// delete attempts to delete the given outpoint in all of the maps. No-op if the
+// outpoint doesn't exist.
+func (ms *mapSlice) delete(op wire.OutPoint) {
+	for i := 0; i < len(ms.maps); i++ {
+		delete(ms.maps[i], op)
+	}
+}
+
+// makeNewMap makes and appends the new map into the map slice.
+func (ms *mapSlice) makeNewMap(totalEntryMemory uint64) {
+	// Get the size of the leftover memory.
+	memSize := ms.maxTotalMemoryUsage - totalEntryMemory
+	for _, maxNum := range ms.maxEntries {
+		memSize -= uint64(calculateRoughMapSize(maxNum, bucketSize))
+	}
+
+	// Get a new map that's sized to house inside the leftover memory.
+	numMaxElements := calculateMinEntries(int(memSize), bucketSize+avgEntrySize)
+	numMaxElements -= 1
+	ms.maxEntries = append(ms.maxEntries, numMaxElements)
+	ms.maps = append(ms.maps, make(map[wire.OutPoint]*UtxoEntry, numMaxElements))
+}
+
+// deleteMaps deletes all maps except for the first one which should be the biggest.
+func (ms *mapSlice) deleteMaps() {
+	size := ms.maxEntries[0]
+	ms.maxEntries = []int{size}
+	ms.maps = ms.maps[:1]
+}
+
 const (
-	// The utxo writes big amounts of data to the database.  In order to limit
-	// the size of individual database transactions, it works in batches.
-
-	// utxoBatchSizeEntries is the maximum number of utxo entries to be written
-	// in a single transaction.
-	utxoBatchSizeEntries = 200000
-
-	// utxoBatchSizeBlocks is the maximum number of blocks to be processed in a
-	// single transaction.
-	utxoBatchSizeBlocks = 50
-
-	// utxoFlushPeriodicThreshold is the threshold percentage at which a flush is
-	// performed when the flush mode FlushPeriodic is used.
-	utxoFlushPeriodicThreshold = 90
-
-	// mapOverhead is the number of bytes per entry to use when approximating the
-	// memory overhead of the entries map itself (i.e. the memory usage due to
-	// internals of the map, such as the underlying buckets that are allocated).
-	// This number was determined by inspecting the true size of the map with
-	// various numbers of entries and comparing it with the total size of all
-	// entries in the map.  The average overhead came out to 55 bytes per entry.
-	mapOverhead = 55
-
-	// pointerSize is the size of a pointer on a 64-bit platform.
-	pointerSize = 8
+	// utxoFlushPeriodicInterval is the interval at which a flush is performed
+	// when the flush mode FlushPeriodic is used.  This is used when the initial
+	// block download is complete and it's useful to flush periodically in case
+	// of unforseen shutdowns.
+	utxoFlushPeriodicInterval = time.Minute * 5
 )
 
-// txoFlags is a bitmask defining additional information and state for a
-// transaction output in a utxo view.
-type txoFlags uint8
+// FlushMode is used to indicate the different urgency types for a flush.
+type FlushMode uint8
 
 const (
-	// tfCoinBase indicates that a txout was contained in a coinbase tx.
-	tfCoinBase txoFlags = 1 << iota
+	// FlushRequired is the flush mode that means a flush must be performed
+	// regardless of the cache state.  For example right before shutting down.
+	FlushRequired FlushMode = iota
 
-	// tfSpent indicates that a txout is spent.
-	tfSpent
+	// FlushPeriodic is the flush mode that means a flush can be performed
+	// when it would be almost needed.  This is used to periodically signal when
+	// no I/O heavy operations are expected soon, so there is time to flush.
+	FlushPeriodic
 
-	// tfModified indicates that a txout has been modified since it was
-	// loaded.
-	tfModified
-
-	// tfFresh indicates that the entry is fresh.  This means that the parent
-	// view never saw this entry.  Note that tfFresh is a performance
-	// optimization with which we can erase entries that are fully spent if we
-	// know we do not need to commit them.  It is always safe to not mark
-	// tfFresh if that condition is not guaranteed.
-	tfFresh
+	// FlushIfNeeded is the flush mode that means a flush must be performed only
+	// if the cache is exceeding a safety threshold very close to its maximum
+	// size.  This is used mostly internally in between operations that can
+	// increase the cache size.
+	FlushIfNeeded
 )
-
-// UtxoEntry houses details about an individual transaction output in a utxo
-// view such as whether or not it was contained in a coinbase tx, the height of
-// the block that contains the tx, whether or not it is spent, its public key
-// script, and how much it pays.
-type UtxoEntry struct {
-	// NOTE: Additions, deletions, or modifications to the order of the
-	// definitions in this struct should not be changed without considering
-	// how it affects alignment on 64-bit platforms.  The current order is
-	// specifically crafted to result in minimal padding.  There will be a
-	// lot of these in memory, so a few extra bytes of padding adds up.
-	// Any changes here should also be reflected in the memoryUsage() function.
-
-	amount      int64
-	pkScript    []byte // The public key script for the output.
-	blockHeight int32  // Height of block containing tx.
-
-	// packedFlags contains additional info about output such as whether it
-	// is a coinbase, whether it is spent, and whether it has been modified
-	// since it was loaded.  This approach is used in order to reduce memory
-	// usage since there will be a lot of these in memory.
-	packedFlags txoFlags
-}
-
-// IsCoinBase returns whether or not the output was contained in a coinbase
-// transaction.
-func (entry *UtxoEntry) IsCoinBase() bool {
-	return entry.packedFlags&tfCoinBase == tfCoinBase
-}
-
-// IsSpent returns whether or not the output has been spent based upon the
-// current state of the unspent transaction output view it was obtained from.
-func (entry *UtxoEntry) IsSpent() bool {
-	return entry.packedFlags&tfSpent == tfSpent
-}
-
-// isModified returns whether or not the output has been modified since it was
-// loaded.
-func (entry *UtxoEntry) isModified() bool {
-	return entry.packedFlags&tfModified == tfModified
-}
-
-// isFresh returns whether or not it's certain the output has never previously
-// been stored in the database.
-func (entry *UtxoEntry) isFresh() bool {
-	return entry.packedFlags&tfFresh == tfFresh
-}
-
-// BlockHeight returns the height of the block containing the output.
-func (entry *UtxoEntry) BlockHeight() int32 {
-	return entry.blockHeight
-}
-
-// Amount returns the amount of the output.
-func (entry *UtxoEntry) Amount() int64 {
-	return entry.amount
-}
-
-// PkScript returns the public key script for the output.
-func (entry *UtxoEntry) PkScript() []byte {
-	return entry.pkScript
-}
-
-// memoryUsage returns the memory usage in bytes of the UTXO entry.
-// It returns 0 for the nil element.
-func (entry *UtxoEntry) memoryUsage() uint64 {
-	if entry == nil {
-		return 0
-	}
-
-	return baseEntrySize + uint64(len(entry.pkScript))
-}
-
-// Spend marks the output as spent.  Spending an output that is already spent
-// has no effect.
-func (entry *UtxoEntry) Spend() {
-	// Nothing to do if the output is already spent.
-	if entry.IsSpent() {
-		return
-	}
-
-	// Mark the output as spent and modified.
-	entry.packedFlags |= tfSpent | tfModified
-}
-
-// Clone returns a shallow copy of the utxo entry.
-func (entry *UtxoEntry) Clone() *UtxoEntry {
-	if entry == nil {
-		return nil
-	}
-
-	return &UtxoEntry{
-		amount:      entry.amount,
-		pkScript:    entry.pkScript,
-		blockHeight: entry.blockHeight,
-		packedFlags: entry.packedFlags,
-	}
-}
-
-// utxoView is a common interface for structures that implement a UTXO view.
-type utxoView interface {
-	// getEntry tries to get an entry from the view.  If the entry is not
-	// in the view, both the returned entry and the error are nil.
-	getEntry(outpoint wire.OutPoint) (*UtxoEntry, error)
-
-	// addEntry adds a new entry to the view.  Set overwrite to true if
-	// this entry should overwrite any existing entry for the same
-	// outpoint.
-	addEntry(outpoint wire.OutPoint, entry *UtxoEntry, overwrite bool) error
-
-	// spendEntry marks an entry as spent.
-	spendEntry(outpoint wire.OutPoint, entry *UtxoEntry) error
-}
-
-// utxoByHashSource is an interface that allows fetching UTXO entries by
-// transaction hash.
-// This interface exists due to the legacy spend journal database structure.
-type utxoByHashSource interface {
-	// getEntryByHash looks for an entry with the given transaction hash.
-	// This method exists due to the legacy spend journal database structure.
-	// Its execution is very inefficient, but it's almost never used.
-	getEntryByHash(hash *chainhash.Hash) (*UtxoEntry, error)
-}
-
-// utxoBatcher is an interface that allows a caller to batch fetch UTXOs from
-// an underlying view.
-type utxoBatcher interface {
-	utxoView
-
-	// getEntries attempts to fetch a serise of entries from the UTXO view.
-	// If a single entry is not found within the view, then an error is
-	// returned.
-	getEntries(outpoints map[wire.OutPoint]struct{}) (map[wire.OutPoint]*UtxoEntry, error)
-}
 
 // utxoCache is a cached utxo view in the chainstate of a BlockChain.
-//
-// It implements the utxoView interface, but should only be used as such with the
-// state mutex held.  It also implements the utxoByHashSource interface.
 type utxoCache struct {
 	db database.DB
 
@@ -214,81 +167,96 @@ type utxoCache struct {
 	// should contain in normal circumstances.
 	maxTotalMemoryUsage uint64
 
-	// This mutex protects the internal state.
-	// A simple mutex instead of a read-write mutex is chosen because the main
-	// read method also possibly does a write on a cache miss.
-	mtx sync.Mutex
-
 	// cachedEntries keeps the internal cache of the utxo state.  The tfModified
 	// flag indicates that the state of the entry (potentially) deviates from the
 	// state in the database.  Explicit nil values in the map are used to
 	// indicate that the database does not contain the entry.
-	cachedEntries    map[wire.OutPoint]*UtxoEntry
+	cachedEntries    mapSlice
 	totalEntryMemory uint64 // Total memory usage in bytes.
-	lastFlushHash    chainhash.Hash
+
+	// Below fields are used to indicate when the last flush happened.
+	lastFlushHash chainhash.Hash
+	lastFlushTime time.Time
 }
 
 // newUtxoCache initiates a new utxo cache instance with its memory usage limited
 // to the given maximum.
 func newUtxoCache(db database.DB, maxTotalMemoryUsage uint64) *utxoCache {
-	avgEntrySize := uint64(outpointSize + pointerSize + baseEntrySize + pubKeyHashLen + mapOverhead)
-	numMaxElements := maxTotalMemoryUsage / avgEntrySize
-	log.Infof("Pre-alloacting for %v entries: ", numMaxElements)
+	// While the entry isn't included in the map size, add the average size to the
+	// bucket size so we get some leftover space for entries to take up.
+	numMaxElements := calculateMinEntries(int(maxTotalMemoryUsage), bucketSize+avgEntrySize)
+	numMaxElements -= 1
+
+	log.Infof("Pre-alloacting for %d MiB: ", maxTotalMemoryUsage/(1024*1024)+1)
+
+	m := make(map[wire.OutPoint]*UtxoEntry, numMaxElements)
 
 	return &utxoCache{
 		db:                  db,
 		maxTotalMemoryUsage: maxTotalMemoryUsage,
-		cachedEntries:       make(map[wire.OutPoint]*UtxoEntry, numMaxElements),
+		cachedEntries: mapSlice{
+			maps:                []map[wire.OutPoint]*UtxoEntry{m},
+			maxEntries:          []int{numMaxElements},
+			maxTotalMemoryUsage: maxTotalMemoryUsage,
+		},
 	}
 }
 
 // totalMemoryUsage returns the total memory usage in bytes of the UTXO cache.
-//
-// This method should be called with the state lock held.
 func (s *utxoCache) totalMemoryUsage() uint64 {
-	// Total memory is all the keys plus the total memory of all the entries.
-	nbEntries := uint64(len(s.cachedEntries))
+	// Total memory is the map size + the size that the utxo entries are
+	// taking up.
+	size := uint64(s.cachedEntries.size())
+	size += s.totalEntryMemory
 
-	// Total size is total size of the keys + total size of the pointers in the
-	// map + total size of the elements held in the pointers.
-	return nbEntries*outpointSize + nbEntries*pointerSize +
-		nbEntries*mapOverhead + s.totalEntryMemory
+	return size
 }
 
-// TotalMemoryUsage returns the total memory usage in bytes of the UTXO cache.
+// fetchEntries returns the UTXO entries for the given outpoints.  The function always
+// returns as many entries as there are outpoints and the returns entries are in the
+// same order as the outpoints.  It returns nil if there is no entry for the outpoint
+// in the UTXO set.
 //
-// This method is safe for concurrent access.
-func (s *utxoCache) TotalMemoryUsage() uint64 {
-	s.mtx.Lock()
-	tmu := s.totalMemoryUsage()
-	s.mtx.Unlock()
-	return tmu
-}
+// The returned entries are NOT safe for concurrent access.
+func (s *utxoCache) fetchEntries(outpoints []wire.OutPoint) ([]*UtxoEntry, error) {
+	entries := make([]*UtxoEntry, len(outpoints))
+	var missingOps []wire.OutPoint
+	var missingOpsIdx []int
+	for i := range outpoints {
+		if entry, ok := s.cachedEntries.get(outpoints[i]); ok {
+			entries[i] = entry
+			continue
+		}
 
-// fetchAndCacheEntries attempts to fetch a series of entries from the
-// database.  In any aren't found, then nil is returned. All entries found are
-// cached in the process.
-//
-// This method should be called with the state lock held.
-func (s *utxoCache) fetchAndCacheEntries(ops ...wire.OutPoint) (
-	map[wire.OutPoint]*UtxoEntry, error) {
+		// At this point, we have missing outpoints.  Allocate them now
+		// so that we never allocate if the cache never misses.
+		if len(missingOps) == 0 {
+			missingOps = make([]wire.OutPoint, 0, len(outpoints))
+			missingOpsIdx = make([]int, 0, len(outpoints))
+		}
 
-	sort.Slice(ops, func(i, j int) bool {
-		return bytes.Compare(ops[i].Hash[:], ops[j].Hash[:]) < 0 &&
-			ops[i].Index < ops[j].Index
-	})
+		missingOpsIdx = append(missingOpsIdx, i)
+		missingOps = append(missingOps, outpoints[i])
+	}
 
-	entries := make(map[wire.OutPoint]*UtxoEntry, len(ops))
+	// Return early and don't attempt access the database if we don't have any
+	// missing outpoints.
+	if len(missingOps) == 0 {
+		return entries, nil
+	}
+
+	// Fetch the missing outpoints in the cache from the database.
+	dbEntries := make([]*UtxoEntry, len(missingOps))
 	err := s.db.View(func(dbTx database.Tx) error {
 		utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
 
-		for _, op := range ops {
-			entry, err := dbFetchUtxoEntry(dbTx, utxoBucket, op)
+		for i := range missingOps {
+			entry, err := dbFetchUtxoEntry(dbTx, utxoBucket, missingOps[i])
 			if err != nil {
 				return err
 			}
 
-			entries[op] = entry
+			dbEntries[i] = entry
 		}
 
 		return nil
@@ -303,448 +271,277 @@ func (s *utxoCache) fetchAndCacheEntries(ops ...wire.OutPoint) (
 	// NOTE: When the fetched entry is nil, it is still added to the cache
 	// as a miss; this prevents future lookups to perform the same database
 	// fetch.
-	for outpoint, entry := range entries {
-		s.cachedEntries[outpoint] = entry
-		s.totalEntryMemory += entry.memoryUsage()
+	for i := range dbEntries {
+		s.cachedEntries.put(missingOps[i], dbEntries[i], s.totalEntryMemory)
+		s.totalEntryMemory += dbEntries[i].memoryUsage()
+	}
+
+	// Fill in the entries with the ones fetched from the database.
+	for i := range missingOpsIdx {
+		entries[missingOpsIdx[i]] = dbEntries[i]
 	}
 
 	return entries, nil
 }
 
-// getEntry returns the UTXO entry for the given outpoint.  It returns nil if
-// there is no entry for the outpoint in the UTXO state.
-//
-// This method is part of the utxoView interface.
-// This method should be called with the state lock held.
-// The returned entry is NOT safe for concurrent access.
-func (s *utxoCache) getEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
-	// First, we'll check out in-memory cache to see if we already have the
-	// entry.
-	if entry, found := s.cachedEntries[outpoint]; found {
-		return entry, nil
-	}
-
-	// If not, then we'll fetch it from the databse.
-	entries, err := s.fetchAndCacheEntries(outpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	return entries[outpoint], nil
-}
-
-// getEntry returns the UTXO entry for the given outpoint.  It returns nil if
-// there is no entry for the outpoint in the UTXO state.
-//
-// This method is part of the utxoView interface.
-// This method should be called with the state lock held.
-// The returned entry is NOT safe for concurrent access.
-func (s *utxoCache) getEntries(outpoints map[wire.OutPoint]struct{}) (
-	map[wire.OutPoint]*UtxoEntry, error) {
-
-	entries := make(map[wire.OutPoint]*UtxoEntry, len(outpoints))
-	var missingEntries []wire.OutPoint
-	for op := range outpoints {
-		if entry, ok := s.cachedEntries[op]; ok {
-			entries[op] = entry
-			continue
-		}
-
-		missingEntries = append(missingEntries, op)
-	}
-
-	dbEntries, err := s.fetchAndCacheEntries(missingEntries...)
-	if err != nil {
-		return nil, err
-	}
-
-	for op, entry := range dbEntries {
-		entries[op] = entry
-	}
-
-	return entries, nil
-}
-
-// FetchEntry returns the UTXO entry for the given outpoint.  It returns nil if
-// there is no entry for the outpoint in the UTXO state.
-//
-// This method is safe for concurrent access.
-func (s *utxoCache) FetchEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
-	s.mtx.Lock()
-	entries, err := s.getEntries(map[wire.OutPoint]struct{}{
-		outpoint: {},
-	})
-
-	if entry, ok := entries[outpoint]; ok {
-		s.mtx.Unlock()
-		return entry.Clone(), nil
-	}
-
-	s.mtx.Unlock()
-
-	return nil, err
-}
-
-// FetchUtxoEntry returns the requested unspent transaction output from the point
-// of view of the end of the main chain.
-//
-// NOTE: Requesting an output for which there is no data will NOT return an
-// error.  Instead both the entry and the error will be nil.  This is done to
-// allow pruning of spent transaction outputs.  In practice this means the
-// caller must check if the returned entry is nil before invoking methods on it.
-//
-// This function is safe for concurrent access.
-func (b *BlockChain) FetchUtxoEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
-	b.chainLock.RLock()
-	entry, err := b.utxoCache.FetchEntry(outpoint)
-	b.chainLock.RUnlock()
-	return entry, err
-}
-
-// getEntryByHash attempts to find any available UTXO for the given hash by
-// searching the entire set of possible outputs for the given hash.
-//
-// This method is part of the utxoByHashSource interface.
-// This method should be called with the state lock held.
-func (s *utxoCache) getEntryByHash(hash *chainhash.Hash) (*UtxoEntry, error) {
-	// First attempt to find a utxo with the provided hash in the cache.
-	prevOut := wire.OutPoint{Hash: *hash}
-	for idx := uint32(0); idx < MaxOutputsPerBlock; idx++ {
-		prevOut.Index = idx
-		if entry := s.cachedEntries[prevOut]; entry != nil {
-			return entry.Clone(), nil
-		}
-	}
-
-	// Then fall back to the database.
-	var entry *UtxoEntry
-	err := s.db.View(func(dbTx database.Tx) error {
-		var err error
-		entry, err = dbFetchUtxoEntryByHash(dbTx, hash)
-		return err
-	})
-
-	// Since we don't know the entries outpoint, we can't cache it.
-	return entry, err
-}
-
-// FetchEntryByHash attempts to find any available UTXO for the given hash by
-// searching the entire set of possible outputs for the given hash.
-//
-// This method is safe for concurrent access.
-func (s *utxoCache) FetchEntryByHash(hash *chainhash.Hash) (*UtxoEntry, error) {
-	s.mtx.Lock()
-	entry, err := s.getEntryByHash(hash)
-	s.mtx.Unlock()
-	return entry.Clone(), err
-}
-
-// spendEntry marks the output as spent.  Spending an output that is already
-// spent has no effect.  Entries that need not be stored anymore after being
-// spent will be removed from the cache.
-//
-// This method is part of the utxoView interface.
-// This method should be called with the state lock held.
-func (s *utxoCache) spendEntry(outpoint wire.OutPoint, addIfNil *UtxoEntry) error {
-	entry := s.cachedEntries[outpoint]
-
-	// If we don't have an entry in cache and an entry was provided, we add it.
-	if entry == nil && addIfNil != nil {
-		if err := s.addEntry(outpoint, addIfNil, false); err != nil {
-			return err
-		}
-		entry = addIfNil
-	}
-
-	// If it's nil or already spent, nothing to do.
-	if entry == nil || entry.IsSpent() {
-		return nil
-	}
-
-	// If an entry is fresh, meaning that there hasn't been a flush since it was
-	// introduced, it can simply be removed.
-	if entry.isFresh() {
-		// We don't delete it from the map, but set the value to nil, so that
-		// later lookups for the entry know that the entry does not exist in the
-		// database.
-		s.cachedEntries[outpoint] = nil
-		s.totalEntryMemory -= entry.memoryUsage()
-		return nil
-	}
-
-	// Mark the output as spent and modified.
-	entry.packedFlags |= tfSpent | tfModified
-
-	//TODO(stevenroose) check if it's ok to drop the pkScript
-	// Since we don't need it anymore, drop the pkScript value of the entry.
-	s.totalEntryMemory -= entry.memoryUsage()
-	entry.pkScript = nil
-	s.totalEntryMemory += entry.memoryUsage()
-
-	return nil
-}
-
-// addEntry adds a new unspent entry if it is not probably unspendable.  Set
-// overwrite to true to skip validity and freshness checks and simply add the
-// item, possibly overwriting another entry that is not-fully-spent.
-//
-// This method is part of the utxoView interface.
-// This method should be called with the state lock held.
-func (s *utxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry, overwrite bool) error {
+// addTxOut adds the specified output to the cache if it is not provably
+// unspendable.  When the cache already has an entry for the output, it will be
+// overwritten with the given output.  All fields will be updated for existing
+// entries since it's possible it has changed during a reorg.
+func (s *utxoCache) addTxOut(outpoint wire.OutPoint, txOut *wire.TxOut, isCoinBase bool, blockHeight int32) error {
 	// Don't add provably unspendable outputs.
-	if txscript.IsUnspendable(entry.pkScript) {
+	if txscript.IsUnspendable(txOut.PkScript) {
 		return nil
 	}
 
-	cachedEntry := s.cachedEntries[outpoint]
+	entry := new(UtxoEntry)
+	entry.amount = txOut.Value
+	// Deep copy the script when the script in the entry differs from the one in
+	// the txout.  This is required since the txout script is a subslice of the
+	// overall contiguous buffer that the msg tx houses for all scripts within
+	// the tx.  It is deep copied here since this entry may be added to the utxo
+	// cache, and we don't want the utxo cache holding the entry to prevent all
+	// of the other tx scripts from getting garbage collected.
+	entry.pkScript = make([]byte, len(txOut.PkScript))
+	copy(entry.pkScript, txOut.PkScript)
 
-	// In overwrite mode, simply add the entry without doing these checks.
-	if !overwrite {
-		// If we didn't have an entry for the outpoint and the existing entry is
-		// not marked modified, we can mark it fresh as the database does not
-		// know about this entry.  This will allow us to erase it when it gets
-		// spent before the next flush.
-		if cachedEntry == nil && !entry.isModified() {
-			entry.packedFlags |= tfFresh
-		}
+	entry.blockHeight = blockHeight
+	entry.packedFlags = tfFresh | tfModified
+	if isCoinBase {
+		entry.packedFlags |= tfCoinBase
 	}
 
-	entry.packedFlags |= tfModified
-	s.cachedEntries[outpoint] = entry
-	s.totalEntryMemory -= cachedEntry.memoryUsage() // 0 for nil
+	s.cachedEntries.put(outpoint, entry, s.totalEntryMemory)
 	s.totalEntryMemory += entry.memoryUsage()
+
 	return nil
 }
 
-// FetchTxView returns a local view on the utxo state for the given transaction.
-//
-// This method is safe for concurrent access.
-func (s *utxoCache) FetchTxView(tx *btcutil.Tx) (*UtxoViewpoint, error) {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-
-	// TODO(roasbeef): no need to try to fech outputs
-
-	view := NewUtxoViewpoint()
-	viewEntries := view.Entries()
-	if !IsCoinBase(tx) {
-		for _, txIn := range tx.MsgTx().TxIn {
-			entry, err := s.getEntry(txIn.PreviousOutPoint)
-			if err != nil {
-				return nil, err
-			}
-
-			viewEntries[txIn.PreviousOutPoint] = entry.Clone()
-		}
-	}
+// addTxOuts adds all outputs in the passed transaction which are not provably
+// unspendable to the view.  When the view already has entries for any of the
+// outputs, they are simply marked unspent.  All fields will be updated for
+// existing entries since it's possible it has changed during a reorg.
+func (s *utxoCache) addTxOuts(tx *btcutil.Tx, blockHeight int32) error {
+	// Loop all of the transaction outputs and add those which are not
+	// provably unspendable.
+	isCoinBase := IsCoinBase(tx)
 	prevOut := wire.OutPoint{Hash: *tx.Hash()}
-	for txOutIdx := range tx.MsgTx().TxOut {
+	for txOutIdx, txOut := range tx.MsgTx().TxOut {
+		// Update existing entries.  All fields are updated because it's
+		// possible (although extremely unlikely) that the existing
+		// entry is being replaced by a different transaction with the
+		// same hash.  This is allowed so long as the previous
+		// transaction is fully spent.
 		prevOut.Index = uint32(txOutIdx)
-
-		entry, err := s.getEntry(prevOut)
+		err := s.addTxOut(prevOut, txOut, isCoinBase, blockHeight)
 		if err != nil {
-			return nil, err
-		}
-
-		viewEntries[prevOut] = entry.Clone()
-	}
-
-	return view, nil
-}
-
-// FetchUtxoView loads unspent transaction outputs for the inputs referenced by
-// the passed transaction from the point of view of the end of the main chain.
-// It also attempts to get the utxos for the outputs of the transaction itself
-// so the returned view can be examined for duplicate transactions.
-//
-// This function is safe for concurrent access however the returned view is NOT.
-func (b *BlockChain) FetchUtxoView(tx *btcutil.Tx) (*UtxoViewpoint, error) {
-	b.chainLock.RLock()
-	view, err := b.utxoCache.FetchTxView(tx)
-	b.chainLock.RUnlock()
-	return view, err
-}
-
-// Commit commits all the entries in the view to the cache.
-//
-// This method should be called with the state lock held.
-func (s *utxoCache) Commit(view *UtxoViewpoint) error {
-	for outpoint, entry := range view.Entries() {
-		// No need to update the database if the entry was not modified or fresh.
-		if entry == nil || (!entry.isModified() && !entry.isFresh()) {
-			continue
-		}
-
-		// We can't use the view entry directly because it can be modified
-		// later on.
-		ourEntry := s.cachedEntries[outpoint]
-		if ourEntry == nil {
-			ourEntry = entry.Clone()
-		}
-
-		// Remove the utxo entry if it is spent.
-		if entry.IsSpent() {
-			if err := s.spendEntry(outpoint, ourEntry); err != nil {
-				return err
-			}
-			continue
-		}
-
-		// It's possible if we disconnected this UTXO at some point, removing it from
-		// the UTXO set, only to have a future block add it back. In that case it could
-		// be going from being marked spent to needing to be marked unspent so we handle
-		// that case by overriding here.
-		if ourEntry.IsSpent() && !entry.IsSpent() {
-			ourEntry = entry
-		}
-
-		// Store the entry we don't know.
-		//
-		// TODO(roasbeef): should have already added when adding all
-		// inputs?
-		if err := s.addEntry(outpoint, ourEntry, false); err != nil {
 			return err
 		}
 	}
 
-	view.prune()
 	return nil
 }
 
-// flush flushes the UTXO state to the database.
-//
-// This method should be called with the state lock held.
-func (s *utxoCache) flush(bestState *BestState) error {
-	// If we performed a flush in the current best state, we have nothing to do.
-	if bestState.Hash == s.lastFlushHash {
+// addTxIn will add the given input to the cache if the previous outpoint the txin
+// is pointing to exists in the utxo set.  The utxo that is being spent by the input
+// will be marked as spent and if the utxo is fresh (meaning that the database on disk
+// never saw it), it will be removed from the cache.
+func (s *utxoCache) addTxIn(txIn *wire.TxIn, stxos *[]SpentTxOut) error {
+	// Ensure the referenced utxo exists in the view.  This should
+	// never happen unless there is a bug is introduced in the code.
+	entries, err := s.fetchEntries([]wire.OutPoint{txIn.PreviousOutPoint})
+	if err != nil {
+		return err
+	}
+	if len(entries) < 1 || entries[0] == nil {
+		return AssertError(fmt.Sprintf("missing input %v",
+			txIn.PreviousOutPoint))
+	}
+
+	// Only create the stxo details if requested.
+	entry := entries[0]
+	if stxos != nil {
+		// Populate the stxo details using the utxo entry.
+		var stxo = SpentTxOut{
+			Amount:     entry.Amount(),
+			PkScript:   entry.PkScript(),
+			Height:     entry.BlockHeight(),
+			IsCoinBase: entry.IsCoinBase(),
+		}
+
+		*stxos = append(*stxos, stxo)
+	}
+
+	// Mark the entry as spent.
+	entry.Spend()
+
+	// If an entry is fresh it indicates that this entry was spent before it could be
+	// flushed to the database. Because of this, we can just delete it from the map of
+	// cached entries.
+	if entry.isFresh() {
+		// If the entry is fresh, we will always have it in the cache.
+		s.cachedEntries.delete(txIn.PreviousOutPoint)
+		s.totalEntryMemory -= entry.memoryUsage()
+	} else {
+		// Can leave the entry to be garbage collected as the only purpose
+		// of this entry now is so that the entry on disk can be deleted.
+		entry = nil
+		s.totalEntryMemory -= entry.memoryUsage()
+	}
+
+	return nil
+}
+
+// addTxIns will add the given inputs of the tx if it's not a coinbase tx and if
+// the previous output that the input is pointing to exists in the utxo set.  The
+// utxo that is being spent by the input will be marked as spent and if the utxo
+// is fresh (meaning that the database on disk never saw it), it will be removed
+// from the cache.
+func (s *utxoCache) addTxIns(tx *btcutil.Tx, stxos *[]SpentTxOut) error {
+	// Coinbase transactions don't have any inputs to spend.
+	if IsCoinBase(tx) {
 		return nil
 	}
 
-	// Add one to round up the integer division.
-	totalMiB := s.totalMemoryUsage()/(1024*1024) + 1
-	log.Infof("Flushing UTXO cache of ~%v MiB to disk. For large sizes, "+
-		"this can take up to several minutes...", totalMiB)
+	for _, txIn := range tx.MsgTx().TxIn {
+		err := s.addTxIn(txIn, stxos)
+		if err != nil {
+			return err
+		}
+	}
 
-	// First update the database to indicate that a utxo state flush is started.
-	// This allows us to recover when the node shuts down in the middle of this
-	// method.
+	return nil
+}
+
+// connectTransaction updates the cache by adding all new utxos created by the
+// passed transaction and marking and/or removing all utxos that the transactions
+// spend as spent.  In addition, when the 'stxos' argument is not nil, it will
+// be updated to append an entry for each spent txout.  An error will be returned
+// if the cache and the database does not contain the required utxos.
+func (s *utxoCache) connectTransaction(tx *btcutil.Tx, blockHeight int32, stxos *[]SpentTxOut) error {
+	err := s.addTxIns(tx, stxos)
+	if err != nil {
+		return err
+	}
+
+	// Add the transaction's outputs as available utxos.
+	return s.addTxOuts(tx, blockHeight)
+}
+
+// connectTransactions updates the cache by adding all new utxos created by all
+// of the transactions in the passed block, marking and/or removing all utxos
+// the transactions spend as spent, and setting the best hash for the view to
+// the passed block.  In addition, when the 'stxos' argument is not nil, it will
+// be updated to append an entry for each spent txout.
+func (s *utxoCache) connectTransactions(block *btcutil.Block, stxos *[]SpentTxOut) error {
+	for _, tx := range block.Transactions() {
+		err := s.connectTransaction(tx, block.Height(), stxos)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeCache writes all the entries that are cached in memory to the database atomically.
+func (s *utxoCache) writeCache(bestState *BestState) error {
+	// Update commits and flushes the cache to the database.
+	// NOTE: The database has its own cache which gets atomically written
+	// to leveldb.
 	err := s.db.Update(func(dbTx database.Tx) error {
-		return dbPutUtxoStateConsistency(dbTx, ucsFlushOngoing, &s.lastFlushHash)
+		utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
+		for i := range s.cachedEntries.maps {
+			for outpoint, entry := range s.cachedEntries.maps[i] {
+				// If the entry is nil or spent, remove the entry from the database
+				// and the cache.
+				if entry == nil || entry.IsSpent() {
+					err := dbDeleteUtxoEntry(utxoBucket, outpoint)
+					if err != nil {
+						return err
+					}
+					delete(s.cachedEntries.maps[i], outpoint)
+
+					continue
+				}
+
+				// No need to update the cache if the entry was not modified.
+				if !entry.isModified() {
+					delete(s.cachedEntries.maps[i], outpoint)
+					continue
+				}
+
+				// Entry is fresh and needs to be put into the database.
+				err := dbPutUtxoEntry(utxoBucket, outpoint, entry)
+				if err != nil {
+					return err
+				}
+				delete(s.cachedEntries.maps[i], outpoint)
+			}
+		}
+		s.cachedEntries.deleteMaps()
+		s.totalEntryMemory = 0
+
+		// When done, store the best state hash in the database to indicate the state
+		// is consistent until that hash.
+		return dbPutUtxoStateConsistency(dbTx, &bestState.Hash)
 	})
 	if err != nil {
 		return err
 	}
 
-	// Store all entries in batches.
-	flushBatch := func(dbTx database.Tx) error {
-		var (
-			// Form a batch by storing all entries to be put and deleted.
-			nbBatchEntries = 0
-			entriesPut     = make(map[wire.OutPoint]*UtxoEntry)
-			entriesDelete  = make([]wire.OutPoint, 0)
-		)
-		for outpoint, entry := range s.cachedEntries {
-			// Nil entries or unmodified entries can just be pruned.
-			// They don't count for the batch size.
-			if entry == nil || !entry.isModified() {
-				s.totalEntryMemory -= entry.memoryUsage()
-				delete(s.cachedEntries, outpoint)
-				continue
-			}
-
-			if entry.IsSpent() {
-				entriesDelete = append(entriesDelete, outpoint)
-			} else {
-				entriesPut[outpoint] = entry
-			}
-			nbBatchEntries++
-
-			s.totalEntryMemory -= entry.memoryUsage()
-			delete(s.cachedEntries, outpoint)
-
-			// End this batch when the maximum number of entries per batch has
-			// been reached.
-			if nbBatchEntries >= utxoBatchSizeEntries {
-				break
-			}
-		}
-
-		// Apply the batched additions and deletions.
-		if err := dbPutUtxoEntries(dbTx, entriesPut); err != nil {
-			return err
-		}
-		if err := dbDeleteUtxoEntries(dbTx, entriesDelete); err != nil {
-			return err
-		}
-		return nil
-	}
-	for len(s.cachedEntries) > 0 {
-		log.Tracef("Flushing %d more entries...", len(s.cachedEntries))
-		err := s.db.Update(func(dbTx database.Tx) error {
-			return flushBatch(dbTx)
-		})
-		if err != nil {
-			return err
-		}
-	}
-
-	// When done, store the best state hash in the database to indicate the state
-	// is consistent until that hash.
-	err = s.db.Update(func(dbTx database.Tx) error {
-		return dbPutUtxoStateConsistency(dbTx, ucsConsistent, &bestState.Hash)
-	})
-	if err != nil {
-		return err
-	}
-
+	// The best state is the new last flush hash.
 	s.lastFlushHash = bestState.Hash
+	s.lastFlushTime = time.Now()
 
-	log.Debug("Done flushing UTXO cache to disk")
 	return nil
 }
 
-// Flush flushes the UTXO state to the database.
-//
-// This function is safe for concurrent access.
-func (s *utxoCache) Flush(mode FlushMode, bestState *BestState) error {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-
+// flush flushes the UTXO state to the database if a flush is needed with the given flush mode.
+func (s *utxoCache) flush(mode FlushMode, bestState *BestState) error {
 	var threshold uint64
 	switch mode {
 	case FlushRequired:
 		threshold = 0
 
 	case FlushIfNeeded:
+		// If we performed a flush in the current best state, we have nothing to do.
+		if bestState.Hash == s.lastFlushHash {
+			return nil
+		}
+
 		threshold = s.maxTotalMemoryUsage
 
 	case FlushPeriodic:
-		threshold = (utxoFlushPeriodicThreshold * s.maxTotalMemoryUsage) / 100
+		// If the time since the last flush is over the periodic interval,
+		// force a flush.  Otherwise just flush when the cache is full.
+		if time.Since(s.lastFlushTime) > utxoFlushPeriodicInterval {
+			threshold = 0
+		} else {
+			threshold = s.maxTotalMemoryUsage
+		}
 	}
 
-	if s.totalMemoryUsage() > threshold {
-		return s.flush(bestState)
+	if s.totalMemoryUsage() >= threshold {
+		// Add one to round up the integer division.
+		totalMiB := s.totalMemoryUsage() / ((1024 * 1024) + 1)
+		log.Infof("Flushing UTXO cache of %d MiB with %d entries to disk. For large sizes, "+
+			"this can take up to several minutes...", totalMiB, s.cachedEntries.length())
+
+		return s.writeCache(bestState)
 	}
+
 	return nil
 }
 
-// rollBackBlock rolls back the effects of the block when the state was left in
-// an inconsistent state.  This means that no errors will be raised when the
-// state is invalid.
+// FlushUtxoCache flushes the UTXO state to the database if a flush is needed with the
+// given flush mode.
 //
-// This method should be called with the state lock held.
-func (s *utxoCache) rollBackBlock(block *btcutil.Block, stxos []SpentTxOut) error {
-	return disconnectTransactions(s, block, stxos, s)
-}
-
-// rollForwardBlock rolls forward the effects of the block when the state was
-// left in an inconsistent state.  This means that no errors will be raised when
-// the state is invalid.
-//
-// This method should be called with the state lock held.
-func (s *utxoCache) rollForwardBlock(block *btcutil.Block) error {
-	// We don't need the collect stxos and we allow overwriting existing entries.
-	return connectTransactions(s, block, nil, true)
+// This function is safe for concurrent access.
+func (b *BlockChain) FlushUtxoCache(mode FlushMode) error {
+	b.chainLock.Lock()
+	defer b.chainLock.Unlock()
+	return b.utxoCache.flush(mode, b.BestSnapshot())
 }
 
 // InitConsistentState checks the consistency status of the utxo state and
@@ -752,174 +549,99 @@ func (s *utxoCache) rollForwardBlock(block *btcutil.Block) error {
 //
 // It needs to be ensured that the chainView passed to this method does not
 // get changed during the execution of this method.
-func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{}) error {
+func (b *BlockChain) InitConsistentState(tip *blockNode, interrupt <-chan struct{}) error {
+	s := b.utxoCache
 	// Load the consistency status from the database.
-	var statusCode byte
-	var statusHash *chainhash.Hash
-	err := s.db.View(func(dbTx database.Tx) error {
-		var err error
-		statusCode, statusHash, err = dbFetchUtxoStateConsistency(dbTx)
-
-		return err
+	var statusBytes []byte
+	s.db.View(func(dbTx database.Tx) error {
+		statusBytes = dbFetchUtxoStateConsistency(dbTx)
+		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	log.Tracef("UTXO cache consistency status from disk: [%d] hash %v",
-		statusCode, statusHash)
-
-	// We can set this variable now already because it will always be valid
-	// unless an error is returned, in which case the state is entirely invalid.
-	// Doing it here prevents forgetting it later.
-	s.lastFlushHash = tip.hash
 
 	// If no status was found, the database is old and didn't have a cached utxo
 	// state yet. In that case, we set the status to the best state and write
 	// this to the database.
-	if statusCode == ucsEmpty {
-		log.Debugf("Database didn't specify UTXO state consistency: consistent "+
-			"to best chain tip (%v)", tip.hash)
+	if statusBytes == nil {
 		err := s.db.Update(func(dbTx database.Tx) error {
-			return dbPutUtxoStateConsistency(dbTx, ucsConsistent, &tip.hash)
+			return dbPutUtxoStateConsistency(dbTx, &tip.hash)
 		})
+
+		// Set the last flush hash as it's the default value of 0s.
+		s.lastFlushHash = tip.hash
 
 		return err
 	}
 
-	// If state is consistent, we are done.
-	if statusCode == ucsConsistent && *statusHash == tip.hash {
-		log.Debugf("UTXO state consistent (%d:%v)", tip.height, tip.hash)
-
-		return nil
-	}
-
-	log.Info("Reconstructing UTXO state after unclean shutdown. This may take " +
-		"a long time...")
-
-	// Even though this should always be true, make sure the fetched hash is in
-	// the best chain.
-	var statusNode *blockNode
-	var statusNodeNext *blockNode // the first one higher than the statusNode
-	attachNodes := list.New()
-	for node := tip; node.height >= 0; node = node.parent {
-		if node.hash == *statusHash {
-			statusNode = node
-			break
-		}
-		attachNodes.PushFront(node)
-		statusNodeNext = node
-	}
-
-	if statusNode == nil {
-		return AssertError(fmt.Sprintf("last utxo consistency status contains "+
-			"hash that is not in best chain: %v", statusHash))
-	}
-
-	// If data was in the middle of a flush, we have to roll back all
-	// blocks from the last best block all the way back to the last
-	// consistent block.
-	log.Debugf("Rolling back %d blocks to rebuild the UTXO state...",
-		tip.height-statusNode.height)
-
-	// Roll back blocks in batches.
-	rollbackBatch := func(dbTx database.Tx, node *blockNode) (*blockNode, error) {
-		nbBatchBlocks := 0
-		for ; node.height > statusNode.height; node = node.parent {
-			block, err := dbFetchBlockByNode(dbTx, node)
-			if err != nil {
-				return nil, err
-			}
-
-			stxos, err := dbFetchSpendJournalEntry(dbTx, block)
-			if err != nil {
-				return nil, err
-			}
-
-			if err := s.rollBackBlock(block, stxos); err != nil {
-				return nil, err
-			}
-
-			nbBatchBlocks++
-
-			if nbBatchBlocks >= utxoBatchSizeBlocks {
-				break
-			}
-		}
-
-		return node, nil
-	}
-
-	for node := tip; node.height > statusNode.height; {
-		log.Tracef("Rolling back %d more blocks...",
-			node.height-statusNode.height)
-		err := s.db.Update(func(dbTx database.Tx) error {
-			var err error
-			node, err = rollbackBatch(dbTx, node)
-
-			return err
-		})
-		if err != nil {
-			return err
-		}
-
-		if interruptRequested(interrupt) {
-			log.Warn("UTXO state reconstruction interrupted")
-
-			return errInterruptRequested
-		}
-	}
-
-	// Now we can update the status already to avoid redoing this work when
-	// interrupted.
-	err = s.db.Update(func(dbTx database.Tx) error {
-		return dbPutUtxoStateConsistency(dbTx, ucsConsistent, statusHash)
-	})
+	statusHash, err := chainhash.NewHash(statusBytes)
 	if err != nil {
 		return err
 	}
 
-	log.Debugf("Replaying %d blocks to rebuild UTXO state...",
-		tip.height-statusNodeNext.height+1)
+	// If state is consistent, we are done.
+	if *statusHash == tip.hash {
+		log.Debugf("UTXO state consistent at (%d:%v)", tip.height, tip.hash)
 
-	// Then we replay the blocks from the last consistent state up to the best
-	// state. Iterate forward from the consistent node to the tip of the best
-	// chain. After every batch, we can also update the consistency state to
-	// avoid redoing the work when interrupted.
-	rollforwardBatch := func(dbTx database.Tx, node *blockNode) (*blockNode, error) {
-		nbBatchBlocks := 0
-		for e := attachNodes.Front(); e != nil; e = e.Next() {
-			node = e.Value.(*blockNode)
-			attachNodes.Remove(e)
+		// The last flush hash is set to the default value of all 0s. Set
+		// it to the tip since we checked it's consistent.
+		s.lastFlushHash = tip.hash
 
-			block, err := dbFetchBlockByNode(dbTx, node)
-			if err != nil {
-				return nil, err
-			}
-
-			if err := s.rollForwardBlock(block); err != nil {
-				return nil, err
-			}
-			nbBatchBlocks++
-
-			if nbBatchBlocks >= utxoBatchSizeBlocks {
-				break
-			}
-		}
-
-		// We can update this after each batch to avoid having to redo the work
-		// when interrupted.
-		return node, dbPutUtxoStateConsistency(dbTx, ucsConsistent, &node.hash)
+		return nil
 	}
 
-	for node := statusNodeNext; node.height <= tip.height; {
-		log.Tracef("Replaying %d more blocks...", tip.height-node.height+1)
-		err := s.db.Update(func(dbTx database.Tx) error {
-			var err error
-			node, err = rollforwardBatch(dbTx, node)
+	lastFlushNode := b.index.LookupNode(statusHash)
+	log.Infof("Reconstructing UTXO state after an unclean shutdown. The UTXO state is "+
+		"consistent at block %s (%d) but the chainstate is at block %s (%d),  This may "+
+		"take a long time...", statusHash.String(), lastFlushNode.height,
+		tip.hash.String(), tip.height)
+
+	// Even though this should always be true, make sure the fetched hash is in
+	// the best chain.
+	fork := b.bestChain.FindFork(lastFlushNode)
+	if fork == nil {
+		return AssertError(fmt.Sprintf("last utxo consistency status contains "+
+			"hash that is not in best chain: %v", statusHash))
+	}
+
+	// We never disconnect blocks as they cannot be inconsistent during a reorganization.
+	// This is because The cache is flushed before the reorganization begins and the utxo
+	// set at each block disconnect is written atomically to the database.
+	node := lastFlushNode
+
+	// We replay the blocks from the last consistent state up to the best
+	// state. Iterate forward from the consistent node to the tip of the best
+	// chain.
+	attachNodes := list.New()
+	for n := tip; n.height >= 0; n = n.parent {
+		if n == fork {
+			break
+		}
+		attachNodes.PushFront(n)
+	}
+
+	for e := attachNodes.Front(); e != nil; e = e.Next() {
+		node = e.Value.(*blockNode)
+
+		var block *btcutil.Block
+		err := s.db.View(func(dbTx database.Tx) error {
+			block, err = dbFetchBlockByNode(dbTx, node)
+			if err != nil {
+				return err
+			}
 
 			return err
 		})
+		if err != nil {
+			return err
+		}
+
+		err = b.utxoCache.connectTransactions(block, nil)
+		if err != nil {
+			return err
+		}
+
+		// Flush the utxo cache if needed.  This will in turn update the
+		// consistent state to this block.
+		err = s.flush(FlushIfNeeded, &BestState{Hash: node.hash, Height: node.height})
 		if err != nil {
 			return err
 		}
@@ -929,12 +651,32 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 
 			return errInterruptRequested
 		}
-		if node.height == tip.height {
-			break
-		}
 	}
-
 	log.Debug("UTXO state reconstruction done")
 
+	// Set the last flush hash as it's the default value of 0s.
+	s.lastFlushHash = tip.hash
+	s.lastFlushTime = time.Now()
+
 	return nil
+}
+
+// flushNeededAfterPrune returns true if the utxo cache needs to be flushed after a prune
+// of the block storage.  In the case of an unexpected shutdown, the utxo cache needs
+// to be reconstructed from where the utxo cache was last flushed.  In order for the
+// utxo cache to be reconstructed, we always need to have the blocks since the utxo cache
+// flush last happened.
+//
+// Example: if the last flush hash was at height 100 and one of the deleted blocks was at
+// height 98, this function will return true.
+func (b *BlockChain) flushNeededAfterPrune(earliestHeight int32) (bool, error) {
+	if earliestHeight < 0 {
+		return false, nil
+	}
+	lastFlushHeight, err := b.BlockHeightByHash(&b.utxoCache.lastFlushHash)
+	if err != nil {
+		return false, err
+	}
+
+	return earliestHeight > lastFlushHeight, nil
 }

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -34,14 +34,6 @@ const (
 	// performed when the flush mode FlushPeriodic is used.
 	utxoFlushPeriodicThreshold = 90
 
-	// This value is calculated by running the following on a 64-bit system:
-	//   unsafe.Sizeof(UtxoEntry{})
-	baseEntrySize = uint64(40)
-
-	// This value is calculated by running the following on a 64-bit system:
-	//   unsafe.Sizeof(wire.OutPoint{})
-	outpointSize = uint64(36)
-
 	// mapOverhead is the number of bytes per entry to use when approximating the
 	// memory overhead of the entries map itself (i.e. the memory usage due to
 	// internals of the map, such as the underlying buckets that are allocated).
@@ -52,9 +44,6 @@ const (
 
 	// pointerSize is the size of a pointer on a 64-bit platform.
 	pointerSize = 8
-
-	// pubKeyHashLen is the length of a P2PKH script.
-	pubKeyHashLen = 25
 )
 
 // txoFlags is a bitmask defining additional information and state for a
@@ -242,7 +231,7 @@ type utxoCache struct {
 // newUtxoCache initiates a new utxo cache instance with its memory usage limited
 // to the given maximum.
 func newUtxoCache(db database.DB, maxTotalMemoryUsage uint64) *utxoCache {
-	avgEntrySize := outpointSize + pointerSize + baseEntrySize + pubKeyHashLen + mapOverhead
+	avgEntrySize := uint64(outpointSize + pointerSize + baseEntrySize + pubKeyHashLen + mapOverhead)
 	numMaxElements := maxTotalMemoryUsage / avgEntrySize
 	log.Infof("Pre-alloacting for %v entries: ", numMaxElements)
 

--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -290,7 +290,7 @@ func (bi *blockImporter) Import() chan *importResults {
 
 		// Flush the changes made to the blockchain.
 		log.Info("Flushing blockchain caches to the disk...")
-		if err := bi.chain.FlushCachedState(blockchain.FlushRequired); err != nil {
+		if err := bi.chain.FlushUtxoCache(blockchain.FlushRequired); err != nil {
 			log.Errorf("Error while flushing the blockchain state: %v", err)
 			bi.errChan <- err
 			return

--- a/goclean.sh
+++ b/goclean.sh
@@ -9,7 +9,7 @@
 
 set -ex
 
-env GORACE="halt_on_error=1" go test -race -tags="rpctest" -covermode atomic -coverprofile=profile.cov ./...
+env GORACE="halt_on_error=1" go test -timeout=15m -race -tags="rpctest" -covermode atomic -coverprofile=profile.cov ./...
 
 # Automatic checks
 golangci-lint run --deadline=10m --disable-all \

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -829,7 +829,7 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 		// Only flush if utreexoView is not active since a utreexo node does
 		// not have a utxo cache.
 		if !sm.chain.IsUtreexoViewActive() {
-			if err := sm.chain.FlushCachedState(blockchain.FlushPeriodic); err != nil {
+			if err := sm.chain.FlushUtxoCache(blockchain.FlushPeriodic); err != nil {
 				log.Errorf("Error while flushing the blockchain cache: %v", err)
 			}
 			return
@@ -1479,7 +1479,7 @@ out:
 	// a utxo cache.
 	if !sm.chain.IsUtreexoViewActive() {
 		log.Debug("Block handler shutting down: flushing blockchain caches...")
-		if err := sm.chain.FlushCachedState(blockchain.FlushRequired); err != nil {
+		if err := sm.chain.FlushUtxoCache(blockchain.FlushRequired); err != nil {
 			log.Errorf("Error while flushing blockchain caches: %v", err)
 		}
 	}


### PR DESCRIPTION
The utxo cache code in the current code is fragile and less performant.
Thus we're replacing it with the better code from btcd.