### PR TITLE
Make bridge nodes recoverable

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -760,6 +760,14 @@ func (b *BlockChain) connectBlock(node *blockNode, block *btcutil.Block,
 		return err
 	}
 
+	// Flush the indexes if they need to be flushed.
+	if b.indexManager != nil {
+		err := b.indexManager.Flush(&state.Hash, FlushIfNeeded, true)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Prune fully spent entries and mark all entries in the view unmodified
 	// now that the modifications have been committed to the database.
 	if view != nil {
@@ -2328,6 +2336,9 @@ type IndexManager interface {
 	// PruneBlock is invoked when an older block is deleted after it's been
 	// processed. This lowers the storage requirement for a node.
 	PruneBlocks(database.Tx, int32, func(int32) (*chainhash.Hash, error)) error
+
+	// Flush flushes the relevant indexes if they need to be flushed.
+	Flush(*chainhash.Hash, FlushMode, bool) error
 }
 
 // Config is a descriptor which specifies the blockchain instance configuration.

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -2341,6 +2341,24 @@ type IndexManager interface {
 	Flush(*chainhash.Hash, FlushMode, bool) error
 }
 
+// FlushUtxoCache flushes the indexes if a flush is needed with the given flush mode.
+// If the flush is on a block connect and not a reorg, the onConnect bool should be true.
+//
+// This function is safe for concurrent access.
+func (b *BlockChain) FlushIndexes(mode FlushMode, onConnect bool) error {
+	b.chainLock.Lock()
+	defer b.chainLock.Unlock()
+
+	if b.indexManager != nil {
+		err := b.indexManager.Flush(&b.BestSnapshot().Hash, mode, onConnect)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Config is a descriptor which specifies the blockchain instance configuration.
 type Config struct {
 	// DB defines the database which houses the blocks and will be used to

--- a/blockchain/indexers/addrindex.go
+++ b/blockchain/indexers/addrindex.go
@@ -816,7 +816,7 @@ func (idx *AddrIndex) DisconnectBlock(dbTx database.Tx, block *btcutil.Block,
 // supported with pruning.
 //
 // This is part of the Indexer interface.
-func (idx *AddrIndex) PruneBlock(dbTx database.Tx, blockHash *chainhash.Hash) error {
+func (idx *AddrIndex) PruneBlock(_ database.Tx, _ *chainhash.Hash, _ int32) error {
 	return nil
 }
 

--- a/blockchain/indexers/addrindex.go
+++ b/blockchain/indexers/addrindex.go
@@ -820,6 +820,13 @@ func (idx *AddrIndex) PruneBlock(dbTx database.Tx, blockHash *chainhash.Hash) er
 	return nil
 }
 
+// For AddrIndex, flush is a no-op.
+//
+// This is part of the Indexer interface.
+func (idx *AddrIndex) Flush(_ *chainhash.Hash, _ blockchain.FlushMode, _ bool) error {
+	return nil
+}
+
 // TxRegionsForAddress returns a slice of block regions which identify each
 // transaction that involves the passed address according to the specified
 // number to skip, number requested, and whether or not the results should be

--- a/blockchain/indexers/addrindex.go
+++ b/blockchain/indexers/addrindex.go
@@ -645,7 +645,7 @@ func (idx *AddrIndex) NeedsInputs() bool {
 // initialize for this index.
 //
 // This is part of the Indexer interface.
-func (idx *AddrIndex) Init(_ *blockchain.BlockChain) error {
+func (idx *AddrIndex) Init(_ *blockchain.BlockChain, _ *chainhash.Hash, _ int32) error {
 	// Nothing to do.
 	return nil
 }

--- a/blockchain/indexers/cfindex.go
+++ b/blockchain/indexers/cfindex.go
@@ -96,7 +96,7 @@ func (idx *CfIndex) NeedsInputs() bool {
 
 // Init initializes the hash-based cf index. This is part of the Indexer
 // interface.
-func (idx *CfIndex) Init(_ *blockchain.BlockChain) error {
+func (idx *CfIndex) Init(_ *blockchain.BlockChain, _ *chainhash.Hash, _ int32) error {
 	return nil // Nothing to do.
 }
 

--- a/blockchain/indexers/cfindex.go
+++ b/blockchain/indexers/cfindex.go
@@ -261,7 +261,7 @@ func (idx *CfIndex) DisconnectBlock(dbTx database.Tx, block *btcutil.Block,
 // reindexing as a pruned node.
 //
 // This is part of the Indexer interface.
-func (idx *CfIndex) PruneBlock(dbTx database.Tx, blockHash *chainhash.Hash) error {
+func (idx *CfIndex) PruneBlock(dbTx database.Tx, blockHash *chainhash.Hash, _ int32) error {
 	for _, key := range cfIndexKeys {
 		err := dbDeleteFilterIdxEntry(dbTx, key, blockHash)
 		if err != nil {

--- a/blockchain/indexers/cfindex.go
+++ b/blockchain/indexers/cfindex.go
@@ -286,6 +286,13 @@ func (idx *CfIndex) PruneBlock(dbTx database.Tx, blockHash *chainhash.Hash) erro
 	return nil
 }
 
+// For CfIndex, flush is a no-op.
+//
+// This is part of the Indexer interface.
+func (idx *CfIndex) Flush(_ *chainhash.Hash, _ blockchain.FlushMode, _ bool) error {
+	return nil
+}
+
 // entryByBlockHash fetches a filter index entry of a particular type
 // (eg. filter, filter header, etc) for a filter type and block hash.
 func (idx *CfIndex) entryByBlockHash(filterTypeKeys [][]byte,

--- a/blockchain/indexers/common.go
+++ b/blockchain/indexers/common.go
@@ -49,7 +49,7 @@ type Indexer interface {
 	// Init is invoked when the index manager is first initializing the
 	// index.  This differs from the Create method in that it is called on
 	// every load, including the case the index was just created.
-	Init(*blockchain.BlockChain) error
+	Init(*blockchain.BlockChain, *chainhash.Hash, int32) error
 
 	// ConnectBlock is invoked when a new block has been connected to the
 	// main chain. The set of output spent within a block is also passed in

--- a/blockchain/indexers/common.go
+++ b/blockchain/indexers/common.go
@@ -66,6 +66,9 @@ type Indexer interface {
 	// PruneBlock is invoked when an older block is deleted after it's been
 	// processed.
 	PruneBlock(database.Tx, *chainhash.Hash) error
+
+	// Flush flushes the index.
+	Flush(*chainhash.Hash, blockchain.FlushMode, bool) error
 }
 
 // AssertError identifies an error that indicates an internal code consistency

--- a/blockchain/indexers/common.go
+++ b/blockchain/indexers/common.go
@@ -65,7 +65,7 @@ type Indexer interface {
 
 	// PruneBlock is invoked when an older block is deleted after it's been
 	// processed.
-	PruneBlock(database.Tx, *chainhash.Hash) error
+	PruneBlock(dbTx database.Tx, deletedBlock *chainhash.Hash, lastKeptHeight int32) error
 
 	// Flush flushes the index.
 	Flush(*chainhash.Hash, blockchain.FlushMode, bool) error

--- a/blockchain/indexers/flatfile.go
+++ b/blockchain/indexers/flatfile.go
@@ -382,6 +382,11 @@ func (ff *FlatFileState) DisconnectBlock(height int32) error {
 	return nil
 }
 
+// BestHeight returns the current latest height of the flat file state.
+func (ff *FlatFileState) BestHeight() int32 {
+	return ff.currentHeight
+}
+
 // deleteFileFile removes the flat file state directory and all the contents
 // in it.
 func deleteFlatFile(path string) error {

--- a/blockchain/indexers/flatfile.go
+++ b/blockchain/indexers/flatfile.go
@@ -29,7 +29,7 @@ const (
 
 var (
 	// magicBytes are the bytes prepended to any entry in the dataFiles.
-	magicBytes = []byte{0xaa, 0xff, 0xaa, 0xff}
+	magicBytes = [4]byte{0xaa, 0xff, 0xaa, 0xff}
 )
 
 // FlatFileState is the shared state for storing flatfiles.  It is specifically designed
@@ -179,7 +179,7 @@ func (ff *FlatFileState) StoreData(height int32, data []byte) error {
 	buf = buf[:len(data)+8]
 
 	// Add the magic bytes, size, and the data to the buffer to be written.
-	copy(buf[:4], magicBytes)
+	copy(buf[:4], magicBytes[:])
 	binary.BigEndian.PutUint32(buf[4:8], uint32(len(data)))
 	copy(buf[8:], data)
 
@@ -225,7 +225,7 @@ func (ff *FlatFileState) FetchData(height int32) ([]byte, error) {
 	}
 
 	// Sanity check.  If wrong magic was read, then error out.
-	if !bytes.Equal(buf[:4], magicBytes) {
+	if !bytes.Equal(buf[:4], magicBytes[:]) {
 		return nil, fmt.Errorf("Read wrong magic bytes. Expect %x but got %x",
 			magicBytes, buf[:4])
 	}
@@ -266,7 +266,7 @@ func (ff *FlatFileState) DisconnectBlock(height int32) error {
 		return err
 	}
 
-	if !bytes.Equal(buf[:4], magicBytes) {
+	if !bytes.Equal(buf[:4], magicBytes[:]) {
 		return fmt.Errorf("read wrong magic of %x", buf[:4])
 	}
 

--- a/blockchain/indexers/flatfile_test.go
+++ b/blockchain/indexers/flatfile_test.go
@@ -327,7 +327,7 @@ func getAfterSizes(ff *FlatFileState, height int32) (int64, int64, error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	if !bytes.Equal(buf[:4], magicBytes) {
+	if !bytes.Equal(buf[:4], magicBytes[:]) {
 		return 0, 0, fmt.Errorf("read wrong magic of %x", buf[:4])
 	}
 	dataSize := binary.BigEndian.Uint32(buf[4:])

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -121,7 +121,7 @@ func (idx *FlatUtreexoProofIndex) Init(chain *blockchain.BlockChain,
 	idx.chain = chain
 
 	// Init Utreexo State.
-	uState, err := InitUtreexoState(idx.config)
+	uState, err := InitUtreexoState(idx.config, chain, tipHash, tipHeight)
 	if err != nil {
 		return err
 	}

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -317,7 +317,10 @@ func (idx *FlatUtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.
 	if err != nil {
 		return err
 	}
-	idx.FlushUtreexoStateIfNeeded(block.Hash())
+	err = idx.FlushUtreexoStateIfNeeded(block.Hash())
+	if err != nil {
+		log.Warnf("error while flushing the utreexo state. %v", err)
+	}
 
 	// Don't store proofs if the node is pruned.
 	if idx.pruned {

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -1271,7 +1271,7 @@ func loadFlatFileState(dataDir, name string) (*FlatFileState, error) {
 // turn is used by the blockchain package.  This allows the index to be
 // seamlessly maintained along with the chain.
 func NewFlatUtreexoProofIndex(pruned bool, chainParams *chaincfg.Params,
-	proofGenInterVal *int32, maxMemoryUsage int64, dataDir string) (*FlatUtreexoProofIndex, error) {
+	proofGenInterVal *int32, maxMemoryUsage int64, dataDir string, flush func() error) (*FlatUtreexoProofIndex, error) {
 
 	// If the proofGenInterVal argument is nil, use the default value.
 	var intervalToUse int32
@@ -1290,6 +1290,7 @@ func NewFlatUtreexoProofIndex(pruned bool, chainParams *chaincfg.Params,
 			Pruned:         pruned,
 			DataDir:        dataDir,
 			Name:           flatUtreexoProofIndexType,
+			FlushMainDB:    flush,
 		},
 	}
 

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -317,6 +317,7 @@ func (idx *FlatUtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.
 	if err != nil {
 		return err
 	}
+	idx.FlushUtreexoStateIfNeeded()
 
 	// Don't store proofs if the node is pruned.
 	if idx.pruned {

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -779,6 +779,13 @@ func (idx *FlatUtreexoProofIndex) DisconnectBlock(dbTx database.Tx, block *btcut
 		return err
 	}
 
+	// Always flush the utreexo state on flushes to never leave the utreexoState
+	// at an unrecoverable state.
+	err = idx.FlushUtreexoState(&block.MsgBlock().Header.PrevBlock)
+	if err != nil {
+		return err
+	}
+
 	// Check if we're at a height where proof was generated. Only check if we're not
 	// pruned as we don't keep the historical proofs as a pruned node.
 	if (block.Height()%idx.proofGenInterVal) == 0 && !idx.config.Pruned {

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -118,6 +118,13 @@ func (idx *FlatUtreexoProofIndex) NeedsInputs() bool {
 func (idx *FlatUtreexoProofIndex) Init(chain *blockchain.BlockChain) error {
 	idx.chain = chain
 
+	// Init Utreexo State.
+	uState, err := InitUtreexoState(idx.config)
+	if err != nil {
+		return err
+	}
+	idx.utreexoState = uState
+
 	// Nothing to do if the node is not pruned.
 	//
 	// If the node is pruned, then we need to check if it started off as
@@ -127,7 +134,7 @@ func (idx *FlatUtreexoProofIndex) Init(chain *blockchain.BlockChain) error {
 	}
 
 	proofPath := flatFilePath(idx.config.DataDir, flatUtreexoProofName)
-	_, err := os.Stat(proofPath)
+	_, err = os.Stat(proofPath)
 	if err != nil {
 		// If the error isn't nil, that means the proofpath
 		// doesn't exist.
@@ -1276,13 +1283,6 @@ func NewFlatUtreexoProofIndex(pruned bool, chainParams *chaincfg.Params,
 			Name:           flatUtreexoProofIndexType,
 		},
 	}
-
-	// Init Utreexo State.
-	uState, err := InitUtreexoState(idx.config)
-	if err != nil {
-		return nil, err
-	}
-	idx.utreexoState = uState
 
 	// Init the utreexo proof state if the node isn't pruned.
 	if !idx.config.Pruned {

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -115,7 +115,9 @@ func (idx *FlatUtreexoProofIndex) NeedsInputs() bool {
 
 // Init initializes the flat utreexo proof index. This is part of the Indexer
 // interface.
-func (idx *FlatUtreexoProofIndex) Init(chain *blockchain.BlockChain) error {
+func (idx *FlatUtreexoProofIndex) Init(chain *blockchain.BlockChain,
+	tipHash *chainhash.Hash, tipHeight int32) error {
+
 	idx.chain = chain
 
 	// Init Utreexo State.

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -317,7 +317,7 @@ func (idx *FlatUtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.
 	if err != nil {
 		return err
 	}
-	idx.FlushUtreexoStateIfNeeded()
+	idx.FlushUtreexoStateIfNeeded(block.Hash())
 
 	// Don't store proofs if the node is pruned.
 	if idx.pruned {

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -130,6 +130,7 @@ func (idx *FlatUtreexoProofIndex) Init(chain *blockchain.BlockChain,
 		return err
 	}
 	idx.utreexoState = uState
+	idx.lastFlushTime = time.Now()
 
 	// Nothing to do if the node is not pruned.
 	//

--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -203,7 +203,7 @@ func compareUtreexoIdx(start, end int32, pruned bool, chain *blockchain.BlockCha
 					return err
 				}
 
-				if !idxType.pruned {
+				if !idxType.config.Pruned {
 					utreexoUD, err = idxType.FetchUtreexoProof(block.Hash())
 					if err != nil {
 						return err
@@ -222,7 +222,7 @@ func compareUtreexoIdx(start, end int32, pruned bool, chain *blockchain.BlockCha
 
 			case *FlatUtreexoProofIndex:
 				var err error
-				if !idxType.pruned {
+				if !idxType.config.Pruned {
 					flatUD, err = idxType.FetchUtreexoProof(b, false)
 					if err != nil {
 						return err
@@ -1033,7 +1033,7 @@ func TestBridgeNodePruneUndoDataGen(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			idxType.pruned = true
+			idxType.config.Pruned = true
 
 		case *UtreexoProofIndex:
 			for height := int32(1); height <= maxHeight; height++ {
@@ -1047,7 +1047,7 @@ func TestBridgeNodePruneUndoDataGen(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			idxType.pruned = true
+			idxType.config.Pruned = true
 		}
 	}
 

--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -70,17 +70,17 @@ func createDB(dbName string) (database.DB, string, error) {
 	return db, dbPath, nil
 }
 
-func initIndexes(interval int32, dbPath string, db *database.DB, params *chaincfg.Params) (
+func initIndexes(interval int32, dbPath string, db database.DB, params *chaincfg.Params) (
 	*Manager, []Indexer, error) {
 
 	proofGenInterval := new(int32)
 	*proofGenInterval = interval
-	flatUtreexoProofIndex, err := NewFlatUtreexoProofIndex(false, params, proofGenInterval, 50*1024*1024, dbPath)
+	flatUtreexoProofIndex, err := NewFlatUtreexoProofIndex(false, params, proofGenInterval, 50*1024*1024, dbPath, db.Flush)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	utreexoProofIndex, err := NewUtreexoProofIndex(*db, false, 50*1024*1024, params, dbPath)
+	utreexoProofIndex, err := NewUtreexoProofIndex(db, false, 50*1024*1024, params, dbPath, db.Flush)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -89,7 +89,7 @@ func initIndexes(interval int32, dbPath string, db *database.DB, params *chaincf
 		utreexoProofIndex,
 		flatUtreexoProofIndex,
 	}
-	indexManager := NewManager(*db, indexes)
+	indexManager := NewManager(db, indexes)
 	return indexManager, indexes, nil
 }
 
@@ -109,7 +109,7 @@ func indexersTestChain(testName string, proofGenInterval int32) (*blockchain.Blo
 	}
 
 	// Create the indexes to be used in the chain.
-	indexManager, indexes, err := initIndexes(proofGenInterval, dbPath, &db, &params)
+	indexManager, indexes, err := initIndexes(proofGenInterval, dbPath, db, &params)
 	if err != nil {
 		tearDown()
 		os.RemoveAll(testDbRoot)

--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -1045,16 +1045,15 @@ func TestBridgeNodePruneUndoDataGen(t *testing.T) {
 
 	// Close the databases so that they can be initialized again
 	// to generate the undo data.
-	bestHash := chain.BestSnapshot().Hash
 	for _, indexer := range indexes {
 		switch idxType := indexer.(type) {
 		case *FlatUtreexoProofIndex:
-			err = idxType.CloseUtreexoState(&bestHash)
+			err := idxType.CloseUtreexoState()
 			if err != nil {
 				t.Fatal(err)
 			}
 		case *UtreexoProofIndex:
-			err = idxType.CloseUtreexoState(&bestHash)
+			err := idxType.CloseUtreexoState()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -479,32 +479,6 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 			return err
 		}
 
-		if interruptRequested(interrupt) {
-			for _, indexer := range m.enabledIndexes {
-				switch idxType := indexer.(type) {
-				case *UtreexoProofIndex:
-					err := idxType.flushUtreexoState(block.Hash())
-					if err != nil {
-						log.Errorf("Error while flushing utreexo state: %v", err)
-					}
-					err = idxType.utreexoState.utreexoStateDB.Close()
-					if err != nil {
-						log.Errorf("Error while flushing utreexo state: %v", err)
-					}
-				case *FlatUtreexoProofIndex:
-					err := idxType.flushUtreexoState(block.Hash())
-					if err != nil {
-						log.Errorf("Error while flushing utreexo state for flat utreexo proof index: %v", err)
-					}
-					err = idxType.utreexoState.utreexoStateDB.Close()
-					if err != nil {
-						log.Errorf("Error while closing the utreexo state for flat utreexo proof index: %v", err)
-					}
-				}
-			}
-			return errInterruptRequested
-		}
-
 		// Connect the block for all indexes that need it.
 		var spentTxos []blockchain.SpentTxOut
 		for i, indexer := range m.enabledIndexes {

--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -483,14 +483,22 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 			for _, indexer := range m.enabledIndexes {
 				switch idxType := indexer.(type) {
 				case *UtreexoProofIndex:
-					err := idxType.CloseUtreexoState(block.Hash())
+					err := idxType.flushUtreexoState(block.Hash())
+					if err != nil {
+						log.Errorf("Error while flushing utreexo state: %v", err)
+					}
+					err = idxType.utreexoState.utreexoStateDB.Close()
 					if err != nil {
 						log.Errorf("Error while flushing utreexo state: %v", err)
 					}
 				case *FlatUtreexoProofIndex:
-					err := idxType.CloseUtreexoState(block.Hash())
+					err := idxType.flushUtreexoState(block.Hash())
 					if err != nil {
 						log.Errorf("Error while flushing utreexo state for flat utreexo proof index: %v", err)
+					}
+					err = idxType.utreexoState.utreexoStateDB.Close()
+					if err != nil {
+						log.Errorf("Error while closing the utreexo state for flat utreexo proof index: %v", err)
 					}
 				}
 			}
@@ -534,14 +542,22 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 			for _, indexer := range m.enabledIndexes {
 				switch idxType := indexer.(type) {
 				case *UtreexoProofIndex:
-					err := idxType.CloseUtreexoState(block.Hash())
+					err := idxType.flushUtreexoState(block.Hash())
 					if err != nil {
-						log.Errorf("Error while flushing utreexo state: %v", err)
+						log.Errorf("Error while flushing utreexo state for utreexo proof index: %v", err)
+					}
+					err = idxType.utreexoState.utreexoStateDB.Close()
+					if err != nil {
+						log.Errorf("Error while closing the utreexo state for utreexo proof index: %v", err)
 					}
 				case *FlatUtreexoProofIndex:
-					err := idxType.CloseUtreexoState(block.Hash())
+					err := idxType.flushUtreexoState(block.Hash())
 					if err != nil {
 						log.Errorf("Error while flushing utreexo state for flat utreexo proof index: %v", err)
+					}
+					err = idxType.utreexoState.utreexoStateDB.Close()
+					if err != nil {
+						log.Errorf("Error while closing the utreexo state for flat utreexo proof index: %v", err)
 					}
 				}
 			}

--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -652,7 +652,7 @@ func (m *Manager) PruneBlocks(dbTx database.Tx, lastKeptHeight int32,
 			}
 
 			// Notify the indexer with the connected block so it can prune it.
-			err = index.PruneBlock(dbTx, blockHash)
+			err = index.PruneBlock(dbTx, blockHash, lastKeptHeight)
 			if err != nil {
 				return err
 			}

--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -472,12 +472,12 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 			for _, indexer := range m.enabledIndexes {
 				switch idxType := indexer.(type) {
 				case *UtreexoProofIndex:
-					err := idxType.FlushUtreexoState()
+					err := idxType.CloseUtreexoState()
 					if err != nil {
 						log.Errorf("Error while flushing utreexo state: %v", err)
 					}
 				case *FlatUtreexoProofIndex:
-					err := idxType.FlushUtreexoState()
+					err := idxType.CloseUtreexoState()
 					if err != nil {
 						log.Errorf("Error while flushing utreexo state for flat utreexo proof index: %v", err)
 					}
@@ -523,12 +523,12 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 			for _, indexer := range m.enabledIndexes {
 				switch idxType := indexer.(type) {
 				case *UtreexoProofIndex:
-					err := idxType.FlushUtreexoState()
+					err := idxType.CloseUtreexoState()
 					if err != nil {
 						log.Errorf("Error while flushing utreexo state: %v", err)
 					}
 				case *FlatUtreexoProofIndex:
-					err := idxType.FlushUtreexoState()
+					err := idxType.CloseUtreexoState()
 					if err != nil {
 						log.Errorf("Error while flushing utreexo state for flat utreexo proof index: %v", err)
 					}

--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -472,12 +472,12 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 			for _, indexer := range m.enabledIndexes {
 				switch idxType := indexer.(type) {
 				case *UtreexoProofIndex:
-					err := idxType.CloseUtreexoState()
+					err := idxType.CloseUtreexoState(block.Hash())
 					if err != nil {
 						log.Errorf("Error while flushing utreexo state: %v", err)
 					}
 				case *FlatUtreexoProofIndex:
-					err := idxType.CloseUtreexoState()
+					err := idxType.CloseUtreexoState(block.Hash())
 					if err != nil {
 						log.Errorf("Error while flushing utreexo state for flat utreexo proof index: %v", err)
 					}
@@ -523,12 +523,12 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 			for _, indexer := range m.enabledIndexes {
 				switch idxType := indexer.(type) {
 				case *UtreexoProofIndex:
-					err := idxType.CloseUtreexoState()
+					err := idxType.CloseUtreexoState(block.Hash())
 					if err != nil {
 						log.Errorf("Error while flushing utreexo state: %v", err)
 					}
 				case *FlatUtreexoProofIndex:
-					err := idxType.CloseUtreexoState()
+					err := idxType.CloseUtreexoState(block.Hash())
 					if err != nil {
 						log.Errorf("Error while flushing utreexo state for flat utreexo proof index: %v", err)
 					}

--- a/blockchain/indexers/ttlindex.go
+++ b/blockchain/indexers/ttlindex.go
@@ -101,6 +101,13 @@ func (idx *TTLIndex) PruneBlock(dbTx database.Tx, blockHash *chainhash.Hash) err
 	return nil
 }
 
+// For TTLIndex, flush is a no-op.
+//
+// This is part of the Indexer interface.
+func (idx *TTLIndex) Flush(_ *chainhash.Hash, _ blockchain.FlushMode, _ bool) error {
+	return nil
+}
+
 // GetTTL returns a pointer to the ttl value of a transaction outpout.
 // Returns nil for a UTXO.
 //

--- a/blockchain/indexers/ttlindex.go
+++ b/blockchain/indexers/ttlindex.go
@@ -41,7 +41,7 @@ func (idx *TTLIndex) NeedsInputs() bool {
 
 // Init initializes the time to live index. This is part of the Indexer
 // interface.
-func (idx *TTLIndex) Init(_ *blockchain.BlockChain) error {
+func (idx *TTLIndex) Init(_ *blockchain.BlockChain, _ *chainhash.Hash, _ int32) error {
 	return nil // Nothing to do.
 }
 

--- a/blockchain/indexers/ttlindex.go
+++ b/blockchain/indexers/ttlindex.go
@@ -97,7 +97,7 @@ func (idx *TTLIndex) DisconnectBlock(dbTx database.Tx, block *btcutil.Block,
 // supported with pruning.
 //
 // This is part of the Indexer interface.
-func (idx *TTLIndex) PruneBlock(dbTx database.Tx, blockHash *chainhash.Hash) error {
+func (idx *TTLIndex) PruneBlock(_ database.Tx, _ *chainhash.Hash, _ int32) error {
 	return nil
 }
 

--- a/blockchain/indexers/txindex.go
+++ b/blockchain/indexers/txindex.go
@@ -437,7 +437,7 @@ func (idx *TxIndex) DisconnectBlock(dbTx database.Tx, block *btcutil.Block,
 // supported with pruning.
 //
 // This is part of the Indexer interface.
-func (idx *TxIndex) PruneBlock(dbTx database.Tx, blockHash *chainhash.Hash) error {
+func (idx *TxIndex) PruneBlock(_ database.Tx, _ *chainhash.Hash, _ int32) error {
 	return nil
 }
 

--- a/blockchain/indexers/txindex.go
+++ b/blockchain/indexers/txindex.go
@@ -441,6 +441,13 @@ func (idx *TxIndex) PruneBlock(dbTx database.Tx, blockHash *chainhash.Hash) erro
 	return nil
 }
 
+// NOTE: For TxIndex, flush is a no-op.
+//
+// This is part of the Indexer interface.
+func (idx *TxIndex) Flush(_ *chainhash.Hash, _ blockchain.FlushMode, _ bool) error {
+	return nil
+}
+
 // TxBlockRegion returns the block region for the provided transaction hash
 // from the transaction index.  The block region can in turn be used to load the
 // raw transaction bytes.  When there is no entry for the provided hash, nil

--- a/blockchain/indexers/txindex.go
+++ b/blockchain/indexers/txindex.go
@@ -294,7 +294,7 @@ var _ Indexer = (*TxIndex)(nil)
 // disconnecting blocks.
 //
 // This is part of the Indexer interface.
-func (idx *TxIndex) Init(_ *blockchain.BlockChain) error {
+func (idx *TxIndex) Init(_ *blockchain.BlockChain, _ *chainhash.Hash, _ int32) error {
 	// Find the latest known block id field for the internal block id
 	// index and initialize it.  This is done because it's a lot more
 	// efficient to do a single search at initialize time than it is to

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -53,6 +53,9 @@ type UtreexoConfig struct {
 	// Name is what the type of utreexo proof indexer this utreexo state is related
 	// to.
 	Name string
+
+	// FlushMainDB flushes the main database where all the data is stored.
+	FlushMainDB func() error
 }
 
 // UtreexoState is a wrapper around the raw accumulator with configuration

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -388,6 +388,16 @@ func initUtreexoState(cfg *UtreexoConfig, maxMemoryUsage int64, basePath string)
 				log.Warnf("error while opening transaction. %v", err)
 			}
 
+			nodesUsed, nodesCapacity := nodesDB.UsageStats()
+			log.Debugf("Utreexo index nodesDB cache usage: %d/%d (%v%%)\n",
+				nodesUsed, nodesCapacity,
+				float64(nodesUsed)/float64(nodesCapacity))
+
+			cachedLeavesUsed, cachedLeavesCapacity := cachedLeavesDB.UsageStats()
+			log.Debugf("Utreexo index cachedLeavesDB cache usage: %d/%d (%v%%)\n",
+				cachedLeavesUsed, cachedLeavesCapacity,
+				float64(cachedLeavesUsed)/float64(cachedLeavesCapacity))
+
 			nodesDB.Flush(ldbTx)
 			cachedLeavesDB.Flush(ldbTx)
 

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -265,6 +265,9 @@ func (idx *UtreexoProofIndex) Flush(bestHash *chainhash.Hash, mode blockchain.Fl
 	if err != nil {
 		return err
 	}
+
+	// Set the last flush time as now as the flush was successful.
+	idx.lastFlushTime = time.Now()
 	return nil
 }
 
@@ -329,6 +332,9 @@ func (idx *FlatUtreexoProofIndex) Flush(bestHash *chainhash.Hash, mode blockchai
 	if err != nil {
 		return err
 	}
+
+	// Set the last flush time as now as the flush was successful.
+	idx.lastFlushTime = time.Now()
 	return nil
 }
 

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -316,9 +316,7 @@ func deserializeUndoBlock(serialized []byte) (uint64, []uint64, []utreexo.Hash, 
 func initUtreexoState(cfg *UtreexoConfig, maxMemoryUsage int64, basePath string) (*UtreexoState, error) {
 	p := utreexo.NewMapPollard(true)
 
-	// 60% of the memory for the nodes map, 40% for the cache leaves map.
-	// TODO Totally arbitrary, it there's something better than change it to that.
-	maxNodesMem := maxMemoryUsage * 6 / 10
+	maxNodesMem := maxMemoryUsage * 7 / 10
 	maxCachedLeavesMem := maxMemoryUsage - maxNodesMem
 
 	db, err := leveldb.OpenFile(basePath, nil)

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -186,7 +186,10 @@ func (idx *UtreexoProofIndex) FlushUtreexoState(bestHash *chainhash.Hash) error 
 
 // CloseUtreexoState flushes and closes the utreexo database state.
 func (idx *UtreexoProofIndex) CloseUtreexoState(bestHash *chainhash.Hash) error {
-	idx.FlushUtreexoState(bestHash)
+	err := idx.FlushUtreexoState(bestHash)
+	if err != nil {
+		log.Warnf("error whiling flushing the utreexo state. %v", err)
+	}
 	return idx.utreexoState.closeDB()
 }
 
@@ -222,7 +225,10 @@ func (idx *FlatUtreexoProofIndex) FlushUtreexoState(bestHash *chainhash.Hash) er
 
 // CloseUtreexoState flushes and closes the utreexo database state.
 func (idx *FlatUtreexoProofIndex) CloseUtreexoState(bestHash *chainhash.Hash) error {
-	idx.FlushUtreexoState(bestHash)
+	err := idx.FlushUtreexoState(bestHash)
+	if err != nil {
+		log.Warnf("error whiling flushing the utreexo state. %v", err)
+	}
 	return idx.utreexoState.closeDB()
 }
 

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -154,6 +154,13 @@ func (idx *FlatUtreexoProofIndex) FetchUtreexoState(blockHeight int32) ([]*chain
 	return chainhashRoots, stump.NumLeaves, nil
 }
 
+// FlushUtreexoStateIfNeeded flushes the utreexo state only if the cache is full.
+func (idx *UtreexoProofIndex) FlushUtreexoStateIfNeeded() {
+	if idx.utreexoState.isFlushNeeded() {
+		idx.FlushUtreexoState()
+	}
+}
+
 // FlushUtreexoState saves the utreexo state to disk.
 func (idx *UtreexoProofIndex) FlushUtreexoState() error {
 	basePath := utreexoBasePath(idx.utreexoState.config)
@@ -180,6 +187,13 @@ func (idx *UtreexoProofIndex) FlushUtreexoState() error {
 func (idx *UtreexoProofIndex) CloseUtreexoState() error {
 	idx.FlushUtreexoState()
 	return idx.utreexoState.closeDB()
+}
+
+// FlushUtreexoStateIfNeeded flushes the utreexo state only if the cache is full.
+func (idx *FlatUtreexoProofIndex) FlushUtreexoStateIfNeeded() {
+	if idx.utreexoState.isFlushNeeded() {
+		idx.FlushUtreexoState()
+	}
 }
 
 // FlushUtreexoState saves the utreexo state to disk.

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -729,7 +729,7 @@ func InitUtreexoState(cfg *UtreexoConfig, chain *blockchain.BlockChain,
 		isFlushNeeded = func() bool {
 			nodesNeedsFlush := nodesDB.IsFlushNeeded()
 			leavesNeedsFlush := cachedLeavesDB.IsFlushNeeded()
-			return nodesNeedsFlush && leavesNeedsFlush
+			return nodesNeedsFlush || leavesNeedsFlush
 		}
 	} else {
 		log.Infof("loading the utreexo state from disk...")

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -473,6 +473,11 @@ func initUtreexoState(cfg *UtreexoConfig, maxMemoryUsage int64, basePath string)
 
 			log.Infof("Finished flushing the utreexo state to disk.")
 		}
+
+		// Flush is never needed since we're keeping everything in memory.
+		isFlushNeeded = func() bool {
+			return false
+		}
 	}
 
 	uState := &UtreexoState{

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -172,6 +172,12 @@ func (idx *UtreexoProofIndex) FlushUtreexoState() error {
 	}
 
 	idx.utreexoState.flush()
+	return nil
+}
+
+// CloseUtreexoState flushes and closes the utreexo database state.
+func (idx *UtreexoProofIndex) CloseUtreexoState() error {
+	idx.FlushUtreexoState()
 	return idx.utreexoState.closeDB()
 }
 
@@ -194,6 +200,12 @@ func (idx *FlatUtreexoProofIndex) FlushUtreexoState() error {
 	}
 
 	idx.utreexoState.flush()
+	return nil
+}
+
+// CloseUtreexoState flushes and closes the utreexo database state.
+func (idx *FlatUtreexoProofIndex) CloseUtreexoState() error {
+	idx.FlushUtreexoState()
 	return idx.utreexoState.closeDB()
 }
 

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -155,10 +155,11 @@ func (idx *FlatUtreexoProofIndex) FetchUtreexoState(blockHeight int32) ([]*chain
 }
 
 // FlushUtreexoStateIfNeeded flushes the utreexo state only if the cache is full.
-func (idx *UtreexoProofIndex) FlushUtreexoStateIfNeeded(bestHash *chainhash.Hash) {
+func (idx *UtreexoProofIndex) FlushUtreexoStateIfNeeded(bestHash *chainhash.Hash) error {
 	if idx.utreexoState.isFlushNeeded() {
-		idx.FlushUtreexoState(bestHash)
+		return idx.FlushUtreexoState(bestHash)
 	}
+	return nil
 }
 
 // FlushUtreexoState saves the utreexo state to disk.
@@ -190,10 +191,11 @@ func (idx *UtreexoProofIndex) CloseUtreexoState(bestHash *chainhash.Hash) error 
 }
 
 // FlushUtreexoStateIfNeeded flushes the utreexo state only if the cache is full.
-func (idx *FlatUtreexoProofIndex) FlushUtreexoStateIfNeeded(bestHash *chainhash.Hash) {
+func (idx *FlatUtreexoProofIndex) FlushUtreexoStateIfNeeded(bestHash *chainhash.Hash) error {
 	if idx.utreexoState.isFlushNeeded() {
-		idx.FlushUtreexoState(bestHash)
+		return idx.FlushUtreexoState(bestHash)
 	}
+	return nil
 }
 
 // FlushUtreexoState saves the utreexo state to disk.

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -155,14 +155,14 @@ func (idx *FlatUtreexoProofIndex) FetchUtreexoState(blockHeight int32) ([]*chain
 }
 
 // FlushUtreexoStateIfNeeded flushes the utreexo state only if the cache is full.
-func (idx *UtreexoProofIndex) FlushUtreexoStateIfNeeded() {
+func (idx *UtreexoProofIndex) FlushUtreexoStateIfNeeded(bestHash *chainhash.Hash) {
 	if idx.utreexoState.isFlushNeeded() {
-		idx.FlushUtreexoState()
+		idx.FlushUtreexoState(bestHash)
 	}
 }
 
 // FlushUtreexoState saves the utreexo state to disk.
-func (idx *UtreexoProofIndex) FlushUtreexoState() error {
+func (idx *UtreexoProofIndex) FlushUtreexoState(bestHash *chainhash.Hash) error {
 	basePath := utreexoBasePath(idx.utreexoState.config)
 	if _, err := os.Stat(basePath); err != nil {
 		os.MkdirAll(basePath, os.ModePerm)
@@ -184,20 +184,20 @@ func (idx *UtreexoProofIndex) FlushUtreexoState() error {
 }
 
 // CloseUtreexoState flushes and closes the utreexo database state.
-func (idx *UtreexoProofIndex) CloseUtreexoState() error {
-	idx.FlushUtreexoState()
+func (idx *UtreexoProofIndex) CloseUtreexoState(bestHash *chainhash.Hash) error {
+	idx.FlushUtreexoState(bestHash)
 	return idx.utreexoState.closeDB()
 }
 
 // FlushUtreexoStateIfNeeded flushes the utreexo state only if the cache is full.
-func (idx *FlatUtreexoProofIndex) FlushUtreexoStateIfNeeded() {
+func (idx *FlatUtreexoProofIndex) FlushUtreexoStateIfNeeded(bestHash *chainhash.Hash) {
 	if idx.utreexoState.isFlushNeeded() {
-		idx.FlushUtreexoState()
+		idx.FlushUtreexoState(bestHash)
 	}
 }
 
 // FlushUtreexoState saves the utreexo state to disk.
-func (idx *FlatUtreexoProofIndex) FlushUtreexoState() error {
+func (idx *FlatUtreexoProofIndex) FlushUtreexoState(bestHash *chainhash.Hash) error {
 	basePath := utreexoBasePath(idx.utreexoState.config)
 	if _, err := os.Stat(basePath); err != nil {
 		os.MkdirAll(basePath, os.ModePerm)
@@ -219,8 +219,8 @@ func (idx *FlatUtreexoProofIndex) FlushUtreexoState() error {
 }
 
 // CloseUtreexoState flushes and closes the utreexo database state.
-func (idx *FlatUtreexoProofIndex) CloseUtreexoState() error {
-	idx.FlushUtreexoState()
+func (idx *FlatUtreexoProofIndex) CloseUtreexoState(bestHash *chainhash.Hash) error {
+	idx.FlushUtreexoState(bestHash)
 	return idx.utreexoState.closeDB()
 }
 

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -275,8 +275,9 @@ func (idx *UtreexoProofIndex) flushUtreexoState(bestHash *chainhash.Hash) error 
 }
 
 // CloseUtreexoState flushes and closes the utreexo database state.
-func (idx *UtreexoProofIndex) CloseUtreexoState(bestHash *chainhash.Hash) error {
-	err := idx.flushUtreexoState(bestHash)
+func (idx *UtreexoProofIndex) CloseUtreexoState() error {
+	bestHash := idx.chain.BestSnapshot().Hash
+	err := idx.flushUtreexoState(&bestHash)
 	if err != nil {
 		log.Warnf("error whiling flushing the utreexo state. %v", err)
 	}
@@ -338,8 +339,9 @@ func (idx *FlatUtreexoProofIndex) flushUtreexoState(bestHash *chainhash.Hash) er
 }
 
 // CloseUtreexoState flushes and closes the utreexo database state.
-func (idx *FlatUtreexoProofIndex) CloseUtreexoState(bestHash *chainhash.Hash) error {
-	err := idx.flushUtreexoState(bestHash)
+func (idx *FlatUtreexoProofIndex) CloseUtreexoState() error {
+	bestHash := idx.chain.BestSnapshot().Hash
+	err := idx.flushUtreexoState(&bestHash)
 	if err != nil {
 		log.Warnf("error whiling flushing the utreexo state. %v", err)
 	}

--- a/blockchain/indexers/utreexobackend_test.go
+++ b/blockchain/indexers/utreexobackend_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2024 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package indexers
+
+import (
+	"math/rand"
+	"os"
+	"testing"
+
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/utreexo/utreexod/chaincfg"
+)
+
+func TestUtreexoStateConsistencyWrite(t *testing.T) {
+	dbPath := t.TempDir()
+	db, err := leveldb.OpenFile(dbPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { os.RemoveAll(dbPath) }()
+
+	// Values to write.
+	numLeaves := rand.Uint64()
+	hash := chaincfg.MainNetParams.GenesisHash
+
+	// Write the consistency state.
+	ldbTx, err := db.OpenTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = dbWriteUtreexoStateConsistency(ldbTx, hash, numLeaves)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ldbTx.Commit()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fetch the consistency state.
+	gotHash, gotNumLeaves, err := dbFetchUtreexoStateConsistency(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compare.
+	if *hash != *gotHash {
+		t.Fatalf("expected %v, got %v", hash.String(), gotHash.String())
+	}
+	if numLeaves != gotNumLeaves {
+		t.Fatalf("expected %v, got %v", numLeaves, gotNumLeaves)
+	}
+}

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -299,7 +299,10 @@ func (idx *UtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Bloc
 	if err != nil {
 		return err
 	}
-	idx.FlushUtreexoStateIfNeeded(block.Hash())
+	err = idx.FlushUtreexoStateIfNeeded(block.Hash())
+	if err != nil {
+		log.Warnf("error while flushing the utreexo state. %v", err)
+	}
 
 	return nil
 }

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -299,7 +299,7 @@ func (idx *UtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Bloc
 	if err != nil {
 		return err
 	}
-	idx.FlushUtreexoStateIfNeeded()
+	idx.FlushUtreexoStateIfNeeded(block.Hash())
 
 	return nil
 }

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -76,7 +76,9 @@ func (idx *UtreexoProofIndex) NeedsInputs() bool {
 
 // Init initializes the utreexo proof index. This is part of the Indexer
 // interface.
-func (idx *UtreexoProofIndex) Init(chain *blockchain.BlockChain) error {
+func (idx *UtreexoProofIndex) Init(chain *blockchain.BlockChain,
+	tipHash *chainhash.Hash, tipHeight int32) error {
+
 	idx.chain = chain
 
 	// Init Utreexo State.

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -299,6 +299,7 @@ func (idx *UtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Bloc
 	if err != nil {
 		return err
 	}
+	idx.FlushUtreexoStateIfNeeded()
 
 	return nil
 }

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -375,6 +375,13 @@ func (idx *UtreexoProofIndex) DisconnectBlock(dbTx database.Tx, block *btcutil.B
 		return err
 	}
 
+	// Always flush the utreexo state on flushes to never leave the utreexoState
+	// at an unrecoverable state.
+	err = idx.FlushUtreexoState(&block.MsgBlock().Header.PrevBlock)
+	if err != nil {
+		return err
+	}
+
 	err = dbDeleteUtreexoState(dbTx, block.Hash())
 	if err != nil {
 		return err

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -587,7 +587,7 @@ func (idx *UtreexoProofIndex) PruneBlock(dbTx database.Tx, blockHash *chainhash.
 // turn is used by the blockchain package.  This allows the index to be
 // seamlessly maintained along with the chain.
 func NewUtreexoProofIndex(db database.DB, pruned bool, maxMemoryUsage int64,
-	chainParams *chaincfg.Params, dataDir string) (*UtreexoProofIndex, error) {
+	chainParams *chaincfg.Params, dataDir string, flush func() error) (*UtreexoProofIndex, error) {
 
 	idx := &UtreexoProofIndex{
 		db:  db,
@@ -598,6 +598,7 @@ func NewUtreexoProofIndex(db database.DB, pruned bool, maxMemoryUsage int64,
 			Pruned:         pruned,
 			DataDir:        dataDir,
 			Name:           db.Type(),
+			FlushMainDB:    flush,
 		},
 	}
 

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -91,6 +91,7 @@ func (idx *UtreexoProofIndex) Init(chain *blockchain.BlockChain,
 		return err
 	}
 	idx.utreexoState = uState
+	idx.lastFlushTime = time.Now()
 
 	// Nothing else to do if the node is an archive node.
 	if !idx.config.Pruned {

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -82,7 +82,7 @@ func (idx *UtreexoProofIndex) Init(chain *blockchain.BlockChain,
 	idx.chain = chain
 
 	// Init Utreexo State.
-	uState, err := InitUtreexoState(idx.config)
+	uState, err := InitUtreexoState(idx.config, chain, tipHash, tipHeight)
 	if err != nil {
 		return err
 	}

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -79,6 +79,13 @@ func (idx *UtreexoProofIndex) NeedsInputs() bool {
 func (idx *UtreexoProofIndex) Init(chain *blockchain.BlockChain) error {
 	idx.chain = chain
 
+	// Init Utreexo State.
+	uState, err := InitUtreexoState(idx.config)
+	if err != nil {
+		return err
+	}
+	idx.utreexoState = uState
+
 	// Nothing else to do if the node is an archive node.
 	if !idx.config.Pruned {
 		return nil
@@ -86,7 +93,7 @@ func (idx *UtreexoProofIndex) Init(chain *blockchain.BlockChain) error {
 
 	// Check if the utreexo undo bucket exists.
 	var exists bool
-	err := idx.db.View(func(dbTx database.Tx) error {
+	err = idx.db.View(func(dbTx database.Tx) error {
 		parentBucket := dbTx.Metadata().Bucket(utreexoParentBucketKey)
 		bucket := parentBucket.Bucket(utreexoUndoKey)
 		exists = bucket != nil
@@ -584,12 +591,6 @@ func NewUtreexoProofIndex(db database.DB, pruned bool, maxMemoryUsage int64,
 			Name:           db.Type(),
 		},
 	}
-
-	uState, err := InitUtreexoState(idx.config)
-	if err != nil {
-		return nil, err
-	}
-	idx.utreexoState = uState
 
 	return idx, nil
 }

--- a/blockchain/internal/utreexobackends/cachedleavesmap.go
+++ b/blockchain/internal/utreexobackends/cachedleavesmap.go
@@ -176,21 +176,29 @@ func (ms *CachedLeavesMapSlice) ClearMaps() {
 // ForEach loops through all the elements in the cachedleaves map slice and calls fn with the key-value pairs.
 //
 // This function is safe for concurrent access.
-func (ms *CachedLeavesMapSlice) ForEach(fn func(utreexo.Hash, uint64)) {
+func (ms *CachedLeavesMapSlice) ForEach(fn func(utreexo.Hash, uint64) error) error {
 	ms.mtx.Lock()
 	defer ms.mtx.Unlock()
 
 	for _, m := range ms.maps {
 		for k, v := range m {
-			fn(k, v)
+			err := fn(k, v)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
 	if len(ms.overflow) > 0 {
 		for k, v := range ms.overflow {
-			fn(k, v)
+			err := fn(k, v)
+			if err != nil {
+				return err
+			}
 		}
 	}
+
+	return nil
 }
 
 // createMaps creates a slice of maps and returns the total count that the maps

--- a/blockchain/internal/utreexobackends/cachedleavesmap.go
+++ b/blockchain/internal/utreexobackends/cachedleavesmap.go
@@ -192,6 +192,10 @@ func (ms *CachedLeavesMapSlice) ClearMaps() {
 			delete(ms.maps[i], key)
 		}
 	}
+
+	for key := range ms.overflow {
+		delete(ms.overflow, key)
+	}
 }
 
 // ForEach loops through all the elements in the cachedleaves map slice and calls fn with the key-value pairs.

--- a/blockchain/internal/utreexobackends/cachedleavesmap.go
+++ b/blockchain/internal/utreexobackends/cachedleavesmap.go
@@ -224,6 +224,11 @@ func (ms *CachedLeavesMapSlice) createMaps(maxMemoryUsage int64) int64 {
 	return int64(totalElemCount)
 }
 
+// Overflowed returns true if the map slice overflowed.
+func (ms *CachedLeavesMapSlice) Overflowed() bool {
+	return len(ms.overflow) > 0
+}
+
 // NewCachedLeavesMapSlice returns a new CachedLeavesMapSlice and the total amount of elements
 // that the map slice can accomodate.
 func NewCachedLeavesMapSlice(maxTotalMemoryUsage int64) (CachedLeavesMapSlice, int64) {

--- a/blockchain/internal/utreexobackends/cachedleavesmap_test.go
+++ b/blockchain/internal/utreexobackends/cachedleavesmap_test.go
@@ -62,7 +62,7 @@ func TestCachedLeaveMapSliceDuplicates(t *testing.T) {
 	}
 
 	// Make sure the length of the map is 1 less than the max elems.
-	if m.Length() != int(maxElems)-1 {
+	if m.Length()-len(m.overflow) != int(maxElems)-1 {
 		t.Fatalf("expected length of %v but got %v",
 			maxElems-1, m.Length())
 	}
@@ -71,8 +71,13 @@ func TestCachedLeaveMapSliceDuplicates(t *testing.T) {
 	if !m.Put(uint64ToHash(0), 0) {
 		t.Fatalf("didn't expect error but unsuccessfully called put")
 	}
-	if m.Length() != int(maxElems) {
+	if m.Length()-len(m.overflow) != int(maxElems) {
 		t.Fatalf("expected length of %v but got %v",
 			maxElems, m.Length())
+	}
+
+	if len(m.overflow) != 1 {
+		t.Fatalf("expected length of %v but got %v",
+			1, len(m.overflow))
 	}
 }

--- a/blockchain/internal/utreexobackends/cachedleavesmap_test.go
+++ b/blockchain/internal/utreexobackends/cachedleavesmap_test.go
@@ -35,7 +35,7 @@ func TestCachedLeaveMapSliceDuplicates(t *testing.T) {
 	m, maxElems := NewCachedLeavesMapSlice(8000)
 	for i := 0; i < 10; i++ {
 		for j := int64(0); j < maxElems; j++ {
-			if !m.Put(uint64ToHash(uint64(j)), 0) {
+			if !m.Put(uint64ToHash(uint64(j)), CachedPosition{}) {
 				t.Fatalf("unexpected error on m.put")
 			}
 		}
@@ -49,7 +49,7 @@ func TestCachedLeaveMapSliceDuplicates(t *testing.T) {
 	// Try inserting x which should be unique. Should fail as the map is full.
 	x := uint64(0)
 	x -= 1
-	if m.Put(uint64ToHash(x), 0) {
+	if m.Put(uint64ToHash(x), CachedPosition{}) {
 		t.Fatalf("expected error but successfully called put")
 	}
 
@@ -57,7 +57,7 @@ func TestCachedLeaveMapSliceDuplicates(t *testing.T) {
 	// a duplicate element.
 	m.Delete(uint64ToHash(0))
 	x = uint64(maxElems) - 1
-	if !m.Put(uint64ToHash(x), 0) {
+	if !m.Put(uint64ToHash(x), CachedPosition{}) {
 		t.Fatalf("unexpected failure on put")
 	}
 
@@ -68,7 +68,7 @@ func TestCachedLeaveMapSliceDuplicates(t *testing.T) {
 	}
 
 	// Put 0 back in and then compare the map.
-	if !m.Put(uint64ToHash(0), 0) {
+	if !m.Put(uint64ToHash(0), CachedPosition{}) {
 		t.Fatalf("didn't expect error but unsuccessfully called put")
 	}
 	if m.Length()-len(m.overflow) != int(maxElems) {

--- a/blockchain/internal/utreexobackends/nodesmap.go
+++ b/blockchain/internal/utreexobackends/nodesmap.go
@@ -208,6 +208,10 @@ func (ms *NodesMapSlice) ClearMaps() {
 			delete(ms.maps[i], key)
 		}
 	}
+
+	for key := range ms.overflow {
+		delete(ms.overflow, key)
+	}
 }
 
 // ForEach loops through all the elements in the nodes map slice and calls fn with the key-value pairs.

--- a/blockchain/internal/utreexobackends/nodesmap.go
+++ b/blockchain/internal/utreexobackends/nodesmap.go
@@ -261,6 +261,11 @@ func (ms *NodesMapSlice) createMaps(maxMemoryUsage int64) int64 {
 	return int64(totalElemCount)
 }
 
+// Overflowed returns true if the map slice overflowed.
+func (ms *NodesMapSlice) Overflowed() bool {
+	return len(ms.overflow) > 0
+}
+
 // NewNodesMapSlice returns a new NodesMapSlice and the total amount of elements
 // that the map slice can accomodate.
 func NewNodesMapSlice(maxTotalMemoryUsage int64) (NodesMapSlice, int64) {

--- a/blockchain/internal/utreexobackends/nodesmap.go
+++ b/blockchain/internal/utreexobackends/nodesmap.go
@@ -213,21 +213,29 @@ func (ms *NodesMapSlice) ClearMaps() {
 // ForEach loops through all the elements in the nodes map slice and calls fn with the key-value pairs.
 //
 // This function is safe for concurrent access.
-func (ms *NodesMapSlice) ForEach(fn func(uint64, CachedLeaf)) {
+func (ms *NodesMapSlice) ForEach(fn func(uint64, CachedLeaf) error) error {
 	ms.mtx.Lock()
 	defer ms.mtx.Unlock()
 
 	for _, m := range ms.maps {
 		for k, v := range m {
-			fn(k, v)
+			err := fn(k, v)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
 	if len(ms.overflow) > 0 {
 		for k, v := range ms.overflow {
-			fn(k, v)
+			err := fn(k, v)
+			if err != nil {
+				return err
+			}
 		}
 	}
+
+	return nil
 }
 
 // createMaps creates a slice of maps and returns the total count that the maps

--- a/blockchain/internal/utreexobackends/nodesmap_test.go
+++ b/blockchain/internal/utreexobackends/nodesmap_test.go
@@ -50,7 +50,7 @@ func TestNodesMapSliceDuplicates(t *testing.T) {
 	}
 
 	// Make sure the length of the map is 1 less than the max elems.
-	if m.Length() != int(maxElems)-1 {
+	if m.Length()-len(m.overflow) != int(maxElems)-1 {
 		t.Fatalf("expected length of %v but got %v",
 			maxElems-1, m.Length())
 	}
@@ -59,8 +59,13 @@ func TestNodesMapSliceDuplicates(t *testing.T) {
 	if !m.Put(0, CachedLeaf{}) {
 		t.Fatalf("didn't expect error but unsuccessfully called put")
 	}
-	if m.Length() != int(maxElems) {
+	if m.Length()-len(m.overflow) != int(maxElems) {
 		t.Fatalf("expected length of %v but got %v",
 			maxElems, m.Length())
+	}
+
+	if len(m.overflow) != 1 {
+		t.Fatalf("expected length of %v but got %v",
+			1, len(m.overflow))
 	}
 }

--- a/blockchain/utreexoio.go
+++ b/blockchain/utreexoio.go
@@ -94,8 +94,6 @@ func (m *NodesBackEnd) Get(k uint64) (utreexo.Leaf, bool) {
 			return utreexo.Leaf{}, false
 		}
 
-		m.cache.Put(k, cLeaf)
-
 		// If we found it, return here.
 		return cLeaf.Leaf, true
 	}

--- a/blockchain/utreexoio.go
+++ b/blockchain/utreexoio.go
@@ -245,6 +245,11 @@ func (m *NodesBackEnd) IsFlushNeeded() bool {
 	return m.cache.Overflowed()
 }
 
+// UsageStats returns the currently cached elements and the total amount the cache can hold.
+func (m *NodesBackEnd) UsageStats() (int64, int64) {
+	return int64(m.cache.Length()), m.maxCacheElem
+}
+
 // flush saves all the cached entries to disk and resets the cache map.
 func (m *NodesBackEnd) Flush(ldbTx *leveldb.Transaction) {
 	m.cache.ForEach(func(k uint64, v utreexobackends.CachedLeaf) {
@@ -406,6 +411,11 @@ func (m *CachedLeavesBackEnd) ForEach(fn func(utreexo.Hash, uint64) error) error
 // IsFlushNeeded returns true if the backend needs to be flushed.
 func (m *CachedLeavesBackEnd) IsFlushNeeded() bool {
 	return m.cache.Overflowed()
+}
+
+// UsageStats returns the currently cached elements and the total amount the cache can hold.
+func (m *CachedLeavesBackEnd) UsageStats() (int64, int64) {
+	return int64(m.cache.Length()), m.maxCacheElem
 }
 
 // Flush resets the cache and saves all the key values onto the database.

--- a/blockchain/utreexoio.go
+++ b/blockchain/utreexoio.go
@@ -240,6 +240,11 @@ func (m *NodesBackEnd) ForEach(fn func(uint64, utreexo.Leaf) error) error {
 	return iter.Error()
 }
 
+// IsFlushNeeded returns true if the backend needs to be flushed.
+func (m *NodesBackEnd) IsFlushNeeded() bool {
+	return m.cache.Overflowed()
+}
+
 // flush saves all the cached entries to disk and resets the cache map.
 func (m *NodesBackEnd) Flush(ldbTx *leveldb.Transaction) {
 	m.cache.ForEach(func(k uint64, v utreexobackends.CachedLeaf) {
@@ -396,6 +401,11 @@ func (m *CachedLeavesBackEnd) ForEach(fn func(utreexo.Hash, uint64) error) error
 	}
 	iter.Release()
 	return iter.Error()
+}
+
+// IsFlushNeeded returns true if the backend needs to be flushed.
+func (m *CachedLeavesBackEnd) IsFlushNeeded() bool {
+	return m.cache.Overflowed()
 }
 
 // Flush resets the cache and saves all the key values onto the database.

--- a/blockchain/utreexoio_test.go
+++ b/blockchain/utreexoio_test.go
@@ -20,19 +20,7 @@ func TestCachedLeavesBackEnd(t *testing.T) {
 	}{
 		{
 			tmpDir: func() string {
-				return filepath.Join(os.TempDir(), "TestCachedLeavesBackEnd0")
-			}(),
-			maxMemUsage: -1,
-		},
-		{
-			tmpDir: func() string {
-				return filepath.Join(os.TempDir(), "TestCachedLeavesBackEnd1")
-			}(),
-			maxMemUsage: 0,
-		},
-		{
-			tmpDir: func() string {
-				return filepath.Join(os.TempDir(), "TestCachedLeavesBackEnd2")
+				return filepath.Join(os.TempDir(), "TestCachedLeavesBackEnd")
 			}(),
 			maxMemUsage: 1 * 1024 * 1024,
 		},
@@ -164,19 +152,7 @@ func TestNodesBackEnd(t *testing.T) {
 	}{
 		{
 			tmpDir: func() string {
-				return filepath.Join(os.TempDir(), "TestNodesBackEnd0")
-			}(),
-			maxMemUsage: -1,
-		},
-		{
-			tmpDir: func() string {
-				return filepath.Join(os.TempDir(), "TestNodesBackEnd1")
-			}(),
-			maxMemUsage: 0,
-		},
-		{
-			tmpDir: func() string {
-				return filepath.Join(os.TempDir(), "TestNodesBackEnd2")
+				return filepath.Join(os.TempDir(), "TestNodesBackEnd")
 			}(),
 			maxMemUsage: 1 * 1024 * 1024,
 		},

--- a/blockchain/utreexoio_test.go
+++ b/blockchain/utreexoio_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/utreexo/utreexo"
 	"github.com/utreexo/utreexod/blockchain/internal/utreexobackends"
 )
@@ -38,7 +39,11 @@ func TestCachedLeavesBackEnd(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		cachedLeavesBackEnd, err := InitCachedLeavesBackEnd(test.tmpDir, test.maxMemUsage)
+		db, err := leveldb.OpenFile(test.tmpDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cachedLeavesBackEnd, err := InitCachedLeavesBackEnd(db, test.maxMemUsage)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -56,11 +61,17 @@ func TestCachedLeavesBackEnd(t *testing.T) {
 		}
 
 		// Close and reopen the backend.
-		err = cachedLeavesBackEnd.Close()
+		cachedLeavesBackEnd.Flush()
+		err = db.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
-		cachedLeavesBackEnd, err = InitCachedLeavesBackEnd(test.tmpDir, test.maxMemUsage)
+
+		db, err = leveldb.OpenFile(test.tmpDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cachedLeavesBackEnd, err = InitCachedLeavesBackEnd(db, test.maxMemUsage)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -172,7 +183,11 @@ func TestNodesBackEnd(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		nodesBackEnd, err := InitNodesBackEnd(test.tmpDir, test.maxMemUsage)
+		db, err := leveldb.OpenFile(test.tmpDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		nodesBackEnd, err := InitNodesBackEnd(db, test.maxMemUsage)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -190,11 +205,17 @@ func TestNodesBackEnd(t *testing.T) {
 		}
 
 		// Close and reopen the backend.
-		err = nodesBackEnd.Close()
+		nodesBackEnd.Flush()
+		err = db.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
-		nodesBackEnd, err = InitNodesBackEnd(test.tmpDir, test.maxMemUsage)
+
+		db, err = leveldb.OpenFile(test.tmpDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		nodesBackEnd, err = InitNodesBackEnd(db, test.maxMemUsage)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/blockchain/utreexoio_test.go
+++ b/blockchain/utreexoio_test.go
@@ -48,8 +48,16 @@ func TestCachedLeavesBackEnd(t *testing.T) {
 			cachedLeavesBackEnd.Put(hash, i)
 		}
 
+		ldbTx, err := db.OpenTransaction()
+		if err != nil {
+			t.Fatal(err)
+		}
 		// Close and reopen the backend.
-		cachedLeavesBackEnd.Flush()
+		cachedLeavesBackEnd.Flush(ldbTx)
+		err = ldbTx.Commit()
+		if err != nil {
+			t.Fatal(err)
+		}
 		err = db.Close()
 		if err != nil {
 			t.Fatal(err)
@@ -180,8 +188,16 @@ func TestNodesBackEnd(t *testing.T) {
 			nodesBackEnd.Put(i, utreexo.Leaf{Hash: hash})
 		}
 
+		ldbTx, err := db.OpenTransaction()
+		if err != nil {
+			t.Fatal(err)
+		}
 		// Close and reopen the backend.
-		nodesBackEnd.Flush()
+		nodesBackEnd.Flush(ldbTx)
+		err = ldbTx.Commit()
+		if err != nil {
+			t.Fatal(err)
+		}
 		err = db.Close()
 		if err != nil {
 			t.Fatal(err)

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -180,11 +180,11 @@ func (ms *mapSlice) deleteMaps() {
 }
 
 const (
-	// utxoFlushPeriodicInterval is the interval at which a flush is performed
+	// UtxoFlushPeriodicInterval is the interval at which a flush is performed
 	// when the flush mode FlushPeriodic is used.  This is used when the initial
 	// block download is complete and it's useful to flush periodically in case
 	// of unforseen shutdowns.
-	utxoFlushPeriodicInterval = time.Minute * 5
+	UtxoFlushPeriodicInterval = time.Minute * 5
 )
 
 // FlushMode is used to indicate the different urgency types for a flush.
@@ -563,7 +563,7 @@ func (s *utxoCache) flush(dbTx database.Tx, mode FlushMode, bestState *BestState
 	case FlushPeriodic:
 		// If the time since the last flush is over the periodic interval,
 		// force a flush.  Otherwise just flush when the cache is full.
-		if time.Since(s.lastFlushTime) > utxoFlushPeriodicInterval {
+		if time.Since(s.lastFlushTime) > UtxoFlushPeriodicInterval {
 			threshold = 0
 		} else {
 			threshold = s.maxTotalMemoryUsage

--- a/config.go
+++ b/config.go
@@ -490,7 +490,7 @@ func loadConfig() (*config, []string, error) {
 		MaxOrphanTxs:               defaultMaxOrphanTransactions,
 		SigCacheMaxSize:            defaultSigCacheMaxSize,
 		UtxoCacheMaxSizeMiB:        defaultUtxoCacheMaxSizeMiB,
-		UtreexoProofIndexMaxMemory: defaultUtxoCacheMaxSizeMiB,
+		UtreexoProofIndexMaxMemory: defaultUtxoCacheMaxSizeMiB * 2,
 		Generate:                   defaultGenerate,
 		TxIndex:                    defaultTxIndex,
 		TTLIndex:                   defaultTTLIndex,

--- a/database/interface.go
+++ b/database/interface.go
@@ -504,6 +504,9 @@ type DB interface {
 	// user-supplied function will result in a panic.
 	Update(fn func(tx Tx) error) error
 
+	// Flush flushes the internal cache of the database to the disk.
+	Flush() error
+
 	// Close cleanly shuts down the database and syncs all data.  It will
 	// block until all database transactions have been finalized (rolled
 	// back or committed).

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -837,14 +837,19 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 	// flush the blockchain cache because we don't expect new blocks immediately.
 	// After that, there is nothing more to do.
 	if !sm.headersFirstMode {
+		// Flush relevant indexes.
+		if err := sm.chain.FlushIndexes(blockchain.FlushPeriodic, true); err != nil {
+			log.Errorf("Error while flushing the blockchain cache: %v", err)
+		}
 		// Only flush if utreexoView is not active since a utreexo node does
 		// not have a utxo cache.
 		if !sm.chain.IsUtreexoViewActive() {
 			if err := sm.chain.FlushUtxoCache(blockchain.FlushPeriodic); err != nil {
 				log.Errorf("Error while flushing the blockchain cache: %v", err)
 			}
-			return
 		}
+
+		return
 	}
 
 	// This is headers-first mode, so if the block is not a checkpoint

--- a/server.go
+++ b/server.go
@@ -3239,7 +3239,7 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 		var err error
 		s.utreexoProofIndex, err = indexers.NewUtreexoProofIndex(
 			db, cfg.Prune != 0, cfg.UtreexoProofIndexMaxMemory*1024*1024,
-			chainParams, cfg.DataDir)
+			chainParams, cfg.DataDir, db.Flush)
 		if err != nil {
 			return nil, err
 		}
@@ -3256,7 +3256,7 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 		var err error
 		s.flatUtreexoProofIndex, err = indexers.NewFlatUtreexoProofIndex(
 			cfg.Prune != 0, chainParams, interval,
-			cfg.UtreexoProofIndexMaxMemory*1024*1024, cfg.DataDir)
+			cfg.UtreexoProofIndexMaxMemory*1024*1024, cfg.DataDir, db.Flush)
 		if err != nil {
 			return nil, err
 		}

--- a/server.go
+++ b/server.go
@@ -2574,7 +2574,7 @@ out:
 
 	// If utreexoProofIndex option is on, flush it after closing down syncManager.
 	if s.utreexoProofIndex != nil {
-		err := s.utreexoProofIndex.CloseUtreexoState()
+		err := s.utreexoProofIndex.CloseUtreexoState(&s.chain.BestSnapshot().Hash)
 		if err != nil {
 			btcdLog.Errorf("Error while flushing utreexo state: %v", err)
 		}
@@ -2582,7 +2582,7 @@ out:
 
 	// If flatUtreexoProofIndex option is on, flush it after closing down syncManager.
 	if s.flatUtreexoProofIndex != nil {
-		err := s.flatUtreexoProofIndex.CloseUtreexoState()
+		err := s.flatUtreexoProofIndex.CloseUtreexoState(&s.chain.BestSnapshot().Hash)
 		if err != nil {
 			btcdLog.Errorf("Error while flushing utreexo state: %v", err)
 		}

--- a/server.go
+++ b/server.go
@@ -2574,7 +2574,7 @@ out:
 
 	// If utreexoProofIndex option is on, flush it after closing down syncManager.
 	if s.utreexoProofIndex != nil {
-		err := s.utreexoProofIndex.FlushUtreexoState()
+		err := s.utreexoProofIndex.CloseUtreexoState()
 		if err != nil {
 			btcdLog.Errorf("Error while flushing utreexo state: %v", err)
 		}
@@ -2582,7 +2582,7 @@ out:
 
 	// If flatUtreexoProofIndex option is on, flush it after closing down syncManager.
 	if s.flatUtreexoProofIndex != nil {
-		err := s.flatUtreexoProofIndex.FlushUtreexoState()
+		err := s.flatUtreexoProofIndex.CloseUtreexoState()
 		if err != nil {
 			btcdLog.Errorf("Error while flushing utreexo state: %v", err)
 		}

--- a/server.go
+++ b/server.go
@@ -2574,7 +2574,7 @@ out:
 
 	// If utreexoProofIndex option is on, flush it after closing down syncManager.
 	if s.utreexoProofIndex != nil {
-		err := s.utreexoProofIndex.CloseUtreexoState(&s.chain.BestSnapshot().Hash)
+		err := s.utreexoProofIndex.CloseUtreexoState()
 		if err != nil {
 			btcdLog.Errorf("Error while flushing utreexo state: %v", err)
 		}
@@ -2582,7 +2582,7 @@ out:
 
 	// If flatUtreexoProofIndex option is on, flush it after closing down syncManager.
 	if s.flatUtreexoProofIndex != nil {
-		err := s.flatUtreexoProofIndex.CloseUtreexoState(&s.chain.BestSnapshot().Hash)
+		err := s.flatUtreexoProofIndex.CloseUtreexoState()
 		if err != nil {
 			btcdLog.Errorf("Error while flushing utreexo state: %v", err)
 		}


### PR DESCRIPTION
When running either the `utreexoproofindex` or the `flatutreexoproofindex` they will not be able to recover in cases of unexpected shutdown. This forces the user to reindex which is very costly.

The changes here make it so that the utreexo proof indexes are able to recover even in cases of unexpected shutdowns.