### PR TITLE
sizehelper, blockchain: move CalcNumEntries code to sizehelper package and fix bugs

### DIFF
--- a/blockchain/internal/sizehelper/sizehelper.go
+++ b/blockchain/internal/sizehelper/sizehelper.go
@@ -158,6 +158,33 @@ func CalculateMinEntries(totalBytes int, bucketSize int) int {
 	return (int(loadFactorNum * (bucketShift(B) / loadFactorDen))) + 1
 }
 
+// CalcNumEntries returns a list of ints that represent how much entries a map
+// should allocate for to stay under the maxMemoryUsage and an int that's a sum
+// of the returned list of ints.
+func CalcNumEntries(bucketSize uintptr, maxMemoryUsage int64) ([]int, int) {
+	entries := []int{}
+
+	totalElemCount := 0
+	totalMapSize := int64(0)
+	for maxMemoryUsage > totalMapSize {
+		numMaxElements := CalculateMinEntries(int(maxMemoryUsage-totalMapSize), int(bucketSize))
+		if numMaxElements == 0 {
+			break
+		}
+
+		mapSize := int64(CalculateRoughMapSize(numMaxElements, bucketSize))
+		if maxMemoryUsage <= totalMapSize+mapSize {
+			break
+		}
+		totalMapSize += mapSize
+
+		entries = append(entries, numMaxElements)
+		totalElemCount += numMaxElements
+	}
+
+	return entries, totalElemCount
+}
+
 // mulUintptr returns a * b and whether the multiplication overflowed.
 // On supported platforms this is an intrinsic lowered by the compiler.
 func mulUintptr(a, b uintptr) (uintptr, bool) {

--- a/blockchain/internal/sizehelper/sizehelper.go
+++ b/blockchain/internal/sizehelper/sizehelper.go
@@ -174,7 +174,14 @@ func CalcNumEntries(bucketSize uintptr, maxMemoryUsage int64) ([]int, int) {
 
 		mapSize := int64(CalculateRoughMapSize(numMaxElements, bucketSize))
 		if maxMemoryUsage <= totalMapSize+mapSize {
-			break
+			// If the totalMapSize + new map is greater than the maxMemoryUsage,
+			// try halving the memory being allocated by doing a -1 on the numMaxElements
+			// count. If it's still over, just break.
+			numMaxElements -= 1
+			mapSize = int64(CalculateRoughMapSize(numMaxElements, bucketSize))
+			if maxMemoryUsage <= totalMapSize+mapSize {
+				break
+			}
 		}
 		totalMapSize += mapSize
 

--- a/blockchain/utreexoio.go
+++ b/blockchain/utreexoio.go
@@ -203,33 +203,6 @@ func (ms *nodesMapSlice) deleteMaps() {
 	}
 }
 
-// calcNumEntries returns a list of ints that represent how much entries a map
-// should allocate for to stay under the maxMemoryUsage and an int that's a sum
-// of the returned list of ints.
-func calcNumEntries(bucketSize uintptr, maxMemoryUsage int64) ([]int, int) {
-	entries := []int{}
-
-	totalElemCount := 0
-	totalMapSize := int64(0)
-	for maxMemoryUsage > totalMapSize {
-		numMaxElements := sizehelper.CalculateMinEntries(int(maxMemoryUsage-totalMapSize), nodesMapBucketSize)
-		if numMaxElements == 0 {
-			break
-		}
-
-		mapSize := int64(sizehelper.CalculateRoughMapSize(numMaxElements, nodesMapBucketSize))
-		if maxMemoryUsage <= totalMapSize+mapSize {
-			break
-		}
-		totalMapSize += mapSize
-
-		entries = append(entries, numMaxElements)
-		totalElemCount += numMaxElements
-	}
-
-	return entries, totalElemCount
-}
-
 // createMaps creates a slice of maps and returns the total count that the maps
 // can handle. maxEntries are also set along with the newly created maps.
 func (ms *nodesMapSlice) createMaps(maxMemoryUsage int64) int64 {
@@ -239,7 +212,7 @@ func (ms *nodesMapSlice) createMaps(maxMemoryUsage int64) int64 {
 
 	// Get the entry count for the maps we'll allocate.
 	var totalElemCount int
-	ms.maxEntries, totalElemCount = calcNumEntries(nodesMapBucketSize, maxMemoryUsage)
+	ms.maxEntries, totalElemCount = sizehelper.CalcNumEntries(nodesMapBucketSize, maxMemoryUsage)
 
 	// maxMemoryUsage that's smaller than the minimum map size will return a totalElemCount
 	// that's equal to 0.
@@ -632,7 +605,7 @@ func (ms *cachedLeavesMapSlice) createMaps(maxMemoryUsage int64) int64 {
 
 	// Get the entry count for the maps we'll allocate.
 	var totalElemCount int
-	ms.maxEntries, totalElemCount = calcNumEntries(nodesMapBucketSize, maxMemoryUsage)
+	ms.maxEntries, totalElemCount = sizehelper.CalcNumEntries(cachedLeavesMapBucketSize, maxMemoryUsage)
 
 	// maxMemoryUsage that's smaller than the minimum map size will return a totalElemCount
 	// that's equal to 0.

--- a/blockchain/utreexoio_test.go
+++ b/blockchain/utreexoio_test.go
@@ -3,61 +3,13 @@ package blockchain
 import (
 	"crypto/sha256"
 	"encoding/binary"
-	"math"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
 
 	"github.com/utreexo/utreexo"
-	"github.com/utreexo/utreexod/blockchain/internal/sizehelper"
 )
-
-// isApproximate returns if a and b are within the given percentage of each other.
-func isApproximate(a, b, percentage float64) bool {
-	// Calculate % of 'a'
-	percentageOfA := math.Abs(a) * percentage
-
-	// Calculate the absolute difference between 'a' and 'b'
-	difference := math.Abs(a - b)
-
-	// Check if the absolute difference is less than or equal to 1% of 'a'
-	return difference <= percentageOfA
-}
-
-func TestCalcNumEntries(t *testing.T) {
-	tests := []struct {
-		maxSize    int64
-		bucketSize uintptr
-	}{
-		{100 * 1024 * 1024, nodesMapBucketSize},
-		{150 * 1024 * 1024, nodesMapBucketSize},
-		{250 * 1024 * 1024, nodesMapBucketSize},
-		{1000 * 1024 * 1024, nodesMapBucketSize},
-		{10000 * 1024 * 1024, nodesMapBucketSize},
-
-		{100 * 1024 * 1024, cachedLeavesMapBucketSize},
-		{150 * 1024 * 1024, cachedLeavesMapBucketSize},
-		{250 * 1024 * 1024, cachedLeavesMapBucketSize},
-		{1000 * 1024 * 1024, cachedLeavesMapBucketSize},
-		{10000 * 1024 * 1024, cachedLeavesMapBucketSize},
-	}
-
-	for _, test := range tests {
-		entries, _ := calcNumEntries(test.bucketSize, test.maxSize)
-
-		roughSize := 0
-		for _, entry := range entries {
-			roughSize += sizehelper.CalculateRoughMapSize(entry, nodesMapBucketSize)
-		}
-
-		// Check if the roughSize is within 1% of test.maxSize.
-		if !isApproximate(float64(test.maxSize), float64(roughSize), 0.01) {
-			t.Fatalf("Expected value to be approximately %v but got %v",
-				test.maxSize, roughSize)
-		}
-	}
-}
 
 func TestNodesMapSliceMaxCacheElems(t *testing.T) {
 	_, maxCacheElems := newNodesMapSlice(0)


### PR DESCRIPTION
The test code for CalcNumEntries is moved and is made better by adding
more test cases for it. This catches the bug where the current code
isn't accurate to 1% of the requested maxSize.

CalcNumEntries wasn't so accurate as it was leaving some room that
could've been utilized. The code is changed to check for more sizes
and is now accurate up to 0.1% of the requested maxSize.