### PR TITLE
addrmgr: fix testing bug that happens here and there

### DIFF
--- a/addrmgr/addrmanager_internal_test.go
+++ b/addrmgr/addrmanager_internal_test.go
@@ -1,7 +1,6 @@
 package addrmgr
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -85,7 +84,7 @@ func TestAddrManagerSerialization(t *testing.T) {
 
 	// We'll start by creating our address manager backed by a temporary
 	// directory.
-	tempDir, err := ioutil.TempDir("", "addrmgr")
+	tempDir, err := os.MkdirTemp("", "TestAddrManagerSerialization")
 	if err != nil {
 		t.Fatalf("unable to create temp dir: %v", err)
 	}
@@ -125,7 +124,7 @@ func TestAddrManagerV1ToV2(t *testing.T) {
 
 	// We'll start by creating our address manager backed by a temporary
 	// directory.
-	tempDir, err := ioutil.TempDir("", "addrmgr")
+	tempDir, err := os.MkdirTemp("", "TestAddrManagerV1ToV2")
 	if err != nil {
 		t.Fatalf("unable to create temp dir: %v", err)
 	}


### PR DESCRIPTION
There's a bug that happens occasionally that I'm pretty sure is
happening because these tests are running in parallel. Give the tmp
directories different paths to fix the bug.

The error is always:
`addrmanager_internal_test.go:165: expected to find 5 adddresses, found 4`

If anything it's ioutil.TmpDir is deprecated so this is a good change.