### PR TITLE
main, utreexoctl: add cookie based login

### DIFF
--- a/cmd/utreexoctl/config.go
+++ b/cmd/utreexoctl/config.go
@@ -27,6 +27,8 @@ const (
 )
 
 var (
+	defaultDataDirname    = "data"
+	defaultDataDir        = filepath.Join(utreexodHomeDir, defaultDataDirname)
 	utreexodHomeDir       = btcutil.AppDataDir("utreexod", false)
 	utreexoctlHomeDir     = btcutil.AppDataDir("utreexoctl", false)
 	utreexowalletHomeDir  = btcutil.AppDataDir("utreexowallet", false)
@@ -94,6 +96,7 @@ func listCommands() {
 // See loadConfig for details on the configuration load process.
 type config struct {
 	ConfigFile     string `short:"C" long:"configfile" description:"Path to configuration file"`
+	DataDir        string `long:"datadir" description:"Path to the utreexod datadir"`
 	ListCommands   bool   `short:"l" long:"listcommands" description:"List all of the supported commands and exit"`
 	NoTLS          bool   `long:"notls" description:"Disable TLS"`
 	Proxy          string `long:"proxy" description:"Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
@@ -291,6 +294,22 @@ func loadConfig() (*config, []string, error) {
 		err := fmt.Errorf(str, "loadConfig")
 		fmt.Fprintln(os.Stderr, err)
 		return nil, nil, err
+	}
+
+	if cfg.DataDir == "" {
+		name := network.Name
+		if network.Name == "testnet3" {
+			name = "testnet"
+		}
+		cfg.DataDir = filepath.Join(defaultDataDir, name)
+	} else {
+		cfg.DataDir = cleanAndExpandPath(cfg.DataDir)
+
+		name := network.Name
+		if network.Name == "testnet3" {
+			name = "testnet"
+		}
+		cfg.DataDir = filepath.Join(cfg.DataDir, name)
 	}
 
 	// Override the RPC certificate if the --wallet flag was specified and

--- a/cmd/utreexoctl/config.go
+++ b/cmd/utreexoctl/config.go
@@ -27,6 +27,7 @@ const (
 )
 
 var (
+	cookieFileName        = ".cookie"
 	defaultDataDirname    = "data"
 	defaultDataDir        = filepath.Join(utreexodHomeDir, defaultDataDirname)
 	utreexodHomeDir       = btcutil.AppDataDir("utreexod", false)

--- a/cmd/utreexoctl/httpclient.go
+++ b/cmd/utreexoctl/httpclient.go
@@ -70,6 +70,8 @@ func newHTTPClient(cfg *config) (*http.Client, error) {
 func readCookieFile(path string) (username, password string, err error) {
 	f, err := os.Open(path)
 	if err != nil {
+		retErr := fmt.Errorf("%v. Cookiefile only exists if the node is running", err)
+		err = retErr
 		return
 	}
 	defer f.Close()

--- a/cmd/utreexoctl/httpclient.go
+++ b/cmd/utreexoctl/httpclient.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
@@ -9,6 +10,9 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/go-socks/socks"
@@ -61,6 +65,33 @@ func newHTTPClient(cfg *config) (*http.Client, error) {
 	return &client, nil
 }
 
+// readCookieFile reads the cookie file from the given path. Throws an error if
+// the contents of the cookie file doesn't match the format: `username:password`.
+func readCookieFile(path string) (username, password string, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Scan()
+	err = scanner.Err()
+	if err != nil {
+		return
+	}
+	s := scanner.Text()
+
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		err = fmt.Errorf("malformed cookie file. Read %v", s)
+		return
+	}
+
+	username, password = parts[0], parts[1]
+	return
+}
+
 // sendPostRequest sends the marshalled JSON-RPC command using HTTP-POST mode
 // to the server described in the passed config struct.  It also attempts to
 // unmarshal the response as a JSON-RPC response and returns either the result
@@ -80,8 +111,17 @@ func sendPostRequest(marshalledJSON []byte, cfg *config) ([]byte, error) {
 	httpRequest.Close = true
 	httpRequest.Header.Set("Content-Type", "application/json")
 
-	// Configure basic access authorization.
-	httpRequest.SetBasicAuth(cfg.RPCUser, cfg.RPCPassword)
+	if cfg.RPCUser != "" && cfg.RPCPassword != "" {
+		// Configure basic access authorization.
+		httpRequest.SetBasicAuth(cfg.RPCUser, cfg.RPCPassword)
+	} else {
+		// Configure basic access authorization with the cookie file.
+		user, pass, err := readCookieFile(filepath.Join(cfg.DataDir, cookieFileName))
+		if err != nil {
+			return nil, err
+		}
+		httpRequest.SetBasicAuth(user, pass)
+	}
 
 	// Create the new HTTP client that is configured according to the user-
 	// specified options and submit the request.

--- a/config.go
+++ b/config.go
@@ -65,6 +65,7 @@ const (
 	defaultMaxOrphanTxSize       = 100000
 	defaultSigCacheMaxSize       = 100000
 	defaultUtxoCacheMaxSizeMiB   = 250
+	defaultCookieFileName        = ".cookie"
 	sampleConfigFilename         = "sample-utreexod.conf"
 	defaultTxIndex               = false
 	defaultTTLIndex              = false

--- a/config.go
+++ b/config.go
@@ -536,27 +536,24 @@ func loadConfig() (*config, []string, error) {
 	// Load additional config from file.
 	var configFileError error
 	parser := newConfigParser(&cfg, &serviceOpts, flags.Default)
-	if !(preCfg.RegressionTest || preCfg.SimNet || preCfg.SigNet) ||
-		preCfg.ConfigFile != defaultConfigFile {
-
-		if _, err := os.Stat(preCfg.ConfigFile); os.IsNotExist(err) {
-			err := createDefaultConfigFile(preCfg.ConfigFile)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error creating a "+
-					"default config file: %v\n", err)
-			}
-		}
-
-		err := flags.NewIniParser(parser).ParseFile(preCfg.ConfigFile)
+	// Create default config file if it doesn't exist.
+	if _, err := os.Stat(preCfg.ConfigFile); os.IsNotExist(err) {
+		err := createDefaultConfigFile(preCfg.ConfigFile)
 		if err != nil {
-			if _, ok := err.(*os.PathError); !ok {
-				fmt.Fprintf(os.Stderr, "Error parsing config "+
-					"file: %v\n", err)
-				fmt.Fprintln(os.Stderr, usageMessage)
-				return nil, nil, err
-			}
-			configFileError = err
+			fmt.Fprintf(os.Stderr, "Error creating a "+
+				"default config file: %v\n", err)
 		}
+	}
+
+	err = flags.NewIniParser(parser).ParseFile(preCfg.ConfigFile)
+	if err != nil {
+		if _, ok := err.(*os.PathError); !ok {
+			fmt.Fprintf(os.Stderr, "Error parsing config "+
+				"file: %v\n", err)
+			fmt.Fprintln(os.Stderr, usageMessage)
+			return nil, nil, err
+		}
+		configFileError = err
 	}
 
 	// Don't add peers from the config file when in regression test mode.

--- a/config.go
+++ b/config.go
@@ -827,12 +827,6 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
-	// The RPC server is disabled if no username or password is provided.
-	if (cfg.RPCUser == "" || cfg.RPCPass == "") &&
-		(cfg.RPCLimitUser == "" || cfg.RPCLimitPass == "") {
-		cfg.DisableRPC = true
-	}
-
 	if cfg.DisableRPC {
 		btcdLog.Infof("RPC service is disabled")
 	}

--- a/config.go
+++ b/config.go
@@ -6,8 +6,6 @@ package main
 
 import (
 	"bufio"
-	"crypto/rand"
-	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -1343,20 +1341,6 @@ func createDefaultConfigFile(destinationPath string) error {
 	}
 	sampleConfigPath := filepath.Join(path, sampleConfigFilename)
 
-	// We generate a random user and password
-	randomBytes := make([]byte, 20)
-	_, err = rand.Read(randomBytes)
-	if err != nil {
-		return err
-	}
-	generatedRPCUser := base64.StdEncoding.EncodeToString(randomBytes)
-
-	_, err = rand.Read(randomBytes)
-	if err != nil {
-		return err
-	}
-	generatedRPCPass := base64.StdEncoding.EncodeToString(randomBytes)
-
 	src, err := os.Open(sampleConfigPath)
 	if err != nil {
 		return err
@@ -1370,20 +1354,13 @@ func createDefaultConfigFile(destinationPath string) error {
 	}
 	defer dest.Close()
 
-	// We copy every line from the sample config file to the destination,
-	// only replacing the two lines for rpcuser and rpcpass
+	// We copy every line from the sample config file to the destination.
 	reader := bufio.NewReader(src)
 	for err != io.EOF {
 		var line string
 		line, err = reader.ReadString('\n')
 		if err != nil && err != io.EOF {
 			return err
-		}
-
-		if strings.Contains(line, "rpcuser=") {
-			line = "rpcuser=" + generatedRPCUser + "\n"
-		} else if strings.Contains(line, "rpcpass=") {
-			line = "rpcpass=" + generatedRPCPass + "\n"
 		}
 
 		if _, err := dest.WriteString(line); err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -4,14 +4,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"testing"
-)
-
-var (
-	rpcuserRegexp = regexp.MustCompile("(?m)^rpcuser=.+$")
-	rpcpassRegexp = regexp.MustCompile("(?m)^rpcpass=.+$")
 )
 
 func TestCreateDefaultConfigFile(t *testing.T) {
@@ -52,21 +46,7 @@ func TestCreateDefaultConfigFile(t *testing.T) {
 	}()
 
 	err = createDefaultConfigFile(testpath)
-
 	if err != nil {
 		t.Fatalf("Failed to create a default config file: %v", err)
-	}
-
-	content, err := ioutil.ReadFile(testpath)
-	if err != nil {
-		t.Fatalf("Failed to read generated default config file: %v", err)
-	}
-
-	if !rpcuserRegexp.Match(content) {
-		t.Error("Could not find rpcuser in generated default config file.")
-	}
-
-	if !rpcpassRegexp.Match(content) {
-		t.Error("Could not find rpcpass in generated default config file.")
 	}
 }

--- a/sample-utreexod.conf
+++ b/sample-utreexod.conf
@@ -173,15 +173,11 @@
 ; ------------------------------------------------------------------------------
 ; RPC server options - The following options control the built-in RPC server
 ; which is used to control and query information from a running btcd process.
-;
-; NOTE: The RPC server is disabled by default if rpcuser AND rpcpass, or
-; rpclimituser AND rpclimitpass, are not specified.
 ; ------------------------------------------------------------------------------
 
 ; Secure the RPC API by specifying the username and password.  You can also
-; specify a limited username and password.  You must specify at least one
-; full set of credentials - limited or admin - or the RPC server will
-; be disabled.
+; specify a limited username and password.  Don't specify rpcuser or the rpcpass
+; to use cookie based authentication.
 ; rpcuser=whatever_admin_username_you_want
 ; rpcpass=
 ; rpclimituser=whatever_limited_username_you_want
@@ -227,9 +223,7 @@
 ; interoperability issues need to be worked around
 ; rpcquirks=1
 
-; Use the following setting to disable the RPC server even if the rpcuser and
-; rpcpass are specified above.  This allows one to quickly disable the RPC
-; server without having to remove credentials from the config file.
+; Use the following setting to disable the RPC server.
 ; norpc=1
 
 ; Use the following setting to disable TLS for the RPC server.  NOTE: This


### PR DESCRIPTION
One pain point with utreexod and utreexoctl was that you have to manually set rpcuser and rpcpassword when you start utreexod in order to use the rpcserver. This cookie fallback allows users to simply start up the node with `utreexod` and have access to the bdkwallet with utreexoctl