### PR TITLE
blockchain: don't flush index on ProcessBlockHeader

### DIFF
--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -175,10 +175,6 @@ func (b *BlockChain) ProcessBlockHeader(header *wire.BlockHeader) error {
 	if err != nil {
 		return err
 	}
-	err = b.index.flushToDB()
-	if err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
To avoid additional code dealing with starting from a point where we already have some headers, don't flush the index after just verifying one header. This also has the side-effect of making the process bit faster since there's no disk i/o happening now.