### PR TITLE
blockchain, indexers: change utreexo bridges to mappollard

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -1054,8 +1054,8 @@ func (idx *FlatUtreexoProofIndex) storeUndoBlock(height int32,
 }
 
 // storeRoots serializes and stores roots to the roots state.
-func (idx *FlatUtreexoProofIndex) storeRoots(height int32, p *utreexo.Pollard) error {
-	serialized, err := blockchain.SerializeUtreexoRoots(p.NumLeaves, p.GetRoots())
+func (idx *FlatUtreexoProofIndex) storeRoots(height int32, p utreexo.Utreexo) error {
+	serialized, err := blockchain.SerializeUtreexoRoots(p.GetNumLeaves(), p.GetRoots())
 	if err != nil {
 		return err
 	}

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -627,8 +627,8 @@ func dbDeleteUtreexoProofEntry(dbTx database.Tx, hash *chainhash.Hash) error {
 }
 
 // Stores the utreexo state in the database.
-func dbStoreUtreexoState(dbTx database.Tx, hash *chainhash.Hash, p *utreexo.Pollard) error {
-	bytes, err := blockchain.SerializeUtreexoRoots(p.NumLeaves, p.GetRoots())
+func dbStoreUtreexoState(dbTx database.Tx, hash *chainhash.Hash, p utreexo.Utreexo) error {
+	bytes, err := blockchain.SerializeUtreexoRoots(p.GetNumLeaves(), p.GetRoots())
 	if err != nil {
 		return err
 	}

--- a/blockchain/utreexoio.go
+++ b/blockchain/utreexoio.go
@@ -45,9 +45,9 @@ type NodesBackEnd struct {
 	db *leveldb.DB
 }
 
-// NewNodesBackEnd returns a newly initialized NodesBackEnd which implements
+// InitNodesBackEnd returns a newly initialized NodesBackEnd which implements
 // utreexo.NodesInterface.
-func NewNodesBackEnd(datadir string) (*NodesBackEnd, error) {
+func InitNodesBackEnd(datadir string) (*NodesBackEnd, error) {
 	db, err := leveldb.OpenFile(datadir, nil)
 	if err != nil {
 		return nil, err
@@ -131,6 +131,11 @@ func (m *NodesBackEnd) ForEach(fn func(uint64, utreexo.Leaf) error) error {
 	return iter.Error()
 }
 
+// Close closes the underlying database.
+func (m *NodesBackEnd) Close() error {
+	return m.db.Close()
+}
+
 var _ utreexo.CachedLeavesInterface = (*CachedLeavesBackEnd)(nil)
 
 // CachedLeavesBackEnd implements the CachedLeavesInterface interface. It's really just a map.
@@ -138,9 +143,9 @@ type CachedLeavesBackEnd struct {
 	db *leveldb.DB
 }
 
-// NewCachedLeavesBackEnd returns a newly initialized CachedLeavesBackEnd which implements
+// InitCachedLeavesBackEnd returns a newly initialized CachedLeavesBackEnd which implements
 // utreexo.CachedLeavesInterface.
-func NewCachedLeavesBackEnd(datadir string) (*CachedLeavesBackEnd, error) {
+func InitCachedLeavesBackEnd(datadir string) (*CachedLeavesBackEnd, error) {
 	db, err := leveldb.OpenFile(datadir, nil)
 	if err != nil {
 		return nil, err
@@ -203,4 +208,9 @@ func (m *CachedLeavesBackEnd) ForEach(fn func(utreexo.Hash, uint64) error) error
 	}
 	iter.Release()
 	return iter.Error()
+}
+
+// Close closes the underlying database.
+func (m *CachedLeavesBackEnd) Close() error {
+	return m.db.Close()
 }


### PR DESCRIPTION
The utreexo state backend is changed to mappollard and both of the
indexes are changed to be fully on disk instead of on memory.

Fixes #63 