### PR TITLE
blockchain, indexers: Add cache option to bridgenodes

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -1271,7 +1271,7 @@ func NewFlatUtreexoProofIndex(dataDir string, pruned bool, chainParams *chaincfg
 		Name:    flatUtreexoProofIndexType,
 		// Default to ram for now.
 		Params: chainParams,
-	})
+	}, 250*1024*1024)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -1243,12 +1243,14 @@ func loadFlatFileState(dataDir, name string) (*FlatFileState, error) {
 }
 
 // NewFlatUtreexoProofIndex returns a new instance of an indexer that is used to create a flat utreexo proof index.
+// The passed in maxMemoryUsage should be in bytes and it determines how much memory the proof index will use up.
+// A maxMemoryUsage of 0 will keep all the elements on disk and a negative maxMemoryUsage will keep all the elements in memory.
 //
 // It implements the Indexer interface which plugs into the IndexManager that in
 // turn is used by the blockchain package.  This allows the index to be
 // seamlessly maintained along with the chain.
-func NewFlatUtreexoProofIndex(dataDir string, pruned bool, chainParams *chaincfg.Params,
-	proofGenInterVal *int32) (*FlatUtreexoProofIndex, error) {
+func NewFlatUtreexoProofIndex(pruned bool, chainParams *chaincfg.Params,
+	proofGenInterVal *int32, maxMemoryUsage int64, dataDir string) (*FlatUtreexoProofIndex, error) {
 
 	// If the proofGenInterVal argument is nil, use the default value.
 	var intervalToUse int32
@@ -1269,9 +1271,8 @@ func NewFlatUtreexoProofIndex(dataDir string, pruned bool, chainParams *chaincfg
 	uState, err := InitUtreexoState(&UtreexoConfig{
 		DataDir: dataDir,
 		Name:    flatUtreexoProofIndexType,
-		// Default to ram for now.
-		Params: chainParams,
-	}, 250*1024*1024)
+		Params:  chainParams,
+	}, maxMemoryUsage)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -75,12 +75,12 @@ func initIndexes(interval int32, dbPath string, db *database.DB, params *chaincf
 
 	proofGenInterval := new(int32)
 	*proofGenInterval = interval
-	flatUtreexoProofIndex, err := NewFlatUtreexoProofIndex(dbPath, false, params, proofGenInterval)
+	flatUtreexoProofIndex, err := NewFlatUtreexoProofIndex(false, params, proofGenInterval, 50*1024*1024, dbPath)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	utreexoProofIndex, err := NewUtreexoProofIndex(*db, false, dbPath, params)
+	utreexoProofIndex, err := NewUtreexoProofIndex(*db, false, 50*1024*1024, params, dbPath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -575,7 +575,7 @@ func NewUtreexoProofIndex(db database.DB, pruned bool, dataDir string, chainPara
 		DataDir: dataDir,
 		Name:    db.Type(),
 		Params:  chainParams,
-	})
+	}, 250*1024*1024)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -559,12 +559,17 @@ func (idx *UtreexoProofIndex) PruneBlock(dbTx database.Tx, blockHash *chainhash.
 	return nil
 }
 
-// NewUtreexoProofIndex returns a new instance of an indexer that is used to create a
+// NewUtreexoProofIndex returns a new instance of an indexer that is used to create a utreexo
+// proof index using the database passed in. The passed in maxMemoryUsage should be in bytes and
+// it determines how much memory the proof index will use up. A maxMemoryUsage of 0 will keep
+// all the elements on disk and a negative maxMemoryUsage will keep all the elements in memory.
 //
 // It implements the Indexer interface which plugs into the IndexManager that in
 // turn is used by the blockchain package.  This allows the index to be
 // seamlessly maintained along with the chain.
-func NewUtreexoProofIndex(db database.DB, pruned bool, dataDir string, chainParams *chaincfg.Params) (*UtreexoProofIndex, error) {
+func NewUtreexoProofIndex(db database.DB, pruned bool, maxMemoryUsage int64,
+	chainParams *chaincfg.Params, dataDir string) (*UtreexoProofIndex, error) {
+
 	idx := &UtreexoProofIndex{
 		db:          db,
 		chainParams: chainParams,
@@ -575,7 +580,7 @@ func NewUtreexoProofIndex(db database.DB, pruned bool, dataDir string, chainPara
 		DataDir: dataDir,
 		Name:    db.Type(),
 		Params:  chainParams,
-	}, 250*1024*1024)
+	}, maxMemoryUsage)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/utreexoio.go
+++ b/blockchain/utreexoio.go
@@ -38,6 +38,42 @@ func deserializeLeaf(serialized [leafLength]byte) utreexo.Leaf {
 	return leaf
 }
 
+// cachedFlag is the status of each of the cached elements in the NodesBackEnd.
+type cachedFlag uint8
+
+const (
+	// fresh means it's never been in the database
+	fresh cachedFlag = 1 << iota
+
+	// modified means it's been in the database and has been modified in the cache.
+	modified
+
+	// removed means that the key it belongs to has been removed but it's still
+	// in the cache.
+	removed
+)
+
+// cachedLeaf has the leaf and a flag for the status in the cache.
+type cachedLeaf struct {
+	leaf  utreexo.Leaf
+	flags cachedFlag
+}
+
+// isFresh returns if the cached leaf has never been in the database.
+func (c *cachedLeaf) isFresh() bool {
+	return c.flags&fresh == fresh
+}
+
+// isModified returns if the cached leaf has been in the database and was modified in the cache.
+func (c *cachedLeaf) isModified() bool {
+	return c.flags&modified == modified
+}
+
+// isRemoved returns if the key for this cached leaf has been removed.
+func (c *cachedLeaf) isRemoved() bool {
+	return c.flags&removed == removed
+}
+
 var _ utreexo.NodesInterface = (*NodesBackEnd)(nil)
 
 // NodesBackEnd implements the NodesInterface interface. It's really just the database.

--- a/blockchain/utreexoio_test.go
+++ b/blockchain/utreexoio_test.go
@@ -1,0 +1,443 @@
+package blockchain
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/utreexo/utreexo"
+)
+
+// isApproximate returns if a and b are within the given percentage of each other.
+func isApproximate(a, b, percentage float64) bool {
+	// Calculate % of 'a'
+	percentageOfA := math.Abs(a) * percentage
+
+	// Calculate the absolute difference between 'a' and 'b'
+	difference := math.Abs(a - b)
+
+	// Check if the absolute difference is less than or equal to 1% of 'a'
+	return difference <= percentageOfA
+}
+
+func TestCalcNumEntries(t *testing.T) {
+	tests := []struct {
+		maxSize    int64
+		bucketSize uintptr
+	}{
+		{100 * 1024 * 1024, nodesMapBucketSize},
+		{150 * 1024 * 1024, nodesMapBucketSize},
+		{250 * 1024 * 1024, nodesMapBucketSize},
+		{1000 * 1024 * 1024, nodesMapBucketSize},
+		{10000 * 1024 * 1024, nodesMapBucketSize},
+
+		{100 * 1024 * 1024, cachedLeavesMapBucketSize},
+		{150 * 1024 * 1024, cachedLeavesMapBucketSize},
+		{250 * 1024 * 1024, cachedLeavesMapBucketSize},
+		{1000 * 1024 * 1024, cachedLeavesMapBucketSize},
+		{10000 * 1024 * 1024, cachedLeavesMapBucketSize},
+	}
+
+	for _, test := range tests {
+		entries, _ := calcNumEntries(test.bucketSize, test.maxSize)
+
+		roughSize := 0
+		for _, entry := range entries {
+			roughSize += calculateRoughMapSize(entry, nodesMapBucketSize)
+		}
+
+		// Check if the roughSize is within 1% of test.maxSize.
+		if !isApproximate(float64(test.maxSize), float64(roughSize), 0.01) {
+			t.Fatalf("Expected value to be approximately %v but got %v",
+				test.maxSize, roughSize)
+		}
+	}
+}
+
+func TestNodesMapSliceMaxCacheElems(t *testing.T) {
+	_, maxCacheElems := newNodesMapSlice(0)
+	if maxCacheElems != 0 {
+		t.Fatalf("expected %v got %v", 0, maxCacheElems)
+	}
+
+	_, maxCacheElems = newNodesMapSlice(-1)
+	if maxCacheElems != 0 {
+		t.Fatalf("expected %v got %v", 0, maxCacheElems)
+	}
+
+	_, maxCacheElems = newNodesMapSlice(8000)
+	if maxCacheElems <= 0 {
+		t.Fatalf("expected something bigger than 0 but got %v", maxCacheElems)
+	}
+
+	_, maxCacheElems = newCachedLeavesMapSlice(0)
+	if maxCacheElems != 0 {
+		t.Fatalf("expected %v got %v", 0, maxCacheElems)
+	}
+
+	_, maxCacheElems = newCachedLeavesMapSlice(-1)
+	if maxCacheElems != 0 {
+		t.Fatalf("expected %v got %v", 0, maxCacheElems)
+	}
+
+	_, maxCacheElems = newCachedLeavesMapSlice(8000)
+	if maxCacheElems <= 0 {
+		t.Fatalf("expected something bigger than 0 but got %v", maxCacheElems)
+	}
+}
+
+func TestNodesMapSliceDuplicates(t *testing.T) {
+	m, maxElems := newNodesMapSlice(8000)
+	for i := 0; i < 10; i++ {
+		for j := int64(0); j < maxElems; j++ {
+			if !m.put(uint64(j), cachedLeaf{}) {
+				t.Fatalf("unexpected error on m.put")
+			}
+		}
+	}
+
+	if m.length() != int(maxElems) {
+		t.Fatalf("expected length of %v but got %v",
+			maxElems, m.length())
+	}
+
+	// Try inserting x which should be unique. Should fail as the map is full.
+	x := uint64(0)
+	x -= 1
+	if m.put(x, cachedLeaf{}) {
+		t.Fatalf("expected error but successfully called put")
+	}
+
+	// Remove the first element in the first map and then try inserting
+	// a duplicate element.
+	m.delete(0)
+	x = uint64(maxElems) - 1
+	if !m.put(x, cachedLeaf{}) {
+		t.Fatalf("unexpected failure on put")
+	}
+
+	// Make sure the length of the map is 1 less than the max elems.
+	if m.length() != int(maxElems)-1 {
+		t.Fatalf("expected length of %v but got %v",
+			maxElems-1, m.length())
+	}
+
+	// Put 0 back in and then compare the map.
+	if !m.put(0, cachedLeaf{}) {
+		t.Fatalf("didn't expect error but unsuccessfully called put")
+	}
+	if m.length() != int(maxElems) {
+		t.Fatalf("expected length of %v but got %v",
+			maxElems, m.length())
+	}
+}
+
+func uint64ToHash(v uint64) utreexo.Hash {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], v)
+	return sha256.Sum256(buf[:])
+}
+
+func TestCachedLeaveMapSliceDuplicates(t *testing.T) {
+	m, maxElems := newCachedLeavesMapSlice(8000)
+	for i := 0; i < 10; i++ {
+		for j := int64(0); j < maxElems; j++ {
+			if !m.put(uint64ToHash(uint64(j)), 0) {
+				t.Fatalf("unexpected error on m.put")
+			}
+		}
+	}
+
+	if m.length() != int(maxElems) {
+		t.Fatalf("expected length of %v but got %v",
+			maxElems, m.length())
+	}
+
+	// Try inserting x which should be unique. Should fail as the map is full.
+	x := uint64(0)
+	x -= 1
+	if m.put(uint64ToHash(x), 0) {
+		t.Fatalf("expected error but successfully called put")
+	}
+
+	// Remove the first element in the first map and then try inserting
+	// a duplicate element.
+	m.delete(uint64ToHash(0))
+	x = uint64(maxElems) - 1
+	if !m.put(uint64ToHash(x), 0) {
+		t.Fatalf("unexpected failure on put")
+	}
+
+	// Make sure the length of the map is 1 less than the max elems.
+	if m.length() != int(maxElems)-1 {
+		t.Fatalf("expected length of %v but got %v",
+			maxElems-1, m.length())
+	}
+
+	// Put 0 back in and then compare the map.
+	if !m.put(uint64ToHash(0), 0) {
+		t.Fatalf("didn't expect error but unsuccessfully called put")
+	}
+	if m.length() != int(maxElems) {
+		t.Fatalf("expected length of %v but got %v",
+			maxElems, m.length())
+	}
+}
+
+func TestCachedLeavesBackEnd(t *testing.T) {
+	tests := []struct {
+		tmpDir      string
+		maxMemUsage int64
+	}{
+		{
+			tmpDir: func() string {
+				return filepath.Join(os.TempDir(), "TestCachedLeavesBackEnd0")
+			}(),
+			maxMemUsage: -1,
+		},
+		{
+			tmpDir: func() string {
+				return filepath.Join(os.TempDir(), "TestCachedLeavesBackEnd1")
+			}(),
+			maxMemUsage: 0,
+		},
+		{
+			tmpDir: func() string {
+				return filepath.Join(os.TempDir(), "TestCachedLeavesBackEnd2")
+			}(),
+			maxMemUsage: 1 * 1024 * 1024,
+		},
+	}
+
+	for _, test := range tests {
+		cachedLeavesBackEnd, err := InitCachedLeavesBackEnd(test.tmpDir, test.maxMemUsage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(test.tmpDir)
+
+		count := uint64(1000)
+		compareMap := make(map[utreexo.Hash]uint64)
+		for i := uint64(0); i < count/2; i++ {
+			var buf [8]byte
+			binary.LittleEndian.PutUint64(buf[:], i)
+			hash := sha256.Sum256(buf[:])
+
+			compareMap[hash] = i
+			cachedLeavesBackEnd.Put(hash, i)
+		}
+
+		// Close and reopen the backend.
+		err = cachedLeavesBackEnd.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		cachedLeavesBackEnd, err = InitCachedLeavesBackEnd(test.tmpDir, test.maxMemUsage)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		// Delete every other element from the backend that we currently have.
+		go func() {
+			for i := uint64(0); i < count/2; i++ {
+				if i%2 != 0 {
+					continue
+				}
+
+				var buf [8]byte
+				binary.LittleEndian.PutUint64(buf[:], i)
+				hash := sha256.Sum256(buf[:])
+
+				cachedLeavesBackEnd.Delete(hash)
+			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		// Put the rest of the elements into the backend.
+		go func() {
+			for i := count / 2; i < count; i++ {
+				var buf [8]byte
+				binary.LittleEndian.PutUint64(buf[:], i)
+				hash := sha256.Sum256(buf[:])
+
+				cachedLeavesBackEnd.Put(hash, i)
+			}
+			wg.Done()
+		}()
+
+		wg.Wait()
+
+		// Do the same for the compare map. We do it here because a hashmap
+		// isn't concurrency safe.
+		for i := uint64(0); i < count/2; i++ {
+			if i%2 != 0 {
+				continue
+			}
+
+			var buf [8]byte
+			binary.LittleEndian.PutUint64(buf[:], i)
+			hash := sha256.Sum256(buf[:])
+			delete(compareMap, hash)
+		}
+		for i := count / 2; i < count; i++ {
+			var buf [8]byte
+			binary.LittleEndian.PutUint64(buf[:], i)
+			hash := sha256.Sum256(buf[:])
+
+			compareMap[hash] = i
+		}
+
+		if cachedLeavesBackEnd.Length() != len(compareMap) {
+			t.Fatalf("compareMap has %d elements but the backend has %d elements",
+				len(compareMap), cachedLeavesBackEnd.Length())
+		}
+
+		// Compare the map and the backend.
+		for k, v := range compareMap {
+			got, found := cachedLeavesBackEnd.Get(k)
+			if !found {
+				t.Fatalf("expected %v but it wasn't found", v)
+			}
+
+			if got != v {
+				var buf [8]byte
+				binary.LittleEndian.PutUint64(buf[:], got)
+				gotHash := sha256.Sum256(buf[:])
+
+				binary.LittleEndian.PutUint64(buf[:], v)
+				expectHash := sha256.Sum256(buf[:])
+
+				if gotHash != expectHash {
+					t.Fatalf("for key %v, expected %v but got %v", k.String(), v, got)
+				}
+			}
+		}
+	}
+}
+
+func TestNodesBackEnd(t *testing.T) {
+	tests := []struct {
+		tmpDir      string
+		maxMemUsage int64
+	}{
+		{
+			tmpDir: func() string {
+				return filepath.Join(os.TempDir(), "TestNodesBackEnd0")
+			}(),
+			maxMemUsage: -1,
+		},
+		{
+			tmpDir: func() string {
+				return filepath.Join(os.TempDir(), "TestNodesBackEnd1")
+			}(),
+			maxMemUsage: 0,
+		},
+		{
+			tmpDir: func() string {
+				return filepath.Join(os.TempDir(), "TestNodesBackEnd2")
+			}(),
+			maxMemUsage: 1 * 1024 * 1024,
+		},
+	}
+
+	for _, test := range tests {
+		nodesBackEnd, err := InitNodesBackEnd(test.tmpDir, test.maxMemUsage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(test.tmpDir)
+
+		count := uint64(1000)
+		compareMap := make(map[uint64]cachedLeaf)
+		for i := uint64(0); i < count/2; i++ {
+			var buf [8]byte
+			binary.LittleEndian.PutUint64(buf[:], i)
+			hash := sha256.Sum256(buf[:])
+
+			compareMap[i] = cachedLeaf{leaf: utreexo.Leaf{Hash: hash}}
+			nodesBackEnd.Put(i, utreexo.Leaf{Hash: hash})
+		}
+
+		// Close and reopen the backend.
+		err = nodesBackEnd.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		nodesBackEnd, err = InitNodesBackEnd(test.tmpDir, test.maxMemUsage)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		// Delete every other element from the backend that we currently have.
+		go func() {
+			for i := uint64(0); i < count/2; i++ {
+				if i%2 != 0 {
+					continue
+				}
+
+				nodesBackEnd.Delete(i)
+			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		// Put the rest of the elements into the backend.
+		go func() {
+			for i := count / 2; i < count; i++ {
+				var buf [8]byte
+				binary.LittleEndian.PutUint64(buf[:], i)
+				hash := sha256.Sum256(buf[:])
+
+				nodesBackEnd.Put(i, utreexo.Leaf{Hash: hash})
+			}
+			wg.Done()
+		}()
+
+		wg.Wait()
+
+		// Do the same for the compare map. We do it here because a hashmap
+		// isn't concurrency safe.
+		for i := uint64(0); i < count/2; i++ {
+			if i%2 != 0 {
+				continue
+			}
+
+			delete(compareMap, i)
+		}
+		for i := count / 2; i < count; i++ {
+			var buf [8]byte
+			binary.LittleEndian.PutUint64(buf[:], i)
+			hash := sha256.Sum256(buf[:])
+
+			compareMap[i] = cachedLeaf{leaf: utreexo.Leaf{Hash: hash}}
+		}
+
+		if nodesBackEnd.Length() != len(compareMap) {
+			t.Fatalf("compareMap has %d elements but the backend has %d elements",
+				len(compareMap), nodesBackEnd.Length())
+		}
+
+		// Compare the map and the backend.
+		for k, v := range compareMap {
+			got, found := nodesBackEnd.Get(k)
+			if !found {
+				t.Fatalf("expected %v but it wasn't found", v)
+			}
+
+			if got.Hash != v.leaf.Hash {
+				if got.Hash != v.leaf.Hash {
+					t.Fatalf("for key %v, expected %v but got %v", k, v.leaf.Hash, got.Hash)
+				}
+			}
+		}
+	}
+}

--- a/config.go
+++ b/config.go
@@ -197,19 +197,20 @@ type config struct {
 	BlockPrioritySize uint32   `long:"blockprioritysize" description:"Size in bytes for high-priority/low-fee transactions when creating a block"`
 
 	// Indexing options.
-	AddrIndex                 bool `long:"addrindex" description:"Maintain a full address-based transaction index which makes the searchrawtransactions RPC available"`
-	TxIndex                   bool `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
-	TTLIndex                  bool `long:"ttlindex" description:"Maintain a full time to live index for all stxos available via the getttl RPC"`
-	UtreexoProofIndex         bool `long:"utreexoproofindex" description:"Maintain a utreexo proof for all blocks"`
-	FlatUtreexoProofIndex     bool `long:"flatutreexoproofindex" description:"Maintain a utreexo proof for all blocks in flat files"`
-	CFilters                  bool `long:"cfilters" description:"Enable committed filtering (CF) support"`
-	NoPeerBloomFilters        bool `long:"nopeerbloomfilters" description:"Disable bloom filtering support"`
-	DropAddrIndex             bool `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up and then exits."`
-	DropCfIndex               bool `long:"dropcfindex" description:"Deletes the index used for committed filtering (CF) support from the database on start up and then exits."`
-	DropTxIndex               bool `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
-	DropTTLIndex              bool `long:"dropttlindex" description:"Deletes the time to live index from the database on start up and then exits."`
-	DropUtreexoProofIndex     bool `long:"droputreexoproofindex" description:"Deletes the utreexo proof index from the database on start up and then exits."`
-	DropFlatUtreexoProofIndex bool `long:"dropflatutreexoproofindex" description:"Deletes the flat utreexo proof index from the database on start up and then exits."`
+	AddrIndex                  bool  `long:"addrindex" description:"Maintain a full address-based transaction index which makes the searchrawtransactions RPC available"`
+	TxIndex                    bool  `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
+	TTLIndex                   bool  `long:"ttlindex" description:"Maintain a full time to live index for all stxos available via the getttl RPC"`
+	UtreexoProofIndex          bool  `long:"utreexoproofindex" description:"Maintain a utreexo proof for all blocks"`
+	FlatUtreexoProofIndex      bool  `long:"flatutreexoproofindex" description:"Maintain a utreexo proof for all blocks in flat files"`
+	UtreexoProofIndexMaxMemory int64 `long:"utreexoproofindexmaxmemory" description:"The maxmimum memory in mebibytes (MiB) that the utreexo proof indexes will use up. Passing in 0 will make the entire proof index stay on disk. Passing in a negative value will make the entire proof index stay in memory. Default of 250MiB."`
+	CFilters                   bool  `long:"cfilters" description:"Enable committed filtering (CF) support"`
+	NoPeerBloomFilters         bool  `long:"nopeerbloomfilters" description:"Disable bloom filtering support"`
+	DropAddrIndex              bool  `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up and then exits."`
+	DropCfIndex                bool  `long:"dropcfindex" description:"Deletes the index used for committed filtering (CF) support from the database on start up and then exits."`
+	DropTxIndex                bool  `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
+	DropTTLIndex               bool  `long:"dropttlindex" description:"Deletes the time to live index from the database on start up and then exits."`
+	DropUtreexoProofIndex      bool  `long:"droputreexoproofindex" description:"Deletes the utreexo proof index from the database on start up and then exits."`
+	DropFlatUtreexoProofIndex  bool  `long:"dropflatutreexoproofindex" description:"Deletes the flat utreexo proof index from the database on start up and then exits."`
 
 	// Wallet options.
 	WatchOnlyWallet                                      bool     `long:"watchonlywallet" description:"Enable the watch only wallet with utreexo proofs. Must have --noutreexo disabled"`
@@ -465,35 +466,36 @@ func newConfigParser(cfg *config, so *serviceOptions, options flags.Options) *fl
 func loadConfig() (*config, []string, error) {
 	// Default config.
 	cfg := config{
-		ConfigFile:           defaultConfigFile,
-		DebugLevel:           defaultLogLevel,
-		MaxPeers:             defaultMaxPeers,
-		BanDuration:          defaultBanDuration,
-		BanThreshold:         defaultBanThreshold,
-		RPCMaxClients:        defaultMaxRPCClients,
-		RPCMaxWebsockets:     defaultMaxRPCWebsockets,
-		RPCMaxConcurrentReqs: defaultMaxRPCConcurrentReqs,
-		DataDir:              defaultDataDir,
-		LogDir:               defaultLogDir,
-		DbType:               defaultDbType,
-		RPCKey:               defaultRPCKeyFile,
-		RPCCert:              defaultRPCCertFile,
-		MinRelayTxFee:        mempool.DefaultMinRelayTxFee.ToBTC(),
-		FreeTxRelayLimit:     defaultFreeTxRelayLimit,
-		TrickleInterval:      defaultTrickleInterval,
-		BlockMinSize:         defaultBlockMinSize,
-		BlockMaxSize:         defaultBlockMaxSize,
-		BlockMinWeight:       defaultBlockMinWeight,
-		BlockMaxWeight:       defaultBlockMaxWeight,
-		BlockPrioritySize:    mempool.DefaultBlockPrioritySize,
-		MaxOrphanTxs:         defaultMaxOrphanTransactions,
-		SigCacheMaxSize:      defaultSigCacheMaxSize,
-		UtxoCacheMaxSizeMiB:  defaultUtxoCacheMaxSizeMiB,
-		Generate:             defaultGenerate,
-		TxIndex:              defaultTxIndex,
-		TTLIndex:             defaultTTLIndex,
-		AddrIndex:            defaultAddrIndex,
-		Prune:                pruneMinSize,
+		ConfigFile:                 defaultConfigFile,
+		DebugLevel:                 defaultLogLevel,
+		MaxPeers:                   defaultMaxPeers,
+		BanDuration:                defaultBanDuration,
+		BanThreshold:               defaultBanThreshold,
+		RPCMaxClients:              defaultMaxRPCClients,
+		RPCMaxWebsockets:           defaultMaxRPCWebsockets,
+		RPCMaxConcurrentReqs:       defaultMaxRPCConcurrentReqs,
+		DataDir:                    defaultDataDir,
+		LogDir:                     defaultLogDir,
+		DbType:                     defaultDbType,
+		RPCKey:                     defaultRPCKeyFile,
+		RPCCert:                    defaultRPCCertFile,
+		MinRelayTxFee:              mempool.DefaultMinRelayTxFee.ToBTC(),
+		FreeTxRelayLimit:           defaultFreeTxRelayLimit,
+		TrickleInterval:            defaultTrickleInterval,
+		BlockMinSize:               defaultBlockMinSize,
+		BlockMaxSize:               defaultBlockMaxSize,
+		BlockMinWeight:             defaultBlockMinWeight,
+		BlockMaxWeight:             defaultBlockMaxWeight,
+		BlockPrioritySize:          mempool.DefaultBlockPrioritySize,
+		MaxOrphanTxs:               defaultMaxOrphanTransactions,
+		SigCacheMaxSize:            defaultSigCacheMaxSize,
+		UtxoCacheMaxSizeMiB:        defaultUtxoCacheMaxSizeMiB,
+		UtreexoProofIndexMaxMemory: defaultUtxoCacheMaxSizeMiB,
+		Generate:                   defaultGenerate,
+		TxIndex:                    defaultTxIndex,
+		TTLIndex:                   defaultTTLIndex,
+		AddrIndex:                  defaultAddrIndex,
+		Prune:                      pruneMinSize,
 	}
 
 	// Service options which are only added on Windows.

--- a/server.go
+++ b/server.go
@@ -3225,7 +3225,7 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 
 		var err error
 		s.utreexoProofIndex, err = indexers.NewUtreexoProofIndex(
-			db, cfg.Prune != 0, cfg.DataDir, chainParams)
+			db, cfg.Prune != 0, 250*1024*1024, chainParams, cfg.DataDir)
 		if err != nil {
 			return nil, err
 		}
@@ -3241,7 +3241,7 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 
 		var err error
 		s.flatUtreexoProofIndex, err = indexers.NewFlatUtreexoProofIndex(
-			cfg.DataDir, cfg.Prune != 0, chainParams, interval)
+			cfg.Prune != 0, chainParams, interval, 250*1024*1024, cfg.DataDir)
 		if err != nil {
 			return nil, err
 		}

--- a/server.go
+++ b/server.go
@@ -3225,7 +3225,8 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 
 		var err error
 		s.utreexoProofIndex, err = indexers.NewUtreexoProofIndex(
-			db, cfg.Prune != 0, 250*1024*1024, chainParams, cfg.DataDir)
+			db, cfg.Prune != 0, cfg.UtreexoProofIndexMaxMemory*1024*1024,
+			chainParams, cfg.DataDir)
 		if err != nil {
 			return nil, err
 		}
@@ -3241,7 +3242,8 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 
 		var err error
 		s.flatUtreexoProofIndex, err = indexers.NewFlatUtreexoProofIndex(
-			cfg.Prune != 0, chainParams, interval, 250*1024*1024, cfg.DataDir)
+			cfg.Prune != 0, chainParams, interval,
+			cfg.UtreexoProofIndexMaxMemory*1024*1024, cfg.DataDir)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Instead of only being on disk, the utreexo bridges now have a default cache of 250mib with it also being configurable. Users can choose to have the entire utreexo tree in memory or on bridge as well.