### PR TITLE
Use signet seeds to return utreexo nodes

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -60,6 +60,7 @@ var (
 	// DefaultSignetDNSSeeds is the list of seed nodes for the default
 	// (public, Taproot enabled) signet network.
 	DefaultSignetDNSSeeds = []DNSSeed{
+		{"seed.dlsouza.lol.", true}, // Davidson Souza, supports filtering, including utreexo (1 << 24)
 		{"178.128.221.177", false},
 		{"2a01:7c8:d005:390::5", false},
 		{"v7ajjeirttkbnt32wpy3c6w3emwnfr3fkla7hpxcfokr3ysd3kqtzmqd.onion:38333", false},

--- a/server.go
+++ b/server.go
@@ -2314,8 +2314,12 @@ func (s *server) peerHandler() {
 	}
 
 	if !cfg.DisableDNSSeed {
+		requiredServices := defaultRequiredServices
+		if cfg.Utreexo {
+			requiredServices |= wire.SFNodeUtreexo
+		}
 		// Add peers discovered through DNS to the address manager.
-		connmgr.SeedFromDNS(activeNetParams.Params, defaultRequiredServices,
+		connmgr.SeedFromDNS(activeNetParams.Params, requiredServices,
 			btcdLookup, func(addrs []*wire.NetAddress) {
 				// Bitcoind uses a lookup of the dns seeder here. This
 				// is rather strange since the values looked up by the


### PR DESCRIPTION
DNS seeds allows you to filter addresses by features. This PR asks for utreexo peers (service bit 1 << 24 is set) if `-utreexo` is enabled. This helps to find bridge nodes for the first IBD.
Also add `seed.dlsouza.lol` that supports this feature.