### PR TITLE
wire: add utreexo proof hash inv

### DIFF
--- a/wire/invvect.go
+++ b/wire/invvect.go
@@ -37,6 +37,7 @@ const (
 	InvTypeTx                   InvType = 1
 	InvTypeBlock                InvType = 2
 	InvTypeFilteredBlock        InvType = 3
+	InvTypeUtreexoProofHash     InvType = 4
 	InvTypeWitnessBlock         InvType = InvTypeBlock | InvWitnessFlag
 	InvTypeUtreexoBlock         InvType = InvTypeBlock | InvUtreexoFlag
 	InvTypeWitnessUtreexoBlock  InvType = InvTypeBlock | InvWitnessFlag | InvUtreexoFlag
@@ -52,6 +53,7 @@ var ivStrings = map[InvType]string{
 	InvTypeTx:                   "MSG_TX",
 	InvTypeBlock:                "MSG_BLOCK",
 	InvTypeFilteredBlock:        "MSG_FILTERED_BLOCK",
+	InvTypeUtreexoProofHash:     "MSG_UTREEXO_PROOF_HASH",
 	InvTypeWitnessBlock:         "MSG_WITNESS_BLOCK",
 	InvTypeUtreexoBlock:         "MSG_UTREEXO_BLOCK",
 	InvTypeWitnessUtreexoBlock:  "MSG_WITNESS_UTREEXO_BLOCK",

--- a/wire/invvect_test.go
+++ b/wire/invvect_test.go
@@ -23,6 +23,7 @@ func TestInvTypeStringer(t *testing.T) {
 		{InvTypeTx, "MSG_TX"},
 		{InvTypeBlock, "MSG_BLOCK"},
 		{InvTypeUtreexoBlock, "MSG_UTREEXO_BLOCK"},
+		{InvTypeUtreexoProofHash, "MSG_UTREEXO_PROOF_HASH"},
 		{0xffffffff, "Unknown InvType (4294967295)"},
 	}
 


### PR DESCRIPTION
Utreexo proof hash invs are always paired with a utreexo tx inv and it's used to communicate which positions of the leaves that are in the accumulator is being spent in the tx.