### PR TITLE
indexers: only include positions that were found

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -872,8 +872,10 @@ func (idx *FlatUtreexoProofIndex) GenerateUDataPartial(dels []wire.LeafData, pos
 
 	targets := make([]uint64, len(delHashes))
 	for i, delHash := range delHashes {
-		pos, _ := idx.utreexoState.state.GetLeafPosition(delHash)
-		targets[i] = pos
+		pos, found := idx.utreexoState.state.GetLeafPosition(delHash)
+		if found {
+			targets[i] = pos
+		}
 	}
 
 	ud.AccProof = utreexo.Proof{

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -446,8 +446,10 @@ func (idx *UtreexoProofIndex) GenerateUDataPartial(dels []wire.LeafData, positio
 
 	targets := make([]uint64, len(delHashes))
 	for i, delHash := range delHashes {
-		pos, _ := idx.utreexoState.state.GetLeafPosition(delHash)
-		targets[i] = pos
+		pos, found := idx.utreexoState.state.GetLeafPosition(delHash)
+		if found {
+			targets[i] = pos
+		}
 	}
 	ud.AccProof = utreexo.Proof{
 		Targets: targets,


### PR DESCRIPTION
GetLeafPosition returns the position and a boolean indicating whether or not a hash was found. The boolean wasn't being checked which ended up with the hashes that weren't found where being included as a 0.

We omit the positions entirely in this commit if they were not found.