### PR TITLE
indexers, main: remove setchain for the utreexo proof indexes

### DIFF
--- a/blockchain/indexers/addrindex.go
+++ b/blockchain/indexers/addrindex.go
@@ -645,7 +645,7 @@ func (idx *AddrIndex) NeedsInputs() bool {
 // initialize for this index.
 //
 // This is part of the Indexer interface.
-func (idx *AddrIndex) Init() error {
+func (idx *AddrIndex) Init(_ *blockchain.BlockChain) error {
 	// Nothing to do.
 	return nil
 }

--- a/blockchain/indexers/cfindex.go
+++ b/blockchain/indexers/cfindex.go
@@ -96,7 +96,7 @@ func (idx *CfIndex) NeedsInputs() bool {
 
 // Init initializes the hash-based cf index. This is part of the Indexer
 // interface.
-func (idx *CfIndex) Init() error {
+func (idx *CfIndex) Init(_ *blockchain.BlockChain) error {
 	return nil // Nothing to do.
 }
 

--- a/blockchain/indexers/common.go
+++ b/blockchain/indexers/common.go
@@ -49,7 +49,7 @@ type Indexer interface {
 	// Init is invoked when the index manager is first initializing the
 	// index.  This differs from the Create method in that it is called on
 	// every load, including the case the index was just created.
-	Init() error
+	Init(*blockchain.BlockChain) error
 
 	// ConnectBlock is invoked when a new block has been connected to the
 	// main chain. The set of output spent within a block is also passed in

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -112,8 +112,9 @@ func (idx *FlatUtreexoProofIndex) NeedsInputs() bool {
 
 // Init initializes the flat utreexo proof index. This is part of the Indexer
 // interface.
-func (idx *FlatUtreexoProofIndex) Init() error {
-	return nil // nothing to do
+func (idx *FlatUtreexoProofIndex) Init(chain *blockchain.BlockChain) error {
+	idx.chain = chain
+	return nil
 }
 
 // Name returns the human-readable name of the index.
@@ -1047,11 +1048,6 @@ func (idx *FlatUtreexoProofIndex) ProveUtxos(utxos []*blockchain.UtxoEntry,
 func (idx *FlatUtreexoProofIndex) VerifyAccProof(toProve []utreexo.Hash,
 	proof *utreexo.Proof) error {
 	return idx.utreexoState.state.Verify(toProve, *proof, false)
-}
-
-// SetChain sets the given chain as the chain to be used for blockhash fetching.
-func (idx *FlatUtreexoProofIndex) SetChain(chain *blockchain.BlockChain) {
-	idx.chain = chain
 }
 
 // flatFilePath returns the path to the flatfile.

--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -311,7 +311,7 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 
 	// Initialize each of the enabled indexes.
 	for _, indexer := range m.enabledIndexes {
-		if err := indexer.Init(); err != nil {
+		if err := indexer.Init(chain); err != nil {
 			return err
 		}
 	}
@@ -459,16 +459,6 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 	// each block that needs to be indexed.
 	log.Infof("Catching up indexes from height %d to %d", lowestHeight,
 		bestHeight)
-
-	// For Utreexo proof indexes, we have to set the chain.
-	for _, indexer := range m.enabledIndexes {
-		switch idxType := indexer.(type) {
-		case *UtreexoProofIndex:
-			idxType.SetChain(chain)
-		case *FlatUtreexoProofIndex:
-			idxType.SetChain(chain)
-		}
-	}
 
 	// Needed for flushing the utreexo state in case of a sigint by the user.
 	defer func() {

--- a/blockchain/indexers/ttlindex.go
+++ b/blockchain/indexers/ttlindex.go
@@ -41,7 +41,7 @@ func (idx *TTLIndex) NeedsInputs() bool {
 
 // Init initializes the time to live index. This is part of the Indexer
 // interface.
-func (idx *TTLIndex) Init() error {
+func (idx *TTLIndex) Init(_ *blockchain.BlockChain) error {
 	return nil // Nothing to do.
 }
 

--- a/blockchain/indexers/txindex.go
+++ b/blockchain/indexers/txindex.go
@@ -294,7 +294,7 @@ var _ Indexer = (*TxIndex)(nil)
 // disconnecting blocks.
 //
 // This is part of the Indexer interface.
-func (idx *TxIndex) Init() error {
+func (idx *TxIndex) Init(_ *blockchain.BlockChain) error {
 	// Find the latest known block id field for the internal block id
 	// index and initialize it.  This is done because it's a lot more
 	// efficient to do a single search at initialize time than it is to

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -71,8 +71,9 @@ func (idx *UtreexoProofIndex) NeedsInputs() bool {
 
 // Init initializes the utreexo proof index. This is part of the Indexer
 // interface.
-func (idx *UtreexoProofIndex) Init() error {
-	return nil // nothing to do
+func (idx *UtreexoProofIndex) Init(chain *blockchain.BlockChain) error {
+	idx.chain = chain
+	return nil
 }
 
 // Name returns the human-readable name of the index.
@@ -363,11 +364,6 @@ func (idx *UtreexoProofIndex) ProveUtxos(utxos []*blockchain.UtxoEntry,
 func (idx *UtreexoProofIndex) VerifyAccProof(toProve []utreexo.Hash,
 	proof *utreexo.Proof) error {
 	return idx.utreexoState.state.Verify(toProve, *proof, false)
-}
-
-// SetChain sets the given chain as the chain to be used for blockhash fetching.
-func (idx *UtreexoProofIndex) SetChain(chain *blockchain.BlockChain) {
-	idx.chain = chain
 }
 
 // PruneBlock is invoked when an older block is deleted after it's been

--- a/server.go
+++ b/server.go
@@ -3270,13 +3270,6 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 		return nil, err
 	}
 
-	if s.utreexoProofIndex != nil {
-		s.utreexoProofIndex.SetChain(s.chain)
-	}
-	if s.flatUtreexoProofIndex != nil {
-		s.flatUtreexoProofIndex.SetChain(s.chain)
-	}
-
 	// Search for a FeeEstimator state in the database. If none can be found
 	// or if it cannot be loaded, create a new one.
 	db.Update(func(tx database.Tx) error {


### PR DESCRIPTION
Remove the separate call to setchain and make the chain setting part of the Init() method on the indexers.