### PR TITLE
Don't save proofs for pruned blocks on IBD

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -233,6 +233,13 @@ func (b *BlockChain) IsKnownOrphan(hash *chainhash.Hash) bool {
 	return exists
 }
 
+// Return the current prune target.
+//
+// This function assumes you are holding the chain lock.
+func (b *BlockChain) GetPruneTarget() uint64 {
+	return b.pruneTarget
+}
+
 // GetOrphanRoot returns the head of the chain for the provided hash from the
 // map of orphan blocks.
 //


### PR DESCRIPTION
(Looking for approach review)

Up to now, we save the proofs and prune them afterward. This is inefficient, and slows IBD down. This PR fixes this by not saving proofs to disk if it's past our pruning target.