### PR TITLE
blockchain, sizehelper: move sizehelper to separate package

### DIFF
--- a/blockchain/internal/sizehelper/sizehelper_test.go
+++ b/blockchain/internal/sizehelper/sizehelper_test.go
@@ -1,11 +1,29 @@
 // Copyright (c) 2023 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
-package blockchain
+package sizehelper
 
 import (
 	"math"
 	"testing"
+)
+
+const (
+	// outpointSize is the size of an outpoint.
+	//
+	// This value is calculated by running the following:
+	//	unsafe.Sizeof(wire.OutPoint{})
+	outpointSize = 36
+
+	// uint64Size is the size of an uint64 allocated in memory.
+	uint64Size = 8
+
+	// bucketSize is the size of the bucket in the cache map.  Exact
+	// calculation is (16 + keysize*8 + valuesize*8) where for the map of:
+	// map[wire.OutPoint]*UtxoEntry would have a keysize=36 and valuesize=8.
+	//
+	// https://github.com/golang/go/issues/34561#issuecomment-536115805
+	bucketSize = 16 + uint64Size*outpointSize + uint64Size*uint64Size
 )
 
 // calculateEntries returns a number of entries that will make the map allocate
@@ -35,9 +53,9 @@ func TestCalculateEntries(t *testing.T) {
 		// So to see if the calculate entries function is working correctly,
 		// we get the rough map size for i entries, then calculate the entries
 		// for that map size.  If the size is the same, the function is correct.
-		roughMapSize := calculateRoughMapSize(i, bucketSize)
+		roughMapSize := CalculateRoughMapSize(i, bucketSize)
 		entries := calculateEntries(roughMapSize, bucketSize)
-		gotRoughMapSize := calculateRoughMapSize(entries, bucketSize)
+		gotRoughMapSize := CalculateRoughMapSize(entries, bucketSize)
 
 		if roughMapSize != gotRoughMapSize {
 			t.Errorf("For hint of %d, expected %v, got %v\n",
@@ -46,14 +64,14 @@ func TestCalculateEntries(t *testing.T) {
 
 		// Test that the entries returned are the maximum for the given map size.
 		// If we increment the entries by one, we should get a bigger map.
-		gotRoughMapSizeWrong := calculateRoughMapSize(entries+1, bucketSize)
+		gotRoughMapSizeWrong := CalculateRoughMapSize(entries+1, bucketSize)
 		if roughMapSize == gotRoughMapSizeWrong {
 			t.Errorf("For hint %d incremented by 1, expected %v, got %v\n",
 				i, gotRoughMapSizeWrong*2, gotRoughMapSizeWrong)
 		}
 
-		minEntries := calculateMinEntries(roughMapSize, bucketSize)
-		gotMinRoughMapSize := calculateRoughMapSize(minEntries, bucketSize)
+		minEntries := CalculateMinEntries(roughMapSize, bucketSize)
+		gotMinRoughMapSize := CalculateRoughMapSize(minEntries, bucketSize)
 		if roughMapSize != gotMinRoughMapSize {
 			t.Errorf("For hint of %d, expected %v, got %v\n",
 				i, roughMapSize, gotMinRoughMapSize)
@@ -61,7 +79,7 @@ func TestCalculateEntries(t *testing.T) {
 
 		// Can only test if they'll be half the size if the entries aren't 0.
 		if minEntries > 0 {
-			gotMinRoughMapSizeWrong := calculateRoughMapSize(minEntries-1, bucketSize)
+			gotMinRoughMapSizeWrong := CalculateRoughMapSize(minEntries-1, bucketSize)
 			if gotMinRoughMapSize == gotMinRoughMapSizeWrong {
 				t.Errorf("For hint %d decremented by 1, expected %v, got %v\n",
 					i, gotRoughMapSizeWrong/2, gotRoughMapSizeWrong)

--- a/blockchain/utreexoio.go
+++ b/blockchain/utreexoio.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/utreexo/utreexo"
+	"github.com/utreexo/utreexod/blockchain/internal/sizehelper"
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
 )
 
@@ -211,12 +212,12 @@ func calcNumEntries(bucketSize uintptr, maxMemoryUsage int64) ([]int, int) {
 	totalElemCount := 0
 	totalMapSize := int64(0)
 	for maxMemoryUsage > totalMapSize {
-		numMaxElements := calculateMinEntries(int(maxMemoryUsage-totalMapSize), nodesMapBucketSize)
+		numMaxElements := sizehelper.CalculateMinEntries(int(maxMemoryUsage-totalMapSize), nodesMapBucketSize)
 		if numMaxElements == 0 {
 			break
 		}
 
-		mapSize := int64(calculateRoughMapSize(numMaxElements, nodesMapBucketSize))
+		mapSize := int64(sizehelper.CalculateRoughMapSize(numMaxElements, nodesMapBucketSize))
 		if maxMemoryUsage <= totalMapSize+mapSize {
 			break
 		}

--- a/blockchain/utreexoio_test.go
+++ b/blockchain/utreexoio_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/utreexo/utreexo"
+	"github.com/utreexo/utreexod/blockchain/internal/sizehelper"
 )
 
 // isApproximate returns if a and b are within the given percentage of each other.
@@ -47,7 +48,7 @@ func TestCalcNumEntries(t *testing.T) {
 
 		roughSize := 0
 		for _, entry := range entries {
-			roughSize += calculateRoughMapSize(entry, nodesMapBucketSize)
+			roughSize += sizehelper.CalculateRoughMapSize(entry, nodesMapBucketSize)
 		}
 
 		// Check if the roughSize is within 1% of test.maxSize.

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/utreexo/utreexod/blockchain/internal/sizehelper"
 	"github.com/utreexo/utreexod/btcutil"
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
 	"github.com/utreexo/utreexod/database"
@@ -62,7 +63,7 @@ func (ms *mapSlice) size() int {
 
 	var size int
 	for _, num := range ms.maxEntries {
-		size += calculateRoughMapSize(num, bucketSize)
+		size += sizehelper.CalculateRoughMapSize(num, bucketSize)
 	}
 
 	return size
@@ -151,14 +152,14 @@ func (ms *mapSlice) makeNewMap(totalEntryMemory uint64) map[wire.OutPoint]*UtxoE
 	// Get the size of the leftover memory.
 	memSize := ms.maxTotalMemoryUsage - totalEntryMemory
 	for _, maxNum := range ms.maxEntries {
-		memSize -= uint64(calculateRoughMapSize(maxNum, bucketSize))
+		memSize -= uint64(sizehelper.CalculateRoughMapSize(maxNum, bucketSize))
 	}
 
 	// Get a new map that's sized to house inside the leftover memory.
 	// -1 on the returned value will make the map allocate half as much total
 	// bytes.  This is done to make sure there's still room left for utxo
 	// entries to take up.
-	numMaxElements := calculateMinEntries(int(memSize), bucketSize+avgEntrySize)
+	numMaxElements := sizehelper.CalculateMinEntries(int(memSize), bucketSize+avgEntrySize)
 	numMaxElements -= 1
 	ms.maxEntries = append(ms.maxEntries, numMaxElements)
 	ms.maps = append(ms.maps, make(map[wire.OutPoint]*UtxoEntry, numMaxElements))
@@ -231,7 +232,7 @@ type utxoCache struct {
 func newUtxoCache(db database.DB, maxTotalMemoryUsage uint64) *utxoCache {
 	// While the entry isn't included in the map size, add the average size to the
 	// bucket size so we get some leftover space for entries to take up.
-	numMaxElements := calculateMinEntries(int(maxTotalMemoryUsage), bucketSize+avgEntrySize)
+	numMaxElements := sizehelper.CalculateMinEntries(int(maxTotalMemoryUsage), bucketSize+avgEntrySize)
 	numMaxElements -= 1
 
 	log.Infof("Pre-alloacting for %d MiB: ", maxTotalMemoryUsage/(1024*1024)+1)

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/utreexo/utreexod/blockchain/internal/sizehelper"
 	"github.com/utreexo/utreexod/btcutil"
 	"github.com/utreexo/utreexod/chaincfg"
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
@@ -44,7 +45,7 @@ func TestMapSlice(t *testing.T) {
 	for _, test := range tests {
 		m := make(map[wire.OutPoint]*UtxoEntry)
 
-		maxSize := calculateRoughMapSize(1000, bucketSize)
+		maxSize := sizehelper.CalculateRoughMapSize(1000, bucketSize)
 
 		maxEntriesFirstMap := 500
 		ms1 := make(map[wire.OutPoint]*UtxoEntry, maxEntriesFirstMap)
@@ -130,7 +131,7 @@ func TestMapsliceConcurrency(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		maxSize := calculateRoughMapSize(1000, bucketSize)
+		maxSize := sizehelper.CalculateRoughMapSize(1000, bucketSize)
 
 		maxEntriesFirstMap := 500
 		ms1 := make(map[wire.OutPoint]*UtxoEntry, maxEntriesFirstMap)

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -14,6 +14,38 @@ import (
 	"github.com/utreexo/utreexod/wire"
 )
 
+// These constants are related to bitcoin.
+const (
+	// outpointSize is the size of an outpoint.
+	//
+	// This value is calculated by running the following:
+	//	unsafe.Sizeof(wire.OutPoint{})
+	outpointSize = 36
+
+	// uint64Size is the size of an uint64 allocated in memory.
+	uint64Size = 8
+
+	// bucketSize is the size of the bucket in the cache map.  Exact
+	// calculation is (16 + keysize*8 + valuesize*8) where for the map of:
+	// map[wire.OutPoint]*UtxoEntry would have a keysize=36 and valuesize=8.
+	//
+	// https://github.com/golang/go/issues/34561#issuecomment-536115805
+	bucketSize = 16 + uint64Size*outpointSize + uint64Size*uint64Size
+
+	// This value is calculated by running the following on a 64-bit system:
+	//   unsafe.Sizeof(UtxoEntry{})
+	baseEntrySize = 40
+
+	// pubKeyHashLen is the length of a P2PKH script.
+	pubKeyHashLen = 25
+
+	// avgEntrySize is how much each entry we expect it to be.  Since most
+	// txs are p2pkh, we can assume the entry to be more or less the size
+	// of a p2pkh tx.  We add on 7 to make it 32 since 64 bit systems will
+	// align by 8 bytes.
+	avgEntrySize = baseEntrySize + (pubKeyHashLen + 7)
+)
+
 // txoFlags is a bitmask defining additional information and state for a
 // transaction output in a utxo view.
 type txoFlags uint8


### PR DESCRIPTION
This is done so that some of the code in package blockchain can be separated out into other packages to better guarntees that there isn't unexported code that is being accessed by a function that shouldn't be accessing it.