### PR TITLE
blockchain, wire: rename ToString() to String()

### DIFF
--- a/blockchain/utreexoviewpoint.go
+++ b/blockchain/utreexoviewpoint.go
@@ -960,7 +960,7 @@ func (b *BlockChain) VerifyUData(ud *wire.UData, txIns []*wire.TxIn, remember bo
 		for i, txIn := range txIns {
 			leafHash := ud.LeafDatas[i].LeafHash()
 			str += fmt.Sprintf("txIn: %s, leafdata: %s, hash %s\n", txIn.PreviousOutPoint.String(),
-				ud.LeafDatas[i].ToString(), hex.EncodeToString(leafHash[:]))
+				ud.LeafDatas[i].String(), hex.EncodeToString(leafHash[:]))
 		}
 		str += fmt.Sprintf("err: %s", err.Error())
 		return fmt.Errorf(str)

--- a/wire/leaf.go
+++ b/wire/leaf.go
@@ -133,8 +133,8 @@ func (l *LeafData) LeafHash() [32]byte {
 	return *(*[32]byte)(digest.Sum(nil))
 }
 
-// ToString turns a LeafData into a string for logging.
-func (l *LeafData) ToString() (s string) {
+// String turns a LeafData into a string for logging.
+func (l *LeafData) String() (s string) {
 	s += fmt.Sprintf("BlockHash:%s,", hex.EncodeToString(l.BlockHash[:]))
 	s += fmt.Sprintf("OutPoint:%s,", l.OutPoint.String())
 	s += fmt.Sprintf("Amount:%d,", l.Amount)


### PR DESCRIPTION
Doing this allows pretty printing because for %v go will call String() instead of printing out a byte slice.