### PR TITLE
main: update utreexo library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/utreexo/utreexo v0.1.3
+	github.com/utreexo/utreexo v0.1.4
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
 	golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd
 )

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/utreexo/utreexo v0.1.2 h1:KLC8rlwPep3w9sYapEgDROYUBNmLzsO5aTPTorBJhJc
 github.com/utreexo/utreexo v0.1.2/go.mod h1:RT9JpZADhLr2YJVBgp48tmUxVeAHaAbOSr6p6nAEJpI=
 github.com/utreexo/utreexo v0.1.3 h1:Z7tj8DTZNHd927ZWT7NSKx14+Dk6BoMeDPhDOmFlibo=
 github.com/utreexo/utreexo v0.1.3/go.mod h1:RT9JpZADhLr2YJVBgp48tmUxVeAHaAbOSr6p6nAEJpI=
+github.com/utreexo/utreexo v0.1.4 h1:jygjZscJEzab7woP7aB6YWUKjhsV5Mrbjj873inhwR8=
+github.com/utreexo/utreexo v0.1.4/go.mod h1:RT9JpZADhLr2YJVBgp48tmUxVeAHaAbOSr6p6nAEJpI=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
The updated library fixes a bug found during adding elements to the accumulator. The new library avoids bugs for both bridges and csns.