### PR TITLE
blockchain, wire, main: allow csns to serve utreexo data

### DIFF
--- a/blockchain/utreexoviewpoint.go
+++ b/blockchain/utreexoviewpoint.go
@@ -924,6 +924,21 @@ func (b *BlockChain) VerifyUData(ud *wire.UData, txIns []*wire.TxIn) error {
 	return nil
 }
 
+// GenerateUData generates a utreexo data based on the current state of the utreexo viewpoint.
+//
+// This function is safe for concurrent access.
+func (b *BlockChain) GenerateUData(dels []wire.LeafData) (*wire.UData, error) {
+	b.chainLock.RLock()
+	defer b.chainLock.RUnlock()
+
+	ud, err := wire.GenerateUData(dels, &b.utreexoView.accumulator)
+	if err != nil {
+		return nil, err
+	}
+
+	return ud, nil
+}
+
 // ChainTipProof represents all the information that is needed to prove that a
 // utxo exists in the chain tip with utreexo accumulator proof.
 type ChainTipProof struct {

--- a/wire/udata.go
+++ b/wire/udata.go
@@ -432,7 +432,7 @@ func DeserializeRemembers(r io.Reader) ([]uint32, error) {
 // to get a batched inclusion proof from the accumulator. It then adds on the leaf data,
 // to create a block proof which both proves inclusion and gives all utxo data
 // needed for transaction verification.
-func GenerateUData(txIns []LeafData, pollard *utreexo.Pollard) (
+func GenerateUData(txIns []LeafData, pollard utreexo.Utreexo) (
 	*UData, error) {
 
 	ud := new(UData)


### PR DESCRIPTION
The server code that only allowed for bridge nodes to serve blocks/tx to
utreexo nodes is now changed so that a csn that has all the neccessary
data is able to send data to another csn.