### PR TITLE
indexers: move utreexo index flushing so it only triggers on interrupts

### DIFF
--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -460,24 +460,6 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 	log.Infof("Catching up indexes from height %d to %d", lowestHeight,
 		bestHeight)
 
-	// Needed for flushing the utreexo state in case of a sigint by the user.
-	defer func() {
-		for _, indexer := range m.enabledIndexes {
-			switch idxType := indexer.(type) {
-			case *UtreexoProofIndex:
-				err := idxType.FlushUtreexoState()
-				if err != nil {
-					log.Errorf("Error while flushing utreexo state: %v", err)
-				}
-			case *FlatUtreexoProofIndex:
-				err := idxType.FlushUtreexoState()
-				if err != nil {
-					log.Errorf("Error while flushing utreexo state for flat utreexo proof index: %v", err)
-				}
-			}
-		}
-	}()
-
 	for height := lowestHeight + 1; height <= bestHeight; height++ {
 		// Load the block for the height since it is required to index
 		// it.
@@ -487,6 +469,20 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 		}
 
 		if interruptRequested(interrupt) {
+			for _, indexer := range m.enabledIndexes {
+				switch idxType := indexer.(type) {
+				case *UtreexoProofIndex:
+					err := idxType.FlushUtreexoState()
+					if err != nil {
+						log.Errorf("Error while flushing utreexo state: %v", err)
+					}
+				case *FlatUtreexoProofIndex:
+					err := idxType.FlushUtreexoState()
+					if err != nil {
+						log.Errorf("Error while flushing utreexo state for flat utreexo proof index: %v", err)
+					}
+				}
+			}
 			return errInterruptRequested
 		}
 
@@ -524,6 +520,20 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 		progressLogger.LogBlockHeight(block)
 
 		if interruptRequested(interrupt) {
+			for _, indexer := range m.enabledIndexes {
+				switch idxType := indexer.(type) {
+				case *UtreexoProofIndex:
+					err := idxType.FlushUtreexoState()
+					if err != nil {
+						log.Errorf("Error while flushing utreexo state: %v", err)
+					}
+				case *FlatUtreexoProofIndex:
+					err := idxType.FlushUtreexoState()
+					if err != nil {
+						log.Errorf("Error while flushing utreexo state for flat utreexo proof index: %v", err)
+					}
+				}
+			}
 			return errInterruptRequested
 		}
 	}


### PR DESCRIPTION
Having the defer forced a utreexo index flush after the index was built. This change makes it so that it only triggers the flush when the program is shutting down.