### PR TITLE
blockchain, indexers: make bridge nodes be able to run on disk

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/utreexo/utreexo"
 	"github.com/utreexo/utreexod/btcutil"
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
@@ -1605,4 +1606,207 @@ func (b *BlockChain) BlockByHash(hash *chainhash.Hash) (*btcutil.Block, error) {
 		return err
 	})
 	return block, err
+}
+
+// leafLength is the length of a seriailzed leaf.
+const leafLength = chainhash.HashSize + 1
+
+// serializeLeaf serializes the leaf to [leafLength]byte.
+func serializeLeaf(leaf utreexo.Leaf) [leafLength]byte {
+	var buf [leafLength]byte
+	copy(buf[:chainhash.HashSize], leaf.Hash[:])
+	if leaf.Remember {
+		buf[32] = 1
+	}
+
+	return buf
+}
+
+// deserializeLeaf serializes the leaf to [leafLength]byte.
+func deserializeLeaf(serialized [leafLength]byte) utreexo.Leaf {
+	leaf := utreexo.Leaf{
+		Hash: *(*[chainhash.HashSize]byte)(serialized[:32]),
+	}
+	if serialized[32] == 1 {
+		leaf.Remember = true
+	}
+
+	return leaf
+}
+
+var _ utreexo.NodesInterface = (*NodesBackEnd)(nil)
+
+// NodesBackEnd implements the NodesInterface interface. It's really just the database.
+type NodesBackEnd struct {
+	db *leveldb.DB
+}
+
+// InitNodesBackEnd returns a newly initialized NodesBackEnd which implements
+// utreexo.NodesInterface.
+func InitNodesBackEnd(datadir string) (*NodesBackEnd, error) {
+	db, err := leveldb.OpenFile(datadir, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NodesBackEnd{db: db}, nil
+}
+
+// Get returns the leaf from the underlying map.
+func (m *NodesBackEnd) Get(k uint64) (utreexo.Leaf, bool) {
+	size := serializeSizeVLQ(k)
+	buf := make([]byte, size)
+	putVLQ(buf, k)
+
+	val, err := m.db.Get(buf[:], nil)
+	if err != nil {
+		return utreexo.Leaf{}, false
+	}
+
+	// Must be leafLength bytes long.
+	if len(val) != leafLength {
+		return utreexo.Leaf{}, false
+	}
+
+	return deserializeLeaf(*(*[leafLength]byte)(val)), true
+}
+
+// Put puts the given position and the leaf to the underlying map.
+func (m *NodesBackEnd) Put(k uint64, v utreexo.Leaf) {
+	size := serializeSizeVLQ(k)
+	buf := make([]byte, size)
+	putVLQ(buf, k)
+
+	serialized := serializeLeaf(v)
+	m.db.Put(buf, serialized[:], nil)
+}
+
+// Delete removes the given key from the underlying map. No-op if the key
+// doesn't exist.
+func (m *NodesBackEnd) Delete(k uint64) {
+	size := serializeSizeVLQ(k)
+	buf := make([]byte, size)
+	putVLQ(buf, k)
+
+	m.db.Delete(buf, nil)
+}
+
+// Length returns the amount of items in the underlying database.
+func (m *NodesBackEnd) Length() int {
+	length := 0
+	iter := m.db.NewIterator(nil, nil)
+	for iter.Next() {
+		length++
+	}
+	iter.Release()
+
+	return length
+}
+
+// ForEach calls the given function for each of the elements in the underlying map.
+func (m *NodesBackEnd) ForEach(fn func(uint64, utreexo.Leaf) error) error {
+	iter := m.db.NewIterator(nil, nil)
+	for iter.Next() {
+		// Remember that the contents of the returned slice should not be modified, and
+		// only valid until the next call to Next.
+		k, _ := deserializeVLQ(iter.Key())
+
+		value := iter.Value()
+		if len(value) != leafLength {
+			return fmt.Errorf("expected value of length %v but got %v",
+				leafLength, len(value))
+		}
+		v := deserializeLeaf(*(*[leafLength]byte)(value))
+
+		err := fn(k, v)
+		if err != nil {
+			return err
+		}
+	}
+	iter.Release()
+	return iter.Error()
+}
+
+// Close closes the underlying database.
+func (m *NodesBackEnd) Close() error {
+	return m.db.Close()
+}
+
+var _ utreexo.CachedLeavesInterface = (*CachedLeavesBackEnd)(nil)
+
+// CachedLeavesBackEnd implements the CachedLeavesInterface interface. It's really just a map.
+type CachedLeavesBackEnd struct {
+	db *leveldb.DB
+}
+
+// InitCachedLeavesBackEnd returns a newly initialized CachedLeavesBackEnd which implements
+// utreexo.CachedLeavesInterface.
+func InitCachedLeavesBackEnd(datadir string) (*CachedLeavesBackEnd, error) {
+	db, err := leveldb.OpenFile(datadir, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CachedLeavesBackEnd{db: db}, nil
+}
+
+// Get returns the data from the underlying map.
+func (m *CachedLeavesBackEnd) Get(k utreexo.Hash) (uint64, bool) {
+	val, err := m.db.Get(k[:], nil)
+	if err != nil {
+		return 0, false
+	}
+
+	pos, _ := deserializeVLQ(val)
+	return pos, true
+}
+
+// Put puts the given data to the underlying map.
+func (m *CachedLeavesBackEnd) Put(k utreexo.Hash, v uint64) {
+	size := serializeSizeVLQ(v)
+	buf := make([]byte, size)
+	putVLQ(buf, v)
+
+	m.db.Put(k[:], buf, nil)
+}
+
+// Delete removes the given key from the underlying map. No-op if the key
+// doesn't exist.
+func (m *CachedLeavesBackEnd) Delete(k utreexo.Hash) {
+	m.db.Delete(k[:], nil)
+}
+
+// Length returns the amount of items in the underlying db.
+func (m *CachedLeavesBackEnd) Length() int {
+	length := 0
+	iter := m.db.NewIterator(nil, nil)
+	for iter.Next() {
+		length++
+	}
+	iter.Release()
+
+	return length
+}
+
+// ForEach calls the given function for each of the elements in the underlying map.
+func (m *CachedLeavesBackEnd) ForEach(fn func(utreexo.Hash, uint64) error) error {
+	iter := m.db.NewIterator(nil, nil)
+	for iter.Next() {
+		// Remember that the contents of the returned slice should not be modified, and
+		// only valid until the next call to Next.
+		k := iter.Key()
+		v, _ := deserializeVLQ(iter.Value())
+
+		err := fn(*(*[chainhash.HashSize]byte)(k), v)
+		if err != nil {
+			return err
+		}
+	}
+	iter.Release()
+	return iter.Error()
+}
+
+// Close closes the underlying database.
+func (m *CachedLeavesBackEnd) Close() error {
+	return m.db.Close()
 }

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -1054,8 +1054,8 @@ func (idx *FlatUtreexoProofIndex) storeUndoBlock(height int32,
 }
 
 // storeRoots serializes and stores roots to the roots state.
-func (idx *FlatUtreexoProofIndex) storeRoots(height int32, p *utreexo.Pollard) error {
-	serialized, err := blockchain.SerializeUtreexoRoots(p.NumLeaves, p.GetRoots())
+func (idx *FlatUtreexoProofIndex) storeRoots(height int32, p utreexo.Utreexo) error {
+	serialized, err := blockchain.SerializeUtreexoRoots(p.GetNumLeaves(), p.GetRoots())
 	if err != nil {
 		return err
 	}
@@ -1271,7 +1271,7 @@ func NewFlatUtreexoProofIndex(dataDir string, pruned bool, chainParams *chaincfg
 		Name:    flatUtreexoProofIndexType,
 		// Default to ram for now.
 		Params: chainParams,
-	})
+	}, true)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -460,24 +460,6 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 	log.Infof("Catching up indexes from height %d to %d", lowestHeight,
 		bestHeight)
 
-	// Needed for flushing the utreexo state in case of a sigint by the user.
-	defer func() {
-		for _, indexer := range m.enabledIndexes {
-			switch idxType := indexer.(type) {
-			case *UtreexoProofIndex:
-				err := idxType.FlushUtreexoState()
-				if err != nil {
-					log.Errorf("Error while flushing utreexo state: %v", err)
-				}
-			case *FlatUtreexoProofIndex:
-				err := idxType.FlushUtreexoState()
-				if err != nil {
-					log.Errorf("Error while flushing utreexo state for flat utreexo proof index: %v", err)
-				}
-			}
-		}
-	}()
-
 	for height := lowestHeight + 1; height <= bestHeight; height++ {
 		// Load the block for the height since it is required to index
 		// it.
@@ -487,6 +469,20 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 		}
 
 		if interruptRequested(interrupt) {
+			for _, indexer := range m.enabledIndexes {
+				switch idxType := indexer.(type) {
+				case *UtreexoProofIndex:
+					err := idxType.FlushUtreexoState()
+					if err != nil {
+						log.Errorf("Error while flushing utreexo state: %v", err)
+					}
+				case *FlatUtreexoProofIndex:
+					err := idxType.FlushUtreexoState()
+					if err != nil {
+						log.Errorf("Error while flushing utreexo state for flat utreexo proof index: %v", err)
+					}
+				}
+			}
 			return errInterruptRequested
 		}
 
@@ -524,6 +520,20 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 		progressLogger.LogBlockHeight(block)
 
 		if interruptRequested(interrupt) {
+			for _, indexer := range m.enabledIndexes {
+				switch idxType := indexer.(type) {
+				case *UtreexoProofIndex:
+					err := idxType.FlushUtreexoState()
+					if err != nil {
+						log.Errorf("Error while flushing utreexo state: %v", err)
+					}
+				case *FlatUtreexoProofIndex:
+					err := idxType.FlushUtreexoState()
+					if err != nil {
+						log.Errorf("Error while flushing utreexo state for flat utreexo proof index: %v", err)
+					}
+				}
+			}
 			return errInterruptRequested
 		}
 	}

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -6,10 +6,12 @@ package indexers
 
 import (
 	"bytes"
+	"encoding/binary"
 	"os"
 	"path/filepath"
 
 	"github.com/utreexo/utreexo"
+	"github.com/utreexo/utreexod/blockchain"
 	"github.com/utreexo/utreexod/chaincfg"
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
 	"github.com/utreexo/utreexod/database"
@@ -19,6 +21,8 @@ const (
 	// utreexoDirName is the name of the directory in which the utreexo state
 	// is stored.
 	utreexoDirName         = "utreexostate"
+	nodesDBDirName         = "nodes"
+	cachedLeavesDBDirName  = "cachedleaves"
 	defaultUtreexoFileName = "forest.dat"
 
 	// udataSerializeBool defines the argument that should be passed to the
@@ -46,7 +50,9 @@ type UtreexoConfig struct {
 // information.  It contains the entire, non-pruned accumulator.
 type UtreexoState struct {
 	config *UtreexoConfig
-	state  *utreexo.Pollard
+	state  utreexo.Utreexo
+
+	closeDB func() error
 }
 
 // utreexoBasePath returns the base path of where the utreexo state should be
@@ -57,29 +63,11 @@ func utreexoBasePath(cfg *UtreexoConfig) string {
 
 // InitUtreexoState returns an initialized utreexo state. If there isn't an
 // existing state on disk, it creates one and returns it.
-func InitUtreexoState(cfg *UtreexoConfig) (*UtreexoState, error) {
+func InitUtreexoState(cfg *UtreexoConfig, inMemory bool) (*UtreexoState, error) {
 	basePath := utreexoBasePath(cfg)
 	log.Infof("Initializing Utreexo state from '%s'", basePath)
-
-	var p *utreexo.Pollard
-	var err error
-	if checkUtreexoExists(cfg, basePath) {
-		p, err = restoreUtreexoState(cfg, basePath)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		p, err = createUtreexoState(cfg, basePath)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	uState := &UtreexoState{config: cfg, state: p}
-
-	log.Info("Utreexo state loaded")
-
-	return uState, nil
+	defer log.Info("Utreexo state loaded")
+	return initUtreexoState(cfg, inMemory, basePath)
 }
 
 // deleteUtreexoState removes the utreexo state directory and all the contents
@@ -118,7 +106,7 @@ func (idx *UtreexoProofIndex) FetchCurrentUtreexoState() ([]*chainhash.Hash, uin
 		chainhashRoots[i] = &newRoot
 	}
 
-	return chainhashRoots, idx.utreexoState.state.NumLeaves
+	return chainhashRoots, idx.utreexoState.state.GetNumLeaves()
 }
 
 // FetchCurrentUtreexoState returns the current utreexo state.
@@ -134,7 +122,7 @@ func (idx *FlatUtreexoProofIndex) FetchCurrentUtreexoState() ([]*chainhash.Hash,
 		chainhashRoots[i] = &newRoot
 	}
 
-	return chainhashRoots, idx.utreexoState.state.NumLeaves
+	return chainhashRoots, idx.utreexoState.state.GetNumLeaves()
 }
 
 // FetchUtreexoState returns the utreexo state at the desired block.
@@ -170,7 +158,6 @@ func (idx *FlatUtreexoProofIndex) FetchUtreexoState(blockHeight int32) ([]*chain
 // FlushUtreexoState saves the utreexo state to disk.
 func (idx *UtreexoProofIndex) FlushUtreexoState() error {
 	basePath := utreexoBasePath(idx.utreexoState.config)
-
 	if _, err := os.Stat(basePath); err != nil {
 		os.MkdirAll(basePath, os.ModePerm)
 	}
@@ -179,12 +166,14 @@ func (idx *UtreexoProofIndex) FlushUtreexoState() error {
 	if err != nil {
 		return err
 	}
-	_, err = idx.utreexoState.state.WriteTo(forestFile)
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], idx.utreexoState.state.GetNumLeaves())
+	_, err = forestFile.Write(buf[:])
 	if err != nil {
 		return err
 	}
 
-	return nil
+	return idx.utreexoState.closeDB()
 }
 
 // FlushUtreexoState saves the utreexo state to disk.
@@ -198,12 +187,14 @@ func (idx *FlatUtreexoProofIndex) FlushUtreexoState() error {
 	if err != nil {
 		return err
 	}
-	_, err = idx.utreexoState.state.WriteTo(forestFile)
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], idx.utreexoState.state.GetNumLeaves())
+	_, err = forestFile.Write(buf[:])
 	if err != nil {
 		return err
 	}
 
-	return nil
+	return idx.utreexoState.closeDB()
 }
 
 // serializeUndoBlock serializes all the data that's needed for undoing a full utreexo state
@@ -320,27 +311,114 @@ func deserializeUndoBlock(serialized []byte) (uint64, []uint64, []utreexo.Hash, 
 	return numAdds, targets, delHashes, nil
 }
 
-// restoreUtreexoState restores forest fields based off the existing utreexo state
-// on disk.
-func restoreUtreexoState(cfg *UtreexoConfig, basePath string) (*utreexo.Pollard, error) {
-	forestFilePath := filepath.Join(basePath, defaultUtreexoFileName)
+// initUtreexoState creates a new utreexo state and returns it.
+func initUtreexoState(cfg *UtreexoConfig, inMemory bool, basePath string) (*UtreexoState, error) {
+	p := utreexo.NewMapPollard(true)
 
-	// Where the forestfile exists
-	file, err := os.OpenFile(forestFilePath, os.O_RDWR, 0400)
+	nodesPath := filepath.Join(basePath, nodesDBDirName)
+	nodesDB, err := blockchain.InitNodesBackEnd(nodesPath)
 	if err != nil {
 		return nil, err
 	}
 
-	_, p, err := utreexo.RestorePollardFrom(file)
+	cachedLeavesPath := filepath.Join(basePath, cachedLeavesDBDirName)
+	cachedLeavesDB, err := blockchain.InitCachedLeavesBackEnd(cachedLeavesPath)
 	if err != nil {
 		return nil, err
 	}
 
-	return p, nil
-}
+	if checkUtreexoExists(cfg, basePath) {
+		forestFilePath := filepath.Join(basePath, defaultUtreexoFileName)
+		file, err := os.OpenFile(forestFilePath, os.O_RDWR, 0400)
+		if err != nil {
+			return nil, err
+		}
+		var buf [8]byte
+		_, err = file.Read(buf[:])
+		if err != nil {
+			return nil, err
+		}
+		p.NumLeaves = binary.LittleEndian.Uint64(buf[:])
+	}
 
-// createUtreexoState creates a new utreexo state and returns it.
-func createUtreexoState(cfg *UtreexoConfig, basePath string) (*utreexo.Pollard, error) {
-	p := utreexo.NewAccumulator()
-	return &p, nil
+	var closeDB func() error
+	if !inMemory {
+		p.Nodes = nodesDB
+		p.CachedLeaves = cachedLeavesDB
+		closeDB = func() error {
+			err := nodesDB.Close()
+			if err != nil {
+				return err
+			}
+
+			err = cachedLeavesDB.Close()
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+	} else {
+		log.Infof("loading the utreexo state from disk...")
+		nodeCnt := 0
+		err = nodesDB.ForEach(func(k uint64, v utreexo.Leaf) error {
+			nodeCnt++
+			p.Nodes.Put(k, v)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		cachedLeavesCnt := 0
+		err = cachedLeavesDB.ForEach(func(k utreexo.Hash, v uint64) error {
+			cachedLeavesCnt++
+			p.CachedLeaves.Put(k, v)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		log.Infof("Finished loading the utreexo state from disk. Loaded %v nodes and %v leaves",
+			nodeCnt, cachedLeavesCnt)
+
+		closeDB = func() error {
+			err = p.Nodes.ForEach(func(k uint64, v utreexo.Leaf) error {
+				nodesDB.Put(k, v)
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+
+			err = p.CachedLeaves.ForEach(func(k utreexo.Hash, v uint64) error {
+				cachedLeavesDB.Put(k, v)
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+
+			err := nodesDB.Close()
+			if err != nil {
+				return err
+			}
+
+			err = cachedLeavesDB.Close()
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+	}
+
+	uState := &UtreexoState{
+		config:  cfg,
+		state:   &p,
+		closeDB: closeDB,
+	}
+
+	return uState, err
 }

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -575,7 +575,7 @@ func NewUtreexoProofIndex(db database.DB, pruned bool, dataDir string, chainPara
 		DataDir: dataDir,
 		Name:    db.Type(),
 		Params:  chainParams,
-	})
+	}, false)
 	if err != nil {
 		return nil, err
 	}
@@ -627,8 +627,8 @@ func dbDeleteUtreexoProofEntry(dbTx database.Tx, hash *chainhash.Hash) error {
 }
 
 // Stores the utreexo state in the database.
-func dbStoreUtreexoState(dbTx database.Tx, hash *chainhash.Hash, p *utreexo.Pollard) error {
-	bytes, err := blockchain.SerializeUtreexoRoots(p.NumLeaves, p.GetRoots())
+func dbStoreUtreexoState(dbTx database.Tx, hash *chainhash.Hash, p utreexo.Utreexo) error {
+	bytes, err := blockchain.SerializeUtreexoRoots(p.GetNumLeaves(), p.GetRoots())
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/utreexo/utreexo v0.1.0
+	github.com/utreexo/utreexo v0.1.1
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
 	golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd
 )

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/utreexo/utreexo v0.0.0-20240207085148-754fd0816976 h1:1r3hZAaf7zhLd/h
 github.com/utreexo/utreexo v0.0.0-20240207085148-754fd0816976/go.mod h1:RT9JpZADhLr2YJVBgp48tmUxVeAHaAbOSr6p6nAEJpI=
 github.com/utreexo/utreexo v0.1.0 h1:ddbIk/yU7sqZ/7Q2XoZhaeWqMBRwhHXaoFRvKYx7uLo=
 github.com/utreexo/utreexo v0.1.0/go.mod h1:RT9JpZADhLr2YJVBgp48tmUxVeAHaAbOSr6p6nAEJpI=
+github.com/utreexo/utreexo v0.1.1 h1:K352t6y6O48WX62zp9iDgV/3Udqp7Xa5zGL3g4OsxxA=
+github.com/utreexo/utreexo v0.1.1/go.mod h1:RT9JpZADhLr2YJVBgp48tmUxVeAHaAbOSr6p6nAEJpI=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
Switches bridge nodes to use `MapPollard` and added a new backend for `MapPollard` using leveldb. Both of the utreexo proof indexs (`--utreexoproofindex` `--flatutreexoproofindex`) are changed to be on disk.