### PR TITLE
Add new getcfilters message for utreexo nodes

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1080,6 +1080,32 @@ func SerializeUtreexoRoots(numLeaves uint64, roots []utreexo.Hash) ([]byte, erro
 	return w.Bytes(), nil
 }
 
+// SerializeUtreexoRootsHash serializes the numLeaves and the roots into a byte slice.
+// it takes in a slice of chainhash.Hash instead of utreexo.Hash. chainhash.Hash is the hashed
+// value of the utreexo.Hash.
+func SerializeUtreexoRootsHash(numLeaves uint64, roots []*chainhash.Hash) ([]byte, error) {
+	// 8 byte NumLeaves + (32 byte roots * len(roots))
+	w := bytes.NewBuffer(make([]byte, 0, 8+(len(roots)*chainhash.HashSize)))
+
+	// Write the NumLeaves first.
+	var buf [8]byte
+	byteOrder.PutUint64(buf[:], numLeaves)
+	_, err := w.Write(buf[:])
+	if err != nil {
+		return nil, err
+	}
+
+	// Then write the roots.
+	for _, root := range roots {
+		_, err = w.Write(root[:])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return w.Bytes(), nil
+}
+
 // DeserializeUtreexoRoots deserializes the provided byte slice into numLeaves and roots.
 func DeserializeUtreexoRoots(serializedUView []byte) (uint64, []utreexo.Hash, error) {
 	totalLen := len(serializedUView)

--- a/blockchain/indexers/cfindex.go
+++ b/blockchain/indexers/cfindex.go
@@ -33,19 +33,22 @@ var (
 	// cfIndexKeys is an array of db bucket names used to house indexes of
 	// block hashes to cfilters.
 	cfIndexKeys = [][]byte{
-		[]byte("cf0byhashidx"),
+		[]byte("cf0byhashidx"), // bucket for basic filter indexes
+		[]byte("cf1byhashidx"), // bucket for UtreexoCFilter
 	}
 
 	// cfHeaderKeys is an array of db bucket names used to house indexes of
 	// block hashes to cf headers.
 	cfHeaderKeys = [][]byte{
 		[]byte("cf0headerbyhashidx"),
+		[]byte("cf1headerbyhashidx"),
 	}
 
 	// cfHashKeys is an array of db bucket names used to house indexes of
 	// block hashes to cf hashes.
 	cfHashKeys = [][]byte{
 		[]byte("cf0hashbyhashidx"),
+		[]byte("cf1hashbyhashidx"),
 	}
 
 	maxFilterType = uint8(len(cfHeaderKeys) - 1)

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -355,12 +355,11 @@ func (idx *UtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Bloc
 	}
 	blockHash := block.Hash()
 	var serializedUtreexo []byte
-	isCSN := true
 	var leaves uint64
 	var roots []*chainhash.Hash
 
 	// For compact state nodes
-	if isCSN {
+	if idx.chain.IsUtreexoViewActive() {
 		viewPoint, err := idx.chain.FetchUtreexoViewpoint(blockHash)
 		if err != nil {
 			return err

--- a/btcutil/gcs/builder/builder.go
+++ b/btcutil/gcs/builder/builder.go
@@ -369,3 +369,19 @@ func MakeHeaderForFilter(filter *gcs.Filter, prevHeader chainhash.Hash) (chainha
 	// above.
 	return chainhash.DoubleHashH(filterTip), nil
 }
+
+// MakeHeaderForUtreexoCFilter makes a filter chain header for a utreexoc filter, given the
+// filter data and the previous filter chain header.
+func MakeHeaderForUtreexoCFilter(filterData []byte, prevHeader chainhash.Hash) (chainhash.Hash, error) {
+	filterTip := make([]byte, 2*chainhash.HashSize)
+	filterHash := chainhash.DoubleHashH(filterData)
+
+	// In the buffer we created above we'll compute hash || prevHash as an
+	// intermediate value.
+	copy(filterTip, filterHash[:])
+	copy(filterTip[chainhash.HashSize:], prevHeader[:])
+
+	// The final filter hash is the double-sha256 of the hash computed
+	// above.
+	return chainhash.DoubleHashH(filterTip), nil
+}

--- a/server.go
+++ b/server.go
@@ -867,6 +867,7 @@ func (sp *serverPeer) OnGetCFilters(_ *peer.Peer, msg *wire.MsgGetCFilters) {
 	// filters that we actually currently maintain.
 	switch msg.FilterType {
 	case wire.GCSFilterRegular:
+	case wire.UtreexoCFilter:
 		break
 
 	default:
@@ -923,6 +924,7 @@ func (sp *serverPeer) OnGetCFHeaders(_ *peer.Peer, msg *wire.MsgGetCFHeaders) {
 	// headers for filters that we actually currently maintain.
 	switch msg.FilterType {
 	case wire.GCSFilterRegular:
+	case wire.UtreexoCFilter:
 		break
 
 	default:

--- a/wire/msgcfilter.go
+++ b/wire/msgcfilter.go
@@ -17,6 +17,7 @@ type FilterType uint8
 const (
 	// GCSFilterRegular is the regular filter type.
 	GCSFilterRegular FilterType = iota
+	UtreexoCFilter
 )
 
 const (


### PR DESCRIPTION
This is meant to be just a draft PR

Add support for new getcfilters message called `UtreexoCFilter`
When a new block is added, a new UtreexoCFilter filter is created and persisted on the node.
This filter is created by serializing the contents of the roots at that height.
When a node receives a getcfilters message, the logic doesn't change much, it handles it almost identical to how it deals with basic filters.