### PR TITLE
main: increase ban threshold to 300

### DIFF
--- a/config.go
+++ b/config.go
@@ -42,7 +42,7 @@ const (
 	defaultLogFilename           = "utreexod.log"
 	defaultMaxPeers              = 125
 	defaultBanDuration           = time.Hour * 24
-	defaultBanThreshold          = 100
+	defaultBanThreshold          = 300
 	defaultConnectTimeout        = time.Second * 30
 	defaultMaxRPCClients         = 10
 	defaultMaxRPCWebsockets      = 25


### PR DESCRIPTION
This increase is so that the utreexo peer isn't punished for performing ibd.

When a utreexo csn node is performing ibd, it is able to sync much faster than a traditional node. This has resulted in cases of where a csn is banned while performing ibd.