### PR TITLE
peer, main: allow for queuing multiple invvects

### DIFF
--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -664,9 +664,9 @@ func TestOutboundPeer(t *testing.T) {
 	fakeInv := wire.NewInvVect(wire.InvTypeBlock, fakeBlockHash)
 
 	// Should be noops as the peer could not connect.
-	p.QueueInventory(fakeInv)
+	p.QueueInventory([]*wire.InvVect{fakeInv})
 	p.AddKnownInventory(fakeInv)
-	p.QueueInventory(fakeInv)
+	p.QueueInventory([]*wire.InvVect{fakeInv})
 
 	fakeMsg := wire.NewMsgVerAck()
 	p.QueueMessage(fakeMsg, nil)
@@ -710,7 +710,7 @@ func TestOutboundPeer(t *testing.T) {
 	}
 
 	// Test Queue Inv after connection
-	p1.QueueInventory(fakeInv)
+	p1.QueueInventory([]*wire.InvVect{fakeInv})
 	p1.Disconnect()
 
 	// Test regression

--- a/server.go
+++ b/server.go
@@ -2035,7 +2035,7 @@ func (s *server) handleRelayInvMsg(state *peerState, msg relayMsg) {
 		// Queue the inventory to be relayed with the next batch.
 		// It will be ignored if the peer is already known to
 		// have the inventory.
-		sp.QueueInventory(msg.invVect)
+		sp.QueueInventory([]*wire.InvVect{msg.invVect})
 	})
 }
 


### PR DESCRIPTION
For utreexo tx inv messages, the invvects will be related to each other as the invvect for the tx will be matched with the position invs. It'll look like so:

[InvTypeUtreexoTx][TXID1]
[InvTypeProofHash][packed positions1.1] (4 positions) [InvTypeProofHash][packed positions1.2] (1 position)

At the moment the invvects can only be queued one at a time which may result in the InvTypeProofHash to be separated from the InvTypeUtreexoTx. Allowing for queuing multiple invvects eliminates this problem.