### PR TITLE
electrum: handle batch rpc requests

### DIFF
--- a/electrum/server.go
+++ b/electrum/server.go
@@ -912,6 +912,69 @@ func (s *ElectrumServer) writeErrorResponse(conn net.Conn, rpcError btcjson.RPCE
 	s.writeChan <- []connAndBytes{{conn, bytes}}
 }
 
+func (s *ElectrumServer) handleSingleMsg(msg btcjson.Request, conn net.Conn) {
+	log.Debugf("unmarshalled %v from conn %s\n", msg, conn.RemoteAddr().String())
+	handler, found := rpcHandlers[msg.Method]
+	if !found || handler == nil {
+		log.Warnf("handler not found for method %v. Sending error msg to %v",
+			msg.Method, conn.RemoteAddr().String())
+		pid := &msg.ID
+		s.writeErrorResponse(conn, *btcjson.ErrRPCMethodNotFound, pid)
+		return
+	}
+
+	result, err := handler(s, &msg, conn, nil)
+	if err != nil {
+		log.Warnf("Errored while handling method %s. Sending error message to %v err: %v\n",
+			msg.Method, conn.RemoteAddr().String(), err)
+
+		pid := &msg.ID
+		rpcError := btcjson.RPCError{
+			Code:    1,
+			Message: err.Error(),
+		}
+		s.writeErrorResponse(conn, rpcError, pid)
+		return
+	}
+
+	marshalledResult, err := json.Marshal(result)
+	if err != nil {
+		log.Warnf("Errored while marshaling result for method %s. Sending error message to %v err: %v\n",
+			msg.Method, conn.RemoteAddr().String(), err)
+		rpcError := btcjson.RPCError{
+			Code: btcjson.ErrRPCInternal.Code,
+			Message: fmt.Sprintf("%s: error: %s",
+				btcjson.ErrRPCInternal.Message, err.Error()),
+		}
+		pid := &msg.ID
+		s.writeErrorResponse(conn, rpcError, pid)
+		return
+	}
+	pid := &msg.ID
+	resp := btcjson.Response{
+		Jsonrpc: btcjson.RpcVersion2,
+		Result:  json.RawMessage(marshalledResult),
+		ID:      pid,
+	}
+	bytes, err := json.Marshal(resp)
+	if err != nil {
+		log.Warnf("Errored while marshaling response for method %s. Sending error message to %v err: %v\n",
+			msg.Method, conn.RemoteAddr().String(), err)
+		rpcError := btcjson.RPCError{
+			Code: btcjson.ErrRPCInternal.Code,
+			Message: fmt.Sprintf("%s: error: %s",
+				btcjson.ErrRPCInternal.Message, err.Error()),
+		}
+		pid := &msg.ID
+		s.writeErrorResponse(conn, rpcError, pid)
+		return
+	}
+	bytes = append(bytes, delim)
+
+	log.Debugf("put %v to be written to %v\n", result, conn.RemoteAddr().String())
+	s.writeChan <- []connAndBytes{{conn, bytes}}
+}
+
 func (s *ElectrumServer) handleConnection(conn net.Conn) {
 	// The timer is stopped when a new message is received and reset after it
 	// is processed.
@@ -949,70 +1012,7 @@ func (s *ElectrumServer) handleConnection(conn net.Conn) {
 			continue
 		}
 
-		log.Debugf("unmarshalled %v from conn %s\n", msg, conn.RemoteAddr().String())
-		handler, found := rpcHandlers[msg.Method]
-		if !found || handler == nil {
-			log.Warnf("handler not found for method %v. Sending error msg to %v",
-				msg.Method, conn.RemoteAddr().String())
-			pid := &msg.ID
-			s.writeErrorResponse(conn, *btcjson.ErrRPCMethodNotFound, pid)
-			idleTimer.Reset(idleTimeout)
-			continue
-		}
-
-		result, err := handler(s, &msg, conn, nil)
-		if err != nil {
-			log.Warnf("Errored while handling method %s. Sending error message to %v err: %v\n",
-				msg.Method, conn.RemoteAddr().String(), err)
-
-			pid := &msg.ID
-			rpcError := btcjson.RPCError{
-				Code:    1,
-				Message: err.Error(),
-			}
-			s.writeErrorResponse(conn, rpcError, pid)
-			idleTimer.Reset(idleTimeout)
-			continue
-		}
-
-		marshalledResult, err := json.Marshal(result)
-		if err != nil {
-			log.Warnf("Errored while marshaling result for method %s. Sending error message to %v err: %v\n",
-				msg.Method, conn.RemoteAddr().String(), err)
-			rpcError := btcjson.RPCError{
-				Code: btcjson.ErrRPCInternal.Code,
-				Message: fmt.Sprintf("%s: error: %s",
-					btcjson.ErrRPCInternal.Message, err.Error()),
-			}
-			pid := &msg.ID
-			s.writeErrorResponse(conn, rpcError, pid)
-			continue
-		}
-		pid := &msg.ID
-		resp := btcjson.Response{
-			Jsonrpc: btcjson.RpcVersion2,
-			Result:  json.RawMessage(marshalledResult),
-			ID:      pid,
-		}
-		bytes, err := json.Marshal(resp)
-		if err != nil {
-			log.Warnf("Errored while marshaling response for method %s. Sending error message to %v err: %v\n",
-				msg.Method, conn.RemoteAddr().String(), err)
-			rpcError := btcjson.RPCError{
-				Code: btcjson.ErrRPCInternal.Code,
-				Message: fmt.Sprintf("%s: error: %s",
-					btcjson.ErrRPCInternal.Message, err.Error()),
-			}
-			pid := &msg.ID
-			s.writeErrorResponse(conn, rpcError, pid)
-			idleTimer.Reset(idleTimeout)
-			continue
-		}
-		bytes = append(bytes, delim)
-
-		log.Debugf("put %v to be written to %v\n", result, conn.RemoteAddr().String())
-		s.writeChan <- []connAndBytes{{conn, bytes}}
-
+		s.handleSingleMsg(msg, conn)
 		idleTimer.Reset(idleTimeout)
 	}
 


### PR DESCRIPTION
Some clients will send batched rpc requests. To handle this, we assume
every request is a batched rpc request and fall back to unmarshalling as
a single request when it errors.