### PR TITLE
main, netsync, peer: full partial tx support

### DIFF
--- a/electrum/server.go
+++ b/electrum/server.go
@@ -577,7 +577,7 @@ func handleTransactionBroadcast(s *ElectrumServer, cmd *btcjson.Request, conn ne
 	// Also, since an error is being returned to the caller, ensure the
 	// transaction is removed from the memory pool.
 	if len(acceptedTxs) == 0 || !acceptedTxs[0].Tx.Hash().IsEqual(tx.Hash()) {
-		s.cfg.Mempool.RemoveTransaction(tx, true)
+		s.cfg.Mempool.RemoveTransaction(tx, true, true)
 
 		errStr := fmt.Errorf("transaction %v is not in accepted list",
 			tx.Hash())

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -1137,8 +1137,8 @@ func (mp *TxPool) maybeAcceptTransaction(tx *btcutil.Tx, isNew, rateLimit, rejec
 		// sent was over valid.
 		err = mp.cfg.VerifyUData(ud, tx.MsgTx().TxIn, false)
 		if err != nil {
-			str := fmt.Sprintf("transaction %v failed the utreexo data verification.",
-				txHash)
+			str := fmt.Sprintf("transaction %v failed the utreexo data verification. %v",
+				txHash, err)
 			return nil, nil, txRuleError(wire.RejectInvalid, str)
 		}
 		log.Debugf("VerifyUData passed for tx %s", txHash.String())

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -480,14 +480,14 @@ func (mp *TxPool) HaveTransaction(hash *chainhash.Hash) bool {
 // RemoveTransaction.  See the comment for RemoveTransaction for more details.
 //
 // This function MUST be called with the mempool lock held (for writes).
-func (mp *TxPool) removeTransaction(tx *btcutil.Tx, removeRedeemers bool) {
+func (mp *TxPool) removeTransaction(tx *btcutil.Tx, removeRedeemers, uncacheUtreexo bool) {
 	txHash := tx.Hash()
 	if removeRedeemers {
 		// Remove any transactions which rely on this one.
 		for i := uint32(0); i < uint32(len(tx.MsgTx().TxOut)); i++ {
 			prevOut := wire.OutPoint{Hash: *txHash, Index: i}
 			if txRedeemer, exists := mp.outpoints[prevOut]; exists {
-				mp.removeTransaction(txRedeemer, true)
+				mp.removeTransaction(txRedeemer, true, uncacheUtreexo)
 			}
 		}
 	}
@@ -502,10 +502,10 @@ func (mp *TxPool) removeTransaction(tx *btcutil.Tx, removeRedeemers bool) {
 
 		// If the utreexo view is active, then remove the cached hashes from the
 		// accumulator.
-		if mp.cfg.IsUtreexoViewActive != nil && mp.cfg.IsUtreexoViewActive() {
+		if mp.cfg.IsUtreexoViewActive != nil && mp.cfg.IsUtreexoViewActive() && uncacheUtreexo {
 			leaves, found := mp.poolLeaves[*txHash]
 			if !found {
-				log.Infof("missing the leaf hashes for tx %s from while "+
+				log.Debugf("missing the leaf hashes for tx %s from while "+
 					"removing it from the pool",
 					tx.MsgTx().TxHash().String())
 			} else {
@@ -531,13 +531,14 @@ func (mp *TxPool) removeTransaction(tx *btcutil.Tx, removeRedeemers bool) {
 // RemoveTransaction removes the passed transaction from the mempool. When the
 // removeRedeemers flag is set, any transactions that redeem outputs from the
 // removed transaction will also be removed recursively from the mempool, as
-// they would otherwise become orphans.
+// they would otherwise become orphans. When the uncacheUtreexo flag is set,
+// it'll uncache the utreexo proof for the given tx if it's cached.
 //
 // This function is safe for concurrent access.
-func (mp *TxPool) RemoveTransaction(tx *btcutil.Tx, removeRedeemers bool) {
+func (mp *TxPool) RemoveTransaction(tx *btcutil.Tx, removeRedeemers, uncacheUtreexo bool) {
 	// Protect concurrent access.
 	mp.mtx.Lock()
-	mp.removeTransaction(tx, removeRedeemers)
+	mp.removeTransaction(tx, removeRedeemers, uncacheUtreexo)
 	mp.mtx.Unlock()
 }
 
@@ -554,7 +555,7 @@ func (mp *TxPool) RemoveDoubleSpends(tx *btcutil.Tx) {
 	for _, txIn := range tx.MsgTx().TxIn {
 		if txRedeemer, ok := mp.outpoints[txIn.PreviousOutPoint]; ok {
 			if !txRedeemer.Hash().IsEqual(tx.Hash()) {
-				mp.removeTransaction(txRedeemer, true)
+				mp.removeTransaction(txRedeemer, true, true)
 			}
 		}
 	}
@@ -1355,7 +1356,10 @@ func (mp *TxPool) maybeAcceptTransaction(tx *btcutil.Tx, isNew, rateLimit, rejec
 		// The conflict set should already include the descendants for
 		// each one, so we don't need to remove the redeemers within
 		// this call as they'll be removed eventually.
-		mp.removeTransaction(conflict, false)
+		//
+		// Don't remove the cached utreexo proof either because we'll need
+		// it for the ingestion.
+		mp.removeTransaction(conflict, false, false)
 	}
 	txD, err := mp.addTransaction(utxoView, tx, bestHeight, txFee)
 	if err != nil {

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1218,7 +1218,9 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 	// request parent blocks of orphans if we receive one we already have.
 	// Finally, attempt to detect potential stalls due to long side chains
 	// we already have and request more blocks to prevent them.
-	for i, iv := range invVects {
+	for i := 0; i < len(invVects); i++ {
+		iv := invVects[i]
+
 		// Ignore unsupported inventory types.
 		switch iv.Type {
 		case wire.InvTypeBlock:
@@ -1229,6 +1231,11 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 		case wire.InvTypeWitnessTx:
 		case wire.InvTypeUtreexoTx:
 		case wire.InvTypeWitnessUtreexoTx:
+		case wire.InvTypeUtreexoProofHash:
+			// If the inv is a utreexo proof hash, then it means that
+			// we've already skipped/added the tx that it belongs to or
+			// we're in headers first mode.
+			continue
 		default:
 			continue
 		}
@@ -1269,6 +1276,27 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 
 			// Add it to the request queue.
 			state.requestQueue = append(state.requestQueue, iv)
+
+			// If the inv is for a utreexo tx, then also pop off the utreexo
+			// proof hash invs and add it to the request queue.
+			if peer.IsUtreexoEnabled() {
+				switch iv.Type {
+				case wire.InvTypeTx:
+				case wire.InvTypeWitnessTx:
+				case wire.InvTypeUtreexoTx:
+				case wire.InvTypeWitnessUtreexoTx:
+				default:
+					continue
+				}
+
+				for j := i + 1; j < len(invVects); j++ {
+					if invVects[j].Type != wire.InvTypeUtreexoProofHash {
+						break
+					}
+					state.requestQueue = append(state.requestQueue, invVects[j])
+				}
+			}
+
 			continue
 		}
 
@@ -1339,14 +1367,11 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 
 				if peer.IsWitnessEnabled() {
 					iv.Type = wire.InvTypeWitnessBlock
+				}
 
-					if peer.IsUtreexoEnabled() {
-						iv.Type = wire.InvTypeWitnessUtreexoBlock
-					}
-				} else {
-					if peer.IsUtreexoEnabled() {
-						iv.Type = wire.InvTypeUtreexoBlock
-					}
+				amUtreexoNode := sm.chain.IsUtreexoViewActive()
+				if amUtreexoNode {
+					iv.Type |= wire.InvUtreexoFlag
 				}
 
 				gdmsg.AddInvVect(iv)
@@ -1360,29 +1385,84 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 		case wire.InvTypeUtreexoTx:
 			fallthrough
 		case wire.InvTypeTx:
-			// Request the transaction if there is not already a
-			// pending request.
-			if _, exists := sm.requestedTxns[iv.Hash]; !exists {
-				limitAdd(sm.requestedTxns, iv.Hash, maxRequestedTxns)
-				limitAdd(state.requestedTxns, iv.Hash, maxRequestedTxns)
+			amUtreexoNode := sm.chain.IsUtreexoViewActive()
+			if !amUtreexoNode {
+				// Request the transaction if there is not already a
+				// pending request.
+				if _, exists := sm.requestedTxns[iv.Hash]; !exists {
+					limitAdd(sm.requestedTxns, iv.Hash, maxRequestedTxns)
+					limitAdd(state.requestedTxns, iv.Hash, maxRequestedTxns)
 
-				// If the peer is capable, request the txn
-				// including all witness data.
-				if peer.IsWitnessEnabled() {
-					iv.Type = wire.InvTypeWitnessTx
-
-					if peer.IsUtreexoEnabled() {
-						iv.Type = wire.InvTypeWitnessUtreexoTx
+					// If the peer is capable, request the txn
+					// including all witness data.
+					if peer.IsWitnessEnabled() {
+						iv.Type = wire.InvTypeWitnessTx
 					}
-				} else {
-					if peer.IsUtreexoEnabled() {
-						iv.Type = wire.InvTypeUtreexoTx
+
+					gdmsg.AddInvVect(iv)
+					numRequested++
+				}
+			} else {
+				// Request the transaction if there is not already a
+				// pending request.
+				if _, exists := sm.requestedTxns[iv.Hash]; !exists {
+					// Pop off all the utreexo proof hash invs that's related to this
+					// tx from the request queue. These represent the positions of the
+					// inputs.
+					var targetPositions []chainhash.Hash
+					for len(requestQueue) > 0 && requestQueue[0].Type == wire.InvTypeUtreexoProofHash {
+						proofInv := requestQueue[0]
+						targetPositions = append(targetPositions, proofInv.Hash)
+
+						requestQueue[0] = nil
+						requestQueue = requestQueue[1:]
+					}
+
+					log.Debugf("for tx %s(%v), got %v packed positions, which are %v",
+						iv.Hash, iv.Type.String(),
+						targetPositions, chainhash.PackedHashesToUint64(targetPositions))
+
+					// Check that the proof invs+the current tx inv and all
+					// other requested invs do not go over the max inv per
+					// message limit.
+					if len(targetPositions)+1+numRequested+1 >= wire.MaxInvPerMsg {
+						break
+					}
+
+					var neededPositions []chainhash.Hash
+					if len(targetPositions) > 0 {
+						neededPositions = sm.chain.GetNeededPositions(targetPositions)
+					}
+
+					log.Debugf("need %v to prove tx %v", chainhash.PackedHashesToUint64(neededPositions), iv.Hash)
+
+					limitAdd(sm.requestedTxns, iv.Hash, maxRequestedTxns)
+					limitAdd(state.requestedTxns, iv.Hash, maxRequestedTxns)
+
+					// If the peer is capable, request the txn
+					// including all witness data.
+					if peer.IsWitnessEnabled() {
+						iv.Type = wire.InvTypeWitnessTx
+					}
+
+					// Add in the utreexo flag then add the tx inv.
+					iv.Type |= wire.InvUtreexoFlag
+					gdmsg.AddInvVect(iv)
+					numRequested++
+
+					// Then add all the packed proof positions inv.
+					for i := range neededPositions {
+						gdmsg.AddInvVect(wire.NewInvVect(
+							wire.InvTypeUtreexoProofHash,
+							&neededPositions[i]),
+						)
+						numRequested++
 					}
 				}
-
-				gdmsg.AddInvVect(iv)
-				numRequested++
 			}
+		case wire.InvTypeUtreexoProofHash:
+			// Purposely left empty. Utreexo proof hash invs are not useful on their own.
+			continue
 		}
 
 		if numRequested >= wire.MaxInvPerMsg {

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1608,7 +1608,7 @@ func (sm *SyncManager) handleBlockchainNotification(notification *blockchain.Not
 		// transaction are NOT removed recursively because they are still
 		// valid.
 		for _, tx := range block.Transactions()[1:] {
-			sm.txMemPool.RemoveTransaction(tx, false)
+			sm.txMemPool.RemoveTransaction(tx, false, true)
 			sm.txMemPool.RemoveDoubleSpends(tx)
 			sm.txMemPool.RemoveOrphan(tx)
 			sm.peerNotifier.TransactionConfirmed(tx)
@@ -1647,7 +1647,7 @@ func (sm *SyncManager) handleBlockchainNotification(notification *blockchain.Not
 				// Remove the transaction and all transactions
 				// that depend on it if it wasn't accepted into
 				// the transaction pool.
-				sm.txMemPool.RemoveTransaction(tx, true)
+				sm.txMemPool.RemoveTransaction(tx, true, true)
 			}
 		}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3841,7 +3841,7 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan st
 	// Also, since an error is being returned to the caller, ensure the
 	// transaction is removed from the memory pool.
 	if len(acceptedTxs) == 0 || !acceptedTxs[0].Tx.Hash().IsEqual(tx.Hash()) {
-		s.cfg.TxMemPool.RemoveTransaction(tx, true)
+		s.cfg.TxMemPool.RemoveTransaction(tx, true, true)
 
 		errStr := fmt.Sprintf("transaction %v is not in accepted list",
 			tx.Hash())

--- a/server.go
+++ b/server.go
@@ -678,10 +678,12 @@ func (sp *serverPeer) OnGetData(_ *peer.Peer, msg *wire.MsgGetData) {
 	var waitChan chan struct{}
 	doneChan := make(chan struct{}, 1)
 
-	for i, iv := range msg.InvList {
+	for i := 0; i < len(msg.InvList); i++ {
+		iv := msg.InvList[i]
+
 		var c chan struct{}
 		// If this will be the last message we send.
-		if i == length-1 && len(notFound.InvList) == 0 {
+		if i == len(msg.InvList)-1 && len(notFound.InvList) == 0 {
 			c = doneChan
 		} else if (i+1)%3 == 0 {
 			// Buffered so as to not make the send goroutine block.
@@ -690,13 +692,39 @@ func (sp *serverPeer) OnGetData(_ *peer.Peer, msg *wire.MsgGetData) {
 		var err error
 		switch iv.Type {
 		case wire.InvTypeWitnessTx:
-			err = sp.server.pushTxMsg(sp, &iv.Hash, c, waitChan, wire.WitnessEncoding)
+			err = sp.server.pushTxMsg(sp, &iv.Hash, nil, c, waitChan, wire.WitnessEncoding)
 		case wire.InvTypeTx:
-			err = sp.server.pushTxMsg(sp, &iv.Hash, c, waitChan, wire.BaseEncoding)
+			err = sp.server.pushTxMsg(sp, &iv.Hash, nil, c, waitChan, wire.BaseEncoding)
 		case wire.InvTypeWitnessUtreexoTx:
-			err = sp.server.pushTxMsg(sp, &iv.Hash, c, waitChan, wire.WitnessEncoding|wire.UtreexoEncoding)
+			fallthrough
 		case wire.InvTypeUtreexoTx:
-			err = sp.server.pushTxMsg(sp, &iv.Hash, c, waitChan, wire.UtreexoEncoding)
+			// Extract all the packed positions. They're appended to the tx inv.
+			packedPositions := make([]chainhash.Hash, 0, len(msg.InvList)-(i+1))
+			if i+1 < len(msg.InvList) {
+				for j := i + 1; j < len(msg.InvList); j++ {
+					if msg.InvList[j].Type == wire.InvTypeUtreexoProofHash {
+						packedPositions = append(packedPositions, msg.InvList[j].Hash)
+						msg.InvList = append(msg.InvList[:j], msg.InvList[j+1:]...)
+						j--
+					} else {
+						break
+					}
+				}
+
+				// Check again to see if this is the last message we'll send as
+				// we popped off the utreexo proof hash invs.
+				if i == len(msg.InvList)-1 && len(notFound.InvList) == 0 {
+					c = doneChan
+				} else if (i+1)%3 == 0 {
+					// Buffered so as to not make the send goroutine block.
+					c = make(chan struct{}, 1)
+				}
+			}
+
+			// All utreexo nodes are segwit nodes. Not including the witness will make it
+			// impossible to generate the leaf hashes since they're propagated in the compact
+			// form.
+			err = sp.server.pushTxMsg(sp, &iv.Hash, packedPositions, c, waitChan, wire.UtreexoEncoding|wire.WitnessEncoding)
 		case wire.InvTypeWitnessBlock:
 			err = sp.server.pushBlockMsg(sp, &iv.Hash, c, waitChan, wire.WitnessEncoding)
 		case wire.InvTypeBlock:
@@ -1496,7 +1524,7 @@ func (s *server) TransactionConfirmed(tx *btcutil.Tx) {
 
 // pushTxMsg sends a tx message for the provided transaction hash to the
 // connected peer.  An error is returned if the transaction hash is not known.
-func (s *server) pushTxMsg(sp *serverPeer, hash *chainhash.Hash, doneChan chan<- struct{},
+func (s *server) pushTxMsg(sp *serverPeer, hash *chainhash.Hash, packedPositions []chainhash.Hash, doneChan chan<- struct{},
 	waitChan <-chan struct{}, encoding wire.MessageEncoding) error {
 
 	// Attempt to fetch the requested transaction from the pool.  A
@@ -1543,58 +1571,68 @@ func (s *server) pushTxMsg(sp *serverPeer, hash *chainhash.Hash, doneChan chan<-
 
 			btcdLog.Debugf("fetched %v for tx %s", leafDatas, tx.Hash())
 
-			// This creates the accumulator proof and also puts the leaf datas
-			// in the utreexo data.
-			ud, err := s.chain.GenerateUData(leafDatas)
-			if err != nil {
-				chanLog.Errorf(err.Error())
-				if doneChan != nil {
-					doneChan <- struct{}{}
+			// Packed positions may be nil or of a length 0 if the
+			// peer already has all the necessary proof hashes cached.
+			if packedPositions != nil || len(packedPositions) == 0 {
+				positions := chainhash.PackedHashesToUint64(packedPositions)
+				ud, err := s.chain.GenerateUDataPartial(leafDatas, positions)
+				if err != nil {
+					chanLog.Errorf(err.Error())
+					if doneChan != nil {
+						doneChan <- struct{}{}
+					}
+					return err
 				}
-				return err
+
+				tx.MsgTx().UData = ud
 			}
-
-			tx.MsgTx().UData = ud
 		}
-
 		// For bridge nodes.
 		if s.utreexoProofIndex != nil {
-			leafDatas, err := blockchain.TxToDelLeaves(tx, s.chain)
-			if err != nil {
-				chanLog.Errorf(err.Error())
-				if doneChan != nil {
-					doneChan <- struct{}{}
+			if packedPositions != nil || len(packedPositions) == 0 {
+				leafDatas, err := blockchain.TxToDelLeaves(tx, s.chain)
+				if err != nil {
+					chanLog.Errorf(err.Error())
+					if doneChan != nil {
+						doneChan <- struct{}{}
+					}
+					return err
 				}
-				return err
-			}
-			ud, err := s.utreexoProofIndex.GenerateUData(leafDatas)
-			if err != nil {
-				chanLog.Errorf(err.Error())
-				if doneChan != nil {
-					doneChan <- struct{}{}
-				}
-				return err
-			}
-			tx.MsgTx().UData = ud
 
+				positions := chainhash.PackedHashesToUint64(packedPositions)
+				ud, err := s.utreexoProofIndex.GenerateUDataPartial(leafDatas, positions)
+				if err != nil {
+					chanLog.Errorf(err.Error())
+					if doneChan != nil {
+						doneChan <- struct{}{}
+					}
+					return err
+				}
+
+				tx.MsgTx().UData = ud
+			}
 		} else if s.flatUtreexoProofIndex != nil {
-			leafDatas, err := blockchain.TxToDelLeaves(tx, s.chain)
-			if err != nil {
-				chanLog.Errorf(err.Error())
-				if doneChan != nil {
-					doneChan <- struct{}{}
+			if packedPositions != nil || len(packedPositions) == 0 {
+				leafDatas, err := blockchain.TxToDelLeaves(tx, s.chain)
+				if err != nil {
+					chanLog.Errorf(err.Error())
+					if doneChan != nil {
+						doneChan <- struct{}{}
+					}
+					return err
 				}
-				return err
-			}
-			ud, err := s.flatUtreexoProofIndex.GenerateUData(leafDatas)
-			if err != nil {
-				chanLog.Errorf(err.Error())
-				if doneChan != nil {
-					doneChan <- struct{}{}
+				positions := chainhash.PackedHashesToUint64(packedPositions)
+				ud, err := s.flatUtreexoProofIndex.GenerateUDataPartial(leafDatas, positions)
+				if err != nil {
+					chanLog.Errorf(err.Error())
+					if doneChan != nil {
+						doneChan <- struct{}{}
+					}
+					return err
 				}
-				return err
+
+				tx.MsgTx().UData = ud
 			}
-			tx.MsgTx().UData = ud
 		}
 	}
 


### PR DESCRIPTION
On tx propagation, a utreexo node may not need the entire proof as some may be cached. This new way of propagating txs is based off of https://github.com/utreexo/utreexo/discussions/77 and allows a utreexo node to only ask for the proof hashes it is missing.