### PR TITLE
chainhash: add packed hashes support

### DIFF
--- a/chaincfg/chainhash/hash_test.go
+++ b/chaincfg/chainhash/hash_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -218,5 +219,27 @@ func TestHashJsonMarshal(t *testing.T) {
 
 	if !hash.IsEqual(&newHash) {
 		t.Errorf("String: wrong hash string - got %v, want %v", newHash.String(), hashStr)
+	}
+}
+
+func TestPackedHashes(t *testing.T) {
+	tests := []struct {
+		uints []uint64
+	}{
+		{uints: []uint64{0, 1, 2, 3}},
+		{uints: []uint64{0, 1, 2, 3, 4}},
+		{uints: []uint64{0, 1, 2, 3, 4, 5}},
+		{uints: []uint64{0, 1, 2, 3, 4, 5, 6}},
+		{uints: []uint64{0, 1, 2, 3, 4, 5, 6, 7}},
+		{uints: []uint64{11, 22, 33, 44, 55}},
+	}
+
+	for _, test := range tests {
+		hashes := Uint64sToPackedHashes(test.uints)
+		got := PackedHashesToUint64(hashes)
+
+		if !reflect.DeepEqual(test.uints, got) {
+			t.Fatalf("expected %v but got %v", test.uints, got)
+		}
 	}
 }


### PR DESCRIPTION
Packed hashes are just 4 uint64s written into a 32 byte hash. This is mostly done to keep compatibility with existing inv message flow for tx propagation.