### PR TITLE
main, blockchain: make csn the default

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,22 +1,31 @@
-name: Build and Test
-on: [push, pull_request]
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
 jobs:
+
   build:
-    name: Go CI
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.18, 1.19]
+        go: ["1.20", "1.21"]
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ matrix.go }}
-      - name: Check out source
-        uses: actions/checkout@v3
-      - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2"
-      - name: Build
-        run: go build ./...
-      - name: Test
-        run: sh ./goclean.sh
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go }}
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Install Linters
+      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
+
+    - name: Test
+      run: sh ./goclean.sh

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ $ ./utreexod --flatutreexoproofindex
 Then you can connect your utreexo node to the bridge node.
 
 ```bash
-# flag --utreexo must be given. If it is not given, the node will run like a normal bitcoin node.
-$ ./utreexod --utreexo --connect=ip_of_the_bridge_node
+$ ./utreexod --addpeer=ip_of_the_bridge_node
 ```
 
 ## Updating

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1049,6 +1049,13 @@ func dbFetchUtxoStateConsistency(dbTx database.Tx) []byte {
 	return dbTx.Metadata().Get(utxoStateConsistencyKeyName)
 }
 
+// UtxoCacheInitialized returns true if the utxo cache has already been initialized.
+// Will return false if this is the first time starting up the node or if the node
+// has been previously started as a utreexo node.
+func UtxoCacheInitialized(dbTx database.Tx) bool {
+	return dbTx.Metadata().Get(utxoStateConsistencyKeyName) != nil
+}
+
 // SerializeUtreexoRoots serializes the numLeaves and the roots into a byte slice.
 func SerializeUtreexoRoots(numLeaves uint64, roots []utreexo.Hash) ([]byte, error) {
 	// 8 byte NumLeaves + (32 byte roots * len(roots))
@@ -1275,6 +1282,11 @@ func (b *BlockChain) createChainState() error {
 		return dbStoreBlock(dbTx, genesisBlock)
 	})
 	return err
+}
+
+// ChainstateInitialized returns true if the chainstate has been previously initialized.
+func ChainstateInitialized(dbTx database.Tx) bool {
+	return dbTx.Metadata().Get(chainStateKeyName) != nil
 }
 
 // initChainState attempts to load and initialize the chain state from the

--- a/goclean.sh
+++ b/goclean.sh
@@ -4,12 +4,10 @@
 # 3. go vet        (http://golang.org/cmd/vet)
 # 4. gosimple      (https://github.com/dominikh/go-simple)
 # 5. unconvert     (https://github.com/mdempsky/unconvert)
-# 6. race detector (http://blog.golang.org/race-detector)
-# 7. test coverage (http://blog.golang.org/cover)
 
 set -ex
 
-env GORACE="halt_on_error=1" go test -race -tags="rpctest" ./...
+go test -short -race -tags="rpctest" ./...
 
 # Automatic checks
 golangci-lint run --deadline=10m --disable-all \

--- a/integration/bip0009_test.go
+++ b/integration/bip0009_test.go
@@ -130,7 +130,7 @@ func assertSoftForkStatus(r *rpctest.Harness, t *testing.T, forkKey string, stat
 // specific soft fork deployment to test.
 func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 	// Initialize the primary mining node with only the genesis block.
-	r, err := rpctest.New(&chaincfg.RegressionNetParams, nil, nil, "")
+	r, err := rpctest.New(&chaincfg.RegressionNetParams, nil, []string{"--noutreexo"}, "")
 	if err != nil {
 		t.Fatalf("unable to create primary harness: %v", err)
 	}
@@ -325,7 +325,7 @@ func TestBIP0009Mining(t *testing.T) {
 	t.Parallel()
 
 	// Initialize the primary mining node with only the genesis block.
-	r, err := rpctest.New(&chaincfg.SimNetParams, nil, nil, "")
+	r, err := rpctest.New(&chaincfg.SimNetParams, nil, []string{"--noutreexo"}, "")
 	if err != nil {
 		t.Fatalf("unable to create primary harness: %v", err)
 	}

--- a/integration/csv_fork_test.go
+++ b/integration/csv_fork_test.go
@@ -114,7 +114,7 @@ func makeTestOutput(r *rpctest.Harness, t *testing.T,
 func TestBIP0113Activation(t *testing.T) {
 	t.Parallel()
 
-	btcdCfg := []string{"--rejectnonstd"}
+	btcdCfg := []string{"--rejectnonstd", "--noutreexo"}
 	r, err := rpctest.New(&chaincfg.SimNetParams, nil, btcdCfg, "")
 	if err != nil {
 		t.Fatal("unable to create primary harness: ", err)
@@ -410,7 +410,7 @@ func TestBIP0068AndBIP0112Activation(t *testing.T) {
 	// (sequence locks) and BIP 112 rule-sets which add input-age based
 	// relative lock times.
 
-	btcdCfg := []string{"--rejectnonstd"}
+	btcdCfg := []string{"--rejectnonstd", "--noutreexo"}
 	r, err := rpctest.New(&chaincfg.SimNetParams, nil, btcdCfg, "")
 	if err != nil {
 		t.Fatal("unable to create primary harness: ", err)

--- a/integration/getchaintips_test.go
+++ b/integration/getchaintips_test.go
@@ -167,7 +167,7 @@ func TestGetChainTips(t *testing.T) {
 		"0000000000000000000000000000000000000000000000000000"
 
 	// Set up regtest chain.
-	r, err := rpctest.New(&chaincfg.RegressionNetParams, nil, nil, "")
+	r, err := rpctest.New(&chaincfg.RegressionNetParams, nil, []string{"--noutreexo"}, "")
 	if err != nil {
 		t.Fatal("TestGetChainTips fail. Unable to create primary harness: ", err)
 	}

--- a/integration/invalidate_reconsider_block_test.go
+++ b/integration/invalidate_reconsider_block_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestInvalidateAndReconsiderBlock(t *testing.T) {
 	// Set up regtest chain.
-	r, err := rpctest.New(&chaincfg.RegressionNetParams, nil, nil, "")
+	r, err := rpctest.New(&chaincfg.RegressionNetParams, nil, []string{"--noutreexo"}, "")
 	if err != nil {
 		t.Fatalf("TestInvalidateAndReconsiderBlock fail. Unable to create primary harness: %v", err)
 	}

--- a/integration/rpcserver_test.go
+++ b/integration/rpcserver_test.go
@@ -151,7 +151,7 @@ func TestMain(m *testing.M) {
 	// In order to properly test scenarios on as if we were on mainnet,
 	// ensure that non-standard transactions aren't accepted into the
 	// mempool or relayed.
-	btcdCfg := []string{"--rejectnonstd"}
+	btcdCfg := []string{"--rejectnonstd", "--noutreexo"}
 	primaryHarness, err = rpctest.New(
 		&chaincfg.SimNetParams, nil, btcdCfg, "",
 	)

--- a/integration/rpctest/rpc_harness_test.go
+++ b/integration/rpctest/rpc_harness_test.go
@@ -106,7 +106,7 @@ func assertConnectedTo(t *testing.T, nodeA *Harness, nodeB *Harness) {
 
 func testConnectNode(r *Harness, t *testing.T) {
 	// Create a fresh test harness.
-	harness, err := New(&chaincfg.SimNetParams, nil, nil, "")
+	harness, err := New(&chaincfg.SimNetParams, nil, []string{"--noutreexo"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func testActiveHarnesses(r *Harness, t *testing.T) {
 	numInitialHarnesses := len(ActiveHarnesses())
 
 	// Create a single test harness.
-	harness1, err := New(&chaincfg.SimNetParams, nil, nil, "")
+	harness1, err := New(&chaincfg.SimNetParams, nil, []string{"--noutreexo"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +182,7 @@ func testJoinMempools(r *Harness, t *testing.T) {
 	// Create a local test harness with only the genesis block.  The nodes
 	// will be synced below so the same transaction can be sent to both
 	// nodes without it being an orphan.
-	harness, err := New(&chaincfg.SimNetParams, nil, nil, "")
+	harness, err := New(&chaincfg.SimNetParams, nil, []string{"--noutreexo"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +282,7 @@ func testJoinMempools(r *Harness, t *testing.T) {
 func testJoinBlocks(r *Harness, t *testing.T) {
 	// Create a second harness with only the genesis block so it is behind
 	// the main harness.
-	harness, err := New(&chaincfg.SimNetParams, nil, nil, "")
+	harness, err := New(&chaincfg.SimNetParams, nil, []string{"--noutreexo"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -470,7 +470,7 @@ func testGenerateAndSubmitBlockWithCustomCoinbaseOutputs(r *Harness,
 func testMemWalletReorg(r *Harness, t *testing.T) {
 	// Create a fresh harness, we'll be using the main harness to force a
 	// re-org on this local harness.
-	harness, err := New(&chaincfg.SimNetParams, nil, nil, "")
+	harness, err := New(&chaincfg.SimNetParams, nil, []string{"--noutreexo"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -567,7 +567,7 @@ const (
 
 func TestMain(m *testing.M) {
 	var err error
-	mainHarness, err = New(&chaincfg.SimNetParams, nil, nil, "")
+	mainHarness, err = New(&chaincfg.SimNetParams, nil, []string{"--noutreexo"}, "")
 	if err != nil {
 		fmt.Println("unable to create main harness: ", err)
 		os.Exit(1)

--- a/integration/utreexocompactstatenode_test.go
+++ b/integration/utreexocompactstatenode_test.go
@@ -85,6 +85,7 @@ func fetchBlocks(blockhashes []*chainhash.Hash, harness *rpctest.Harness) (
 func TestUtreexoCSN(t *testing.T) {
 	bridgeNodeArgs := []string{
 		"--flatutreexoproofindex",
+		"--noutreexo",
 	}
 	// Set up regtest chain for the bridge node.
 	bridgeNode, err := rpctest.New(&chaincfg.RegressionNetParams, nil, bridgeNodeArgs, "")
@@ -187,7 +188,6 @@ func TestUtreexoCSN(t *testing.T) {
 
 	// Set up the CSN.
 	csnArgs := []string{
-		"--utreexo",
 		"--watchonlywallet",
 	}
 	for _, addr := range watchAddrs {


### PR DESCRIPTION
Since users would expect to run csns, when using utreexod, make it the default and have a flag for turning it off.

Some additional checks added in so that it errors on startup when a user tries to switch between a utreexo and a non-utreexo node.