### PR TITLE
wire, main, indexers: remove unconfirmed marker

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -177,7 +177,7 @@ func (idx *FlatUtreexoProofIndex) Init(chain *blockchain.BlockChain) error {
 		}
 		r := bytes.NewReader(proofBytes)
 		ud := new(wire.UData)
-		err = ud.DeserializeCompact(r, udataSerializeBool, 0)
+		err = ud.DeserializeCompact(r)
 		if err != nil {
 			return err
 		}
@@ -827,7 +827,7 @@ func (idx *FlatUtreexoProofIndex) FetchUtreexoProof(height int32, excludeAccProo
 			return nil, err
 		}
 	} else {
-		err = ud.DeserializeCompact(r, udataSerializeBool, 0)
+		err = ud.DeserializeCompact(r)
 		if err != nil {
 			return nil, err
 		}
@@ -923,7 +923,7 @@ func (idx *FlatUtreexoProofIndex) FetchMultiUtreexoProof(height int32) (
 	// Deserialize the utreexo data that will provide the proof for the upcoming
 	// blocks in the interval.
 	multiUd := new(wire.UData)
-	err = multiUd.DeserializeCompact(r, udataSerializeBool, 0)
+	err = multiUd.DeserializeCompact(r)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -967,7 +967,7 @@ func (idx *FlatUtreexoProofIndex) FetchRemembers(height int32) ([]uint32, error)
 // storeProof serializes and stores the utreexo data in the proof state.
 func (idx *FlatUtreexoProofIndex) storeProof(height int32, excludeAccProof bool, ud *wire.UData) error {
 	if excludeAccProof {
-		bytesBuf := bytes.NewBuffer(make([]byte, 0, ud.SerializeUxtoDataSizeCompact(udataSerializeBool)))
+		bytesBuf := bytes.NewBuffer(make([]byte, 0, ud.SerializeUxtoDataSizeCompact()))
 		err := ud.SerializeCompactNoAccProof(bytesBuf)
 		if err != nil {
 			return err
@@ -978,8 +978,8 @@ func (idx *FlatUtreexoProofIndex) storeProof(height int32, excludeAccProof bool,
 			return fmt.Errorf("store proof err. %v", err)
 		}
 	} else {
-		bytesBuf := bytes.NewBuffer(make([]byte, 0, ud.SerializeSizeCompact(udataSerializeBool)))
-		err := ud.SerializeCompact(bytesBuf, udataSerializeBool)
+		bytesBuf := bytes.NewBuffer(make([]byte, 0, ud.SerializeSizeCompact()))
+		err := ud.SerializeCompact(bytesBuf)
 		if err != nil {
 			return err
 		}
@@ -1000,7 +1000,7 @@ func (idx *FlatUtreexoProofIndex) storeMultiBlockProof(height int32, ud, multiUd
 	dels []utreexo.Hash) error {
 
 	size := ud.SerializeSizeCompactNoAccProof()
-	size += multiUd.SerializeSizeCompact(udataSerializeBool)
+	size += multiUd.SerializeSizeCompact()
 	size += (len(dels) * chainhash.HashSize) + 4 // 4 for uint32 size
 
 	bytesBuf := bytes.NewBuffer(make([]byte, 0, size))
@@ -1010,7 +1010,7 @@ func (idx *FlatUtreexoProofIndex) storeMultiBlockProof(height int32, ud, multiUd
 	}
 
 	multiUd.LeafDatas = []wire.LeafData{}
-	err = multiUd.SerializeCompact(bytesBuf, udataSerializeBool)
+	err = multiUd.SerializeCompact(bytesBuf)
 	if err != nil {
 		return err
 	}

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -25,10 +25,6 @@ const (
 	nodesDBDirName         = "nodes"
 	cachedLeavesDBDirName  = "cachedleaves"
 	defaultUtreexoFileName = "forest.dat"
-
-	// udataSerializeBool defines the argument that should be passed to the
-	// serialize and deserialize functions for udata.
-	udataSerializeBool = false
 )
 
 // UtreexoConfig is a descriptor which specifies the Utreexo state instance configuration.

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -151,7 +151,7 @@ func (idx *UtreexoProofIndex) Init(chain *blockchain.BlockChain) error {
 			}
 			r := bytes.NewReader(proofBytes)
 
-			err = ud.DeserializeCompact(r, udataSerializeBool, 0)
+			err = ud.DeserializeCompact(r)
 			if err != nil {
 				return err
 			}
@@ -399,7 +399,7 @@ func (idx *UtreexoProofIndex) FetchUtreexoProof(hash *chainhash.Hash) (*wire.UDa
 		}
 		r := bytes.NewReader(proofBytes)
 
-		err = ud.DeserializeCompact(r, udataSerializeBool, 0)
+		err = ud.DeserializeCompact(r)
 		if err != nil {
 			return err
 		}
@@ -606,10 +606,10 @@ func DropUtreexoProofIndex(db database.DB, dataDir string, interrupt <-chan stru
 // TODO Use the compact serialization.
 func dbStoreUtreexoProof(dbTx database.Tx, hash *chainhash.Hash, ud *wire.UData) error {
 	// Pre-allocated the needed buffer.
-	udSize := ud.SerializeSizeCompact(udataSerializeBool)
+	udSize := ud.SerializeSizeCompact()
 	buf := bytes.NewBuffer(make([]byte, 0, udSize))
 
-	err := ud.SerializeCompact(buf, udataSerializeBool)
+	err := ud.SerializeCompact(buf)
 	if err != nil {
 		return err
 	}

--- a/blockchain/indexers/utreexoproofstats.go
+++ b/blockchain/indexers/utreexoproofstats.go
@@ -71,7 +71,7 @@ func (ps *proofStats) UpdateUDStats(excludeAccProof bool, ud *wire.UData) {
 	ps.TgCount += uint64(len(ud.AccProof.Targets))
 
 	// Update leaf data size.
-	ps.LdSize += uint64(ud.SerializeUxtoDataSizeCompact(false))
+	ps.LdSize += uint64(ud.SerializeUxtoDataSizeCompact())
 	ps.LdCount += uint64(len(ud.LeafDatas))
 
 	// Update proof size if the proof is to be included.

--- a/server.go
+++ b/server.go
@@ -2722,7 +2722,7 @@ func (s *server) GetProofSizeforTx(msgTx *wire.MsgTx) (int, int, error) {
 		return 0, 0, err
 	}
 
-	return ud.SerializeAccSizeCompact(), ud.SerializeUxtoDataSizeCompact(true), nil
+	return ud.SerializeAccSizeCompact(), ud.SerializeUxtoDataSizeCompact(), nil
 }
 
 // UpdateProofBytesRead updates the bytes for utreexo proofs that would have
@@ -2739,7 +2739,7 @@ func (s *server) UpdateProofBytesRead(msgTx *wire.MsgTx) error {
 
 	} else if s.chain.IsUtreexoViewActive() {
 		if msgTx.UData != nil {
-			s.addProofBytesReceived(uint64(msgTx.UData.SerializeSizeCompact(true)))
+			s.addProofBytesReceived(uint64(msgTx.UData.SerializeSizeCompact()))
 			s.addAccBytesReceived(uint64(msgTx.UData.SerializeAccSizeCompact()))
 		}
 	}
@@ -2761,7 +2761,7 @@ func (s *server) UpdateProofBytesWritten(msgTx *wire.MsgTx) error {
 
 	} else if s.chain.IsUtreexoViewActive() {
 		if msgTx.UData != nil {
-			s.addProofBytesSent(uint64(msgTx.UData.SerializeSizeCompact(true)))
+			s.addProofBytesSent(uint64(msgTx.UData.SerializeSizeCompact()))
 			s.addAccBytesSent(uint64(msgTx.UData.SerializeAccSizeCompact()))
 		}
 	}

--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -115,7 +115,7 @@ func (msg *MsgBlock) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) er
 	// checked for length, this probably is ok. But do think of
 	// a better solution.
 	msg.UData = new(UData)
-	err = msg.UData.DeserializeCompact(r, false, 0)
+	err = msg.UData.DeserializeCompact(r)
 	if err != nil {
 		if enc&UtreexoEncoding == UtreexoEncoding {
 			return err
@@ -232,7 +232,7 @@ func (msg *MsgBlock) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) er
 			str := "utreexo encoding specified but MsgBlock.UData field is nil"
 			return messageError("MsgBlock.BtcEncode", str)
 		}
-		err = msg.UData.SerializeCompact(w, false)
+		err = msg.UData.SerializeCompact(w)
 		if err != nil {
 			return err
 		}

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -681,7 +681,7 @@ func (msg *MsgTx) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) error
 
 	if enc&UtreexoEncoding == UtreexoEncoding {
 		msg.UData = new(UData)
-		err = msg.UData.DeserializeCompact(r, true, len(msg.TxIn))
+		err = msg.UData.DeserializeCompact(r)
 		if err != nil {
 			return err
 		}
@@ -790,7 +790,7 @@ func (msg *MsgTx) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) error
 		// AccProof can be nil for transactions that are included in
 		// a block.
 		if msg.UData != nil {
-			err = msg.UData.SerializeCompact(w, true)
+			err = msg.UData.SerializeCompact(w)
 			if err != nil {
 				return err
 			}

--- a/wire/udata.go
+++ b/wire/udata.go
@@ -419,14 +419,8 @@ func DeserializeRemembers(r io.Reader) ([]uint32, error) {
 // leaf data is compact as you can't generate the correct hash.
 func HashesFromLeafDatas(leafDatas []LeafData) ([]utreexo.Hash, error) {
 	// make slice of hashes from leafdata
-	var unconfirmedCount int
 	delHashes := make([]utreexo.Hash, 0, len(leafDatas))
 	for _, ld := range leafDatas {
-		if ld.IsUnconfirmed() {
-			unconfirmedCount++
-			continue
-		}
-
 		// We can't calculate the correct hash if the leaf data is in
 		// the compact state.
 		if ld.IsCompact() {


### PR DESCRIPTION
The unconfirmed marker created a discrepancy between the proof sent out
for blocks and transactions. It was used for marking if a referenced tx
that was being spent was unconfirmed or not but it's removed in favor of
the node checking locally for the referenced tx. If the node is unable
to find all the referenced txs, the tx is put into the orphan pool.