### PR TITLE
connmgr: ignore dnsseeds that don't support filetering for utreexo nodes

### DIFF
--- a/connmgr/seed.go
+++ b/connmgr/seed.go
@@ -35,6 +35,12 @@ func SeedFromDNS(chainParams *chaincfg.Params, reqServices wire.ServiceFlag,
 
 	for _, dnsseed := range chainParams.DNSSeeds {
 		var host string
+
+		// Ignore seeds that don't have filtering the reqServices include utreexo bit.
+		if !dnsseed.HasFiltering && reqServices&wire.SFNodeUtreexo == wire.SFNodeUtreexo {
+			continue
+		}
+
 		if !dnsseed.HasFiltering || reqServices == wire.SFNodeNetwork {
 			host = dnsseed.Host
 		} else {


### PR DESCRIPTION
Utreexo nodes need to be connected to other utreexo nodes to get txs and blocks. Ignore the seeds that do not support filtering as they gives nodes that don't provide the required data.