### PR TITLE
btcjson, main, utreexoctl: add getbeststate command

### DIFF
--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -268,6 +268,15 @@ func NewGetBlockCountCmd() *GetBlockCountCmd {
 	return &GetBlockCountCmd{}
 }
 
+// GetBestStateCmd defines the getbeststate JSON-RPC command.
+type GetBestStateCmd struct{}
+
+// NewGetBestState returns a new instance which can be used to issue a
+// getbeststate JSON-RPC command.
+func NewGetBestState() *GetBestStateCmd {
+	return &GetBestStateCmd{}
+}
+
 // FilterTypeName defines the type used in the getblockfilter JSON-RPC command for the
 // filter type field.
 type FilterTypeName string
@@ -1273,6 +1282,7 @@ func init() {
 	MustRegisterCmd("fundrawtransaction", (*FundRawTransactionCmd)(nil), flags)
 	MustRegisterCmd("getaddednodeinfo", (*GetAddedNodeInfoCmd)(nil), flags)
 	MustRegisterCmd("getbestblockhash", (*GetBestBlockHashCmd)(nil), flags)
+	MustRegisterCmd("getbeststate", (*GetBestStateCmd)(nil), flags)
 	MustRegisterCmd("getblock", (*GetBlockCmd)(nil), flags)
 	MustRegisterCmd("getblockchaininfo", (*GetBlockChainInfoCmd)(nil), flags)
 	MustRegisterCmd("getblockcount", (*GetBlockCountCmd)(nil), flags)

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -149,6 +149,18 @@ type GetBlockVerboseTxResult struct {
 	NextHash      string        `json:"nextblockhash,omitempty"`
 }
 
+// GetBestStateResult models the data from the getbeststate command.
+type GetBestStateResult struct {
+	Hash        string `json:"hash"`        // The hash of the block.
+	Height      int32  `json:"height"`      // The height of the block.
+	Bits        uint32 `json:"bits"`        // The difficulty bits of the block.
+	BlockSize   uint64 `json:"blocksize"`   // The size of the block.
+	BlockWeight uint64 `json:"blockweight"` // The weight of the block.
+	NumTxns     uint64 `json:"numtxns"`     // The number of txns in the block.
+	TotalTxns   uint64 `json:"totaltxns"`   // The total number of txns in the chain.
+	MedianTime  int64  `json:"mediantime"`  // Median time as per CalcPastMedianTime.
+}
+
 // GetChainTipsResult models the data from the getchaintips command.
 type GetChainTipsResult struct {
 	Height    int32  `json:"height"`

--- a/cmd/utreexoctl/version.go
+++ b/cmd/utreexoctl/version.go
@@ -17,7 +17,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	appMajor uint = 0
-	appMinor uint = 1
+	appMinor uint = 2
 	appPatch uint = 0
 
 	// appPreRelease MUST only contain characters from semanticAlphabet

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -148,6 +148,7 @@ var rpcHandlersBeforeInit = map[string]commandHandler{
 	"getaddednodeinfo":                   handleGetAddedNodeInfo,
 	"getbestblock":                       handleGetBestBlock,
 	"getbestblockhash":                   handleGetBestBlockHash,
+	"getbeststate":                       handleGetBestState,
 	"getblock":                           handleGetBlock,
 	"getblockchaininfo":                  handleGetBlockChainInfo,
 	"getblockcount":                      handleGetBlockCount,
@@ -285,6 +286,7 @@ var rpcLimited = map[string]struct{}{
 	"estimatefee":                {},
 	"getbestblock":               {},
 	"getbestblockhash":           {},
+	"getbeststate":               {},
 	"getblock":                   {},
 	"getblockcount":              {},
 	"getblockhash":               {},
@@ -1189,6 +1191,23 @@ func handleGetBestBlock(s *rpcServer, cmd interface{}, closeChan <-chan struct{}
 func handleGetBestBlockHash(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
 	best := s.cfg.Chain.BestSnapshot()
 	return best.Hash.String(), nil
+}
+
+// handleGetBestState implements the getbeststate command.
+func handleGetBestState(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	best := s.cfg.Chain.BestSnapshot()
+	reply := btcjson.GetBestStateResult{
+		Hash:        best.Hash.String(),
+		Height:      best.Height,
+		Bits:        best.Bits,
+		BlockSize:   best.BlockSize,
+		BlockWeight: best.BlockWeight,
+		NumTxns:     best.NumTxns,
+		TotalTxns:   best.TotalTxns,
+		MedianTime:  best.MedianTime.Unix(),
+	}
+
+	return reply, nil
 }
 
 // getDifficultyRatio returns the proof-of-work difficulty as a multiple of the

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -189,6 +189,19 @@ var helpDescsEnUS = map[string]string{
 	"getbestblockhash--synopsis": "Returns the hash of the of the best (most recent) block in the longest block chain.",
 	"getbestblockhash--result0":  "The hex-encoded block hash",
 
+	// GetBestStateCmd help.
+	"getbeststate--synopsis": "Returns the current best state and the information associated with it in the longest block chain.",
+
+	// GetBestStateResult help.
+	"getbeststateresult-hash":        "The hash of the block",
+	"getbeststateresult-height":      "The height of the block",
+	"getbeststateresult-bits":        "The difficultly bits of the block",
+	"getbeststateresult-blocksize":   "The blocksize of the block",
+	"getbeststateresult-blockweight": "The blockweight of the block",
+	"getbeststateresult-numtxns":     "The number of transactions in the block",
+	"getbeststateresult-totaltxns":   "The total number of transactions in the longest chain",
+	"getbeststateresult-mediantime":  "The median time of the block in unix time",
+
 	// GetBlockCmd help.
 	"getblock--synopsis":   "Returns information about a block given its hash.",
 	"getblock-hash":        "The hash of the block",
@@ -894,6 +907,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getaddednodeinfo":                   {(*[]string)(nil), (*[]btcjson.GetAddedNodeInfoResult)(nil)},
 	"getbestblock":                       {(*btcjson.GetBestBlockResult)(nil)},
 	"getbestblockhash":                   {(*string)(nil)},
+	"getbeststate":                       {(*btcjson.GetBestStateResult)(nil)},
 	"getblock":                           {(*string)(nil), (*btcjson.GetBlockVerboseResult)(nil)},
 	"getblockcount":                      {(*int64)(nil)},
 	"getblockhash":                       {(*string)(nil)},


### PR DESCRIPTION
The getbeststate rpc mainly helps with setting new assumeutreexo points
as the beststate information is necessary for setting them.