### PR TITLE
Add new getcfilters message for utreexo nodes

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1080,6 +1080,32 @@ func SerializeUtreexoRoots(numLeaves uint64, roots []utreexo.Hash) ([]byte, erro
 	return w.Bytes(), nil
 }
 
+// SerializeUtreexoRootsHash serializes the numLeaves and the roots into a byte slice.
+// it takes in a slice of chainhash.Hash instead of utreexo.Hash. chainhash.Hash is the hashed
+// value of the utreexo.Hash.
+func SerializeUtreexoRootsHash(numLeaves uint64, roots []*chainhash.Hash) ([]byte, error) {
+	// 8 byte NumLeaves + (32 byte roots * len(roots))
+	w := bytes.NewBuffer(make([]byte, 0, 8+(len(roots)*chainhash.HashSize)))
+
+	// Write the NumLeaves first.
+	var buf [8]byte
+	byteOrder.PutUint64(buf[:], numLeaves)
+	_, err := w.Write(buf[:])
+	if err != nil {
+		return nil, err
+	}
+
+	// Then write the roots.
+	for _, root := range roots {
+		_, err = w.Write(root[:])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return w.Bytes(), nil
+}
+
 // DeserializeUtreexoRoots deserializes the provided byte slice into numLeaves and roots.
 func DeserializeUtreexoRoots(serializedUView []byte) (uint64, []utreexo.Hash, error) {
 	totalLen := len(serializedUView)

--- a/blockchain/indexers/utreexocfindex.go
+++ b/blockchain/indexers/utreexocfindex.go
@@ -1,0 +1,301 @@
+package indexers
+
+import (
+	"errors"
+
+	"github.com/utreexo/utreexod/blockchain"
+	"github.com/utreexo/utreexod/btcutil"
+	"github.com/utreexo/utreexod/btcutil/gcs/builder"
+	"github.com/utreexo/utreexod/chaincfg"
+	"github.com/utreexo/utreexod/chaincfg/chainhash"
+	"github.com/utreexo/utreexod/database"
+	"github.com/utreexo/utreexod/wire"
+)
+
+// utreexoProofIndexName is the human-readable name for the index.
+const (
+	utreexoCFIndexName = "utreexo custom cfilter index"
+)
+
+// utreexocfilter is a custom commited filter which serves utreexo roots
+// these roots are already present, so they need not be created/stored, their
+// headers could be stored though
+var (
+	// utreexoCFIndexParentBucketKey is the name of the parent bucket used to
+	// house the index. The rest of the buckets live below this bucket.
+	utreexoCFIndexParentBucketKey = []byte("utreexocfindexparentbucket")
+
+	// utreexoCfHeaderKeys is an array of db bucket names used to house indexes of
+	// block hashes to cf headers.
+	utreexoCfHeaderKeys = [][]byte{
+		[]byte("utreexocfheaderbyhashidx"),
+	}
+)
+
+// dbFetchFilterIdxEntry retrieves a data blob from the filter index database.
+// An entry's absence is not considered an error.
+func dbFetchUtreexoCFilterIdxEntry(dbTx database.Tx, key []byte, h *chainhash.Hash) ([]byte, error) {
+	idx := dbTx.Metadata().Bucket(utreexoCFIndexParentBucketKey).Bucket(key)
+	return idx.Get(h[:]), nil
+}
+
+// dbStoreFilterIdxEntry stores a data blob in the filter index database.
+func dbStoreUtreexoCFilterIdxEntry(dbTx database.Tx, key []byte, h *chainhash.Hash, f []byte) error {
+	idx := dbTx.Metadata().Bucket(utreexoCFIndexParentBucketKey).Bucket(key)
+	return idx.Put(h[:], f)
+}
+
+// dbDeleteFilterIdxEntry deletes a data blob from the filter index database.
+func dbDeleteUtreexoCFilterIdxEntry(dbTx database.Tx, key []byte, h *chainhash.Hash) error {
+	idx := dbTx.Metadata().Bucket(utreexoCFIndexParentBucketKey).Bucket(key)
+	return idx.Delete(h[:])
+}
+
+var _ Indexer = (*UtreexoCFIndex)(nil)
+
+var _ NeedsInputser = (*UtreexoCFIndex)(nil)
+
+type UtreexoCFIndex struct {
+	db          database.DB
+	chainParams *chaincfg.Params
+
+	chain *blockchain.BlockChain
+
+	utreexoProofIndex *UtreexoProofIndex
+
+	flatUtreexoProofIndex *FlatUtreexoProofIndex
+}
+
+func (idx *UtreexoCFIndex) NeedsInputs() bool {
+	return true
+}
+
+// Init initializes the utreexo cf index. This is part of the Indexer
+// interface.
+func (idx *UtreexoCFIndex) Init(_ *blockchain.BlockChain) error {
+	return nil // Nothing to do.
+}
+
+// Key returns the database key to use for the index as a byte slice. This is
+// part of the Indexer interface.
+func (idx *UtreexoCFIndex) Key() []byte {
+	return utreexoCFIndexParentBucketKey
+}
+
+// Name returns the human-readable name of the index. This is part of the
+// Indexer interface.
+func (idx *UtreexoCFIndex) Name() string {
+	return utreexoCFIndexName
+}
+
+// Create is invoked when the index manager determines the index needs to
+// be created for the first time. It creates buckets for the custom utreexo
+// filter index.
+func (idx *UtreexoCFIndex) Create(dbTx database.Tx) error {
+	meta := dbTx.Metadata()
+
+	utreexoCfIndexParentBucket, err := meta.CreateBucket(utreexoCFIndexParentBucketKey)
+	if err != nil {
+		return err
+	}
+
+	for _, bucketName := range utreexoCfHeaderKeys {
+		_, err = utreexoCfIndexParentBucket.CreateBucket(bucketName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// storeUtreexoCFilter stores a given utreexocfilter header
+func storeUtreexoCFHeader(dbTx database.Tx, block *btcutil.Block, filterData []byte,
+	filterType wire.FilterType) error {
+	if filterType != wire.UtreexoCFilter {
+		return errors.New("invalid filter type")
+	}
+
+	// Figure out which header bucket to use.
+	hkey := utreexoCfHeaderKeys[0]
+	h := block.Hash()
+
+	// fetch the previous block's filter header.
+	var prevHeader *chainhash.Hash
+	ph := &block.MsgBlock().Header.PrevBlock
+	if ph.IsEqual(&zeroHash) {
+		prevHeader = &zeroHash
+	} else {
+		pfh, err := dbFetchUtreexoCFilterIdxEntry(dbTx, hkey, ph)
+		if err != nil {
+			return err
+		}
+
+		// Construct the new block's filter header, and store it.
+		prevHeader, err = chainhash.NewHash(pfh)
+		if err != nil {
+			return err
+		}
+	}
+
+	fh, err := builder.MakeHeaderForUtreexoCFilter(filterData, *prevHeader)
+	if err != nil {
+		return err
+	}
+	return dbStoreUtreexoCFilterIdxEntry(dbTx, hkey, h, fh[:])
+}
+
+// ConnectBlock is invoked by the index manager when a new block has been
+// connected to the main chain.
+// This is part of the Indexer interface.
+func (idx *UtreexoCFIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Block,
+	stxos []blockchain.SpentTxOut) error {
+
+	blockHash := block.Hash()
+	roots, leaves, err := idx.fetchUtreexoRoots(dbTx, blockHash)
+
+	if err != nil {
+		return err
+	}
+
+	// serialize the hashes of the utreexo roots hash
+	serializedUtreexo, err := blockchain.SerializeUtreexoRootsHash(leaves, roots)
+	if err != nil {
+		return err
+	}
+
+	return storeUtreexoCFHeader(dbTx, block, serializedUtreexo, wire.UtreexoCFilter)
+}
+
+// fetches the utreexo roots for a given block hash
+func (idx *UtreexoCFIndex) fetchUtreexoRoots(dbTx database.Tx,
+	blockHash *chainhash.Hash) ([]*chainhash.Hash, uint64, error) {
+
+	var leaves uint64
+	var roots []*chainhash.Hash
+
+	// For compact state nodes
+	if idx.chain.IsUtreexoViewActive() && idx.chain.IsAssumeUtreexo() {
+		viewPoint, err := idx.chain.FetchUtreexoViewpoint(blockHash)
+		if err != nil {
+			return nil, 0, err
+		}
+		roots = viewPoint.GetRoots()
+		leaves = viewPoint.NumLeaves()
+	}
+	// for bridge nodes
+	if idx.utreexoProofIndex != nil {
+		roots, leaves, err := idx.utreexoProofIndex.FetchUtreexoState(dbTx, blockHash)
+		if err != nil {
+			return nil, 0, err
+		}
+		return roots, leaves, nil
+	} else if idx.flatUtreexoProofIndex != nil {
+		height, err := idx.chain.BlockHeightByHash(blockHash)
+		if err != nil {
+			return nil, 0, err
+		}
+		roots, leaves, err := idx.flatUtreexoProofIndex.FetchUtreexoState(height)
+		if err != nil {
+			return nil, 0, err
+		}
+		return roots, leaves, nil
+	}
+
+	return roots, leaves, nil
+}
+
+// DisconnectBlock is invoked by the index manager when a block has been
+// disconnected from the main chain.  This indexer removes the hash-to-cf
+// mapping for every passed block. This is part of the Indexer interface.
+func (idx *UtreexoCFIndex) DisconnectBlock(dbTx database.Tx, block *btcutil.Block,
+	_ []blockchain.SpentTxOut) error {
+
+	for _, key := range utreexoCfHeaderKeys {
+		err := dbDeleteUtreexoCFilterIdxEntry(dbTx, key, block.Hash())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// PruneBlock is invoked when an older block is deleted after it's been
+// processed.
+// TODO (kcalvinalvin): Consider keeping the filters at a later date to help with
+// reindexing as a pruned node.
+//
+// This is part of the Indexer interface.
+func (idx *UtreexoCFIndex) PruneBlock(dbTx database.Tx, blockHash *chainhash.Hash) error {
+
+	for _, key := range utreexoCfHeaderKeys {
+		err := dbDeleteUtreexoCFilterIdxEntry(dbTx, key, blockHash)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// entryByBlockHash fetches a filter index entry of a particular type
+// (eg. filter, filter header, etc) for a filter type and block hash.
+func (idx *UtreexoCFIndex) entryByBlockHash(dbTx database.Tx,
+	filterType wire.FilterType, h *chainhash.Hash) ([]byte, error) {
+
+	if uint8(filterType) != uint8(wire.UtreexoCFilter) {
+		return nil, errors.New("unsupported filter type")
+	}
+
+	roots, leaves, err := idx.fetchUtreexoRoots(dbTx, h)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// serialize the hashes of the utreexo roots hash
+	serializedUtreexo, err := blockchain.SerializeUtreexoRootsHash(leaves, roots)
+	if err != nil {
+		return nil, err
+	}
+
+	return serializedUtreexo, err
+}
+
+// FilterByBlockHash returns the serialized contents of a block's utreexo
+// cfilter.
+func (idx *UtreexoCFIndex) FilterByBlockHash(dbTx database.Tx, h *chainhash.Hash,
+	filterType wire.FilterType) ([]byte, error) {
+	return idx.entryByBlockHash(dbTx, filterType, h)
+}
+
+// NewCfIndex returns a new instance of an indexer that is used to create a
+// mapping of the hashes of all blocks in the blockchain to their respective
+// committed filters.
+//
+// It implements the Indexer interface which plugs into the IndexManager that
+// in turn is used by the blockchain package. This allows the index to be
+// seamlessly maintained along with the chain.
+func NewUtreexoCfIndex(db database.DB, chainParams *chaincfg.Params, utreexoProofIndex *UtreexoProofIndex,
+	flatUtreexoProofIndex *FlatUtreexoProofIndex) *UtreexoCFIndex {
+	return &UtreexoCFIndex{db: db, chainParams: chainParams, utreexoProofIndex: utreexoProofIndex,
+		flatUtreexoProofIndex: flatUtreexoProofIndex}
+}
+
+// DropCfIndex drops the CF index from the provided database if exists.
+func DropUtreexoCfIndex(db database.DB, interrupt <-chan struct{}) error {
+	return dropIndex(db, utreexoCFIndexParentBucketKey, utreexoCFIndexName, interrupt)
+}
+
+// CfIndexInitialized returns true if the cfindex has been created previously.
+func UtreexoCfIndexInitialized(db database.DB) bool {
+	var exists bool
+	db.View(func(dbTx database.Tx) error {
+		bucket := dbTx.Metadata().Bucket(utreexoCFIndexParentBucketKey)
+		exists = bucket != nil
+		return nil
+	})
+
+	return exists
+}

--- a/blockchain/indexers/utreexocfindex.go
+++ b/blockchain/indexers/utreexocfindex.go
@@ -175,7 +175,7 @@ func (idx *UtreexoCFIndex) fetchUtreexoRoots(dbTx database.Tx,
 	var roots []*chainhash.Hash
 
 	// For compact state nodes
-	if idx.chain.IsUtreexoViewActive() && idx.chain.IsAssumeUtreexo() {
+	if idx.chain.IsUtreexoViewActive() {
 		viewPoint, err := idx.chain.FetchUtreexoViewpoint(blockHash)
 		if err != nil {
 			return nil, 0, err

--- a/btcutil/gcs/builder/builder.go
+++ b/btcutil/gcs/builder/builder.go
@@ -369,3 +369,19 @@ func MakeHeaderForFilter(filter *gcs.Filter, prevHeader chainhash.Hash) (chainha
 	// above.
 	return chainhash.DoubleHashH(filterTip), nil
 }
+
+// MakeHeaderForUtreexoCFilter makes a filter chain header for a utreexoc filter, given the
+// filter data and the previous filter chain header.
+func MakeHeaderForUtreexoCFilter(filterData []byte, prevHeader chainhash.Hash) (chainhash.Hash, error) {
+	filterTip := make([]byte, 2*chainhash.HashSize)
+	filterHash := chainhash.DoubleHashH(filterData)
+
+	// In the buffer we created above we'll compute hash || prevHash as an
+	// intermediate value.
+	copy(filterTip, filterHash[:])
+	copy(filterTip[chainhash.HashSize:], prevHeader[:])
+
+	// The final filter hash is the double-sha256 of the hash computed
+	// above.
+	return chainhash.DoubleHashH(filterTip), nil
+}

--- a/config.go
+++ b/config.go
@@ -204,9 +204,11 @@ type config struct {
 	FlatUtreexoProofIndex      bool  `long:"flatutreexoproofindex" description:"Maintain a utreexo proof for all blocks in flat files"`
 	UtreexoProofIndexMaxMemory int64 `long:"utreexoproofindexmaxmemory" description:"The maxmimum memory in mebibytes (MiB) that the utreexo proof indexes will use up. Passing in 0 will make the entire proof index stay on disk. Passing in a negative value will make the entire proof index stay in memory. Default of 250MiB."`
 	CFilters                   bool  `long:"cfilters" description:"Enable committed filtering (CF) support"`
+	UtreexoCFilters            bool  `long:"utreexocfilters" description:"Enable committed filtering (CF) support serving utreexo roots."`
 	NoPeerBloomFilters         bool  `long:"nopeerbloomfilters" description:"Disable bloom filtering support"`
 	DropAddrIndex              bool  `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up and then exits."`
 	DropCfIndex                bool  `long:"dropcfindex" description:"Deletes the index used for committed filtering (CF) support from the database on start up and then exits."`
+	DropUtreexoCfIndex         bool  `long:"droputreexocfindex" description:"Deletes the index used for custom utreexo commited filter indexing support serving utreexo roots from the database on start up and then exits."`
 	DropTxIndex                bool  `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
 	DropTTLIndex               bool  `long:"dropttlindex" description:"Deletes the time to live index from the database on start up and then exits."`
 	DropUtreexoProofIndex      bool  `long:"droputreexoproofindex" description:"Deletes the utreexo proof index from the database on start up and then exits."`

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2381,7 +2381,7 @@ func handleGetChainTips(s *rpcServer, cmd interface{}, closeChan <-chan struct{}
 
 // handleGetCFilter implements the getcfilter command.
 func handleGetCFilter(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
-	if s.cfg.CfIndex == nil {
+	if s.cfg.CfIndex == nil || s.cfg.UtreexoCfIndex != nil {
 		return nil, &btcjson.RPCError{
 			Code:    btcjson.ErrRPCNoCFIndex,
 			Message: "The CF index must be enabled for this command",
@@ -2394,7 +2394,20 @@ func handleGetCFilter(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) 
 		return nil, rpcDecodeHexError(c.Hash)
 	}
 
-	filterBytes, err := s.cfg.CfIndex.FilterByBlockHash(hash, c.FilterType)
+	var filterBytes []byte
+	if c.FilterType == wire.UtreexoCFilter {
+		err = s.cfg.DB.View(func(dbTx database.Tx) error {
+			var err error
+			filterBytes, err = s.cfg.UtreexoCfIndex.FilterByBlockHash(dbTx, hash, c.FilterType)
+			return err
+		})
+		if err != nil {
+			return nil, rpcNoTxInfoError(hash)
+		}
+	} else {
+		filterBytes, err = s.cfg.CfIndex.FilterByBlockHash(hash, c.FilterType)
+	}
+
 	if err != nil {
 		rpcsLog.Debugf("Could not find committed filter for %v: %v",
 			hash, err)
@@ -5649,6 +5662,7 @@ type rpcserverConfig struct {
 	TxIndex               *indexers.TxIndex
 	AddrIndex             *indexers.AddrIndex
 	CfIndex               *indexers.CfIndex
+	UtreexoCfIndex        *indexers.UtreexoCFIndex
 	TTLIndex              *indexers.TTLIndex
 	UtreexoProofIndex     *indexers.UtreexoProofIndex
 	FlatUtreexoProofIndex *indexers.FlatUtreexoProofIndex

--- a/server.go
+++ b/server.go
@@ -252,6 +252,7 @@ type server struct {
 	txIndex               *indexers.TxIndex
 	addrIndex             *indexers.AddrIndex
 	cfIndex               *indexers.CfIndex
+	utreexoCfIndex        *indexers.UtreexoCFIndex
 	ttlIndex              *indexers.TTLIndex
 	utreexoProofIndex     *indexers.UtreexoProofIndex
 	flatUtreexoProofIndex *indexers.FlatUtreexoProofIndex
@@ -863,52 +864,85 @@ func (sp *serverPeer) OnGetCFilters(_ *peer.Peer, msg *wire.MsgGetCFilters) {
 		return
 	}
 
+	var hashes []chainhash.Hash
+	var hashPtrs []*chainhash.Hash
+	// if the filter type is supported, we initialize variables to avoid duplicate code
+	if msg.FilterType == wire.GCSFilterRegular || msg.FilterType == wire.UtreexoCFilter {
+		var err error
+		// get the block hashes included in the getcfilters message
+		hashes, err = sp.server.chain.HeightToHashRange(
+			int32(msg.StartHeight), &msg.StopHash, wire.MaxGetCFiltersReqRange,
+		)
+		if err != nil {
+			peerLog.Debugf("Invalid getcfilters request: %v", err)
+			return
+		}
+
+		// Create []*chainhash.Hash from []chainhash.Hash to pass to
+		// FiltersByBlockHashes.
+		hashPtrs = make([]*chainhash.Hash, len(hashes))
+		for i := range hashes {
+			hashPtrs[i] = &hashes[i]
+		}
+	}
+
 	// We'll also ensure that the remote party is requesting a set of
 	// filters that we actually currently maintain.
 	switch msg.FilterType {
 	case wire.GCSFilterRegular:
-		break
+		filters, err := sp.server.cfIndex.FiltersByBlockHashes(
+			hashPtrs, msg.FilterType,
+		)
+		if err != nil {
+			peerLog.Errorf("Error retrieving cfilters: %v", err)
+			return
+		}
+
+		for i, filterBytes := range filters {
+			if len(filterBytes) == 0 {
+				peerLog.Warnf("Could not obtain cfilter for %v",
+					hashes[i])
+				return
+			}
+
+			filterMsg := wire.NewMsgCFilter(
+				msg.FilterType, &hashes[i], filterBytes,
+			)
+			sp.QueueMessage(filterMsg, nil)
+		}
+
+	case wire.UtreexoCFilter:
+		for i, blockHash := range hashPtrs {
+			var serializedUtreexo []byte
+
+			leaves, roots, err := sp.getUtreexoRoots(blockHash)
+			if err != nil {
+				return
+			}
+
+			// serialize the hashes of the utreexo roots hash
+			serializedUtreexo, err = blockchain.SerializeUtreexoRootsHash(leaves, roots)
+			if err != nil {
+				peerLog.Errorf("error serializing utreexoc filter: %v", err)
+				return
+			}
+
+			if len(serializedUtreexo) == 0 {
+				peerLog.Warnf("Could not obtain utreexocfilter for %v",
+					hashes[i])
+				return
+			}
+
+			filterMsg := wire.NewMsgCFilter(
+				msg.FilterType, &hashes[i], serializedUtreexo,
+			)
+			sp.QueueMessage(filterMsg, nil)
+		}
 
 	default:
 		peerLog.Debug("Filter request for unknown filter: %v",
 			msg.FilterType)
 		return
-	}
-
-	hashes, err := sp.server.chain.HeightToHashRange(
-		int32(msg.StartHeight), &msg.StopHash, wire.MaxGetCFiltersReqRange,
-	)
-	if err != nil {
-		peerLog.Debugf("Invalid getcfilters request: %v", err)
-		return
-	}
-
-	// Create []*chainhash.Hash from []chainhash.Hash to pass to
-	// FiltersByBlockHashes.
-	hashPtrs := make([]*chainhash.Hash, len(hashes))
-	for i := range hashes {
-		hashPtrs[i] = &hashes[i]
-	}
-
-	filters, err := sp.server.cfIndex.FiltersByBlockHashes(
-		hashPtrs, msg.FilterType,
-	)
-	if err != nil {
-		peerLog.Errorf("Error retrieving cfilters: %v", err)
-		return
-	}
-
-	for i, filterBytes := range filters {
-		if len(filterBytes) == 0 {
-			peerLog.Warnf("Could not obtain cfilter for %v",
-				hashes[i])
-			return
-		}
-
-		filterMsg := wire.NewMsgCFilter(
-			msg.FilterType, &hashes[i], filterBytes,
-		)
-		sp.QueueMessage(filterMsg, nil)
 	}
 }
 
@@ -919,114 +953,256 @@ func (sp *serverPeer) OnGetCFHeaders(_ *peer.Peer, msg *wire.MsgGetCFHeaders) {
 		return
 	}
 
+	var startHeight int32
+	var maxResults int
+	var hashList []chainhash.Hash
+	var hashPtrs []*chainhash.Hash
+	// if the filter type is supported, we initialize variables to avoid duplicate code
+	if msg.FilterType == wire.GCSFilterRegular || msg.FilterType == wire.UtreexoCFilter {
+
+		startHeight = int32(msg.StartHeight)
+		maxResults = wire.MaxCFHeadersPerMsg
+
+		// If StartHeight is positive, fetch the predecessor block hash so we
+		// can populate the PrevFilterHeader field.
+		if msg.StartHeight > 0 {
+			startHeight--
+			maxResults++
+		}
+
+		// Fetch the hashes from the block index.
+		var err error
+		hashList, err = sp.server.chain.HeightToHashRange(
+			startHeight, &msg.StopHash, maxResults,
+		)
+		if err != nil {
+			peerLog.Debugf("Invalid getcfheaders request: %v", err)
+		}
+
+		// This is possible if StartHeight is one greater that the height of
+		// StopHash, and we pull a valid range of hashes including the previous
+		// filter header.
+		if len(hashList) == 0 || (msg.StartHeight > 0 && len(hashList) == 1) {
+			peerLog.Debug("No results for getcfheaders request")
+			return
+		}
+
+		// Create []*chainhash.Hash from []chainhash.Hash to pass to
+		// FilterHeadersByBlockHashes.
+		hashPtrs = make([]*chainhash.Hash, len(hashList))
+		for i := range hashList {
+			hashPtrs[i] = &hashList[i]
+		}
+	}
+
 	// We'll also ensure that the remote party is requesting a set of
 	// headers for filters that we actually currently maintain.
 	switch msg.FilterType {
 	case wire.GCSFilterRegular:
-		break
+
+		// Fetch the raw filter hash bytes from the database for all blocks.
+		filterHashes, err := sp.server.cfIndex.FilterHashesByBlockHashes(
+			hashPtrs, msg.FilterType,
+		)
+		if err != nil {
+			peerLog.Errorf("Error retrieving cfilter hashes: %v", err)
+			return
+		}
+
+		// Generate cfheaders message and send it.
+		headersMsg := wire.NewMsgCFHeaders()
+
+		// Populate the PrevFilterHeader field.
+		if msg.StartHeight > 0 {
+			prevBlockHash := &hashList[0]
+
+			// Fetch the raw committed filter header bytes from the
+			// database.
+			headerBytes, err := sp.server.cfIndex.FilterHeaderByBlockHash(
+				prevBlockHash, msg.FilterType)
+			if err != nil {
+				peerLog.Errorf("Error retrieving CF header: %v", err)
+				return
+			}
+			if len(headerBytes) == 0 {
+				peerLog.Warnf("Could not obtain CF header for %v", prevBlockHash)
+				return
+			}
+
+			// Deserialize the hash into PrevFilterHeader.
+			err = headersMsg.PrevFilterHeader.SetBytes(headerBytes)
+			if err != nil {
+				peerLog.Warnf("Committed filter header deserialize "+
+					"failed: %v", err)
+				return
+			}
+
+			hashList = hashList[1:]
+			filterHashes = filterHashes[1:]
+		}
+
+		// Populate HeaderHashes.
+		for i, hashBytes := range filterHashes {
+			if len(hashBytes) == 0 {
+				peerLog.Warnf("Could not obtain CF hash for %v", hashList[i])
+				return
+			}
+
+			// Deserialize the hash.
+			filterHash, err := chainhash.NewHash(hashBytes)
+			if err != nil {
+				peerLog.Warnf("Committed filter hash deserialize "+
+					"failed: %v", err)
+				return
+			}
+
+			headersMsg.AddCFHash(filterHash)
+		}
+
+		headersMsg.FilterType = msg.FilterType
+		headersMsg.StopHash = msg.StopHash
+
+		sp.QueueMessage(headersMsg, nil)
+
+		// handle custom utreexocfilter message
+	case wire.UtreexoCFilter:
+
+		// Generate cfheaders message and send it.
+		headersMsg := wire.NewMsgCFHeaders()
+
+		// Populate the PrevFilterHeader field.
+		if msg.StartHeight > 0 {
+			prevBlockHash := &hashList[0]
+
+			// Fetch the raw committed filter header bytes from the
+			// database.
+			headerBytes, err := sp.server.cfIndex.FilterHeaderByBlockHash(
+				prevBlockHash, msg.FilterType)
+			if err != nil {
+				peerLog.Errorf("Error retrieving CF header: %v", err)
+				return
+			}
+			if len(headerBytes) == 0 {
+				peerLog.Warnf("Could not obtain CF header for %v", prevBlockHash)
+				return
+			}
+
+			// Deserialize the hash into PrevFilterHeader.
+			err = headersMsg.PrevFilterHeader.SetBytes(headerBytes)
+			if err != nil {
+				peerLog.Warnf("Committed filter header deserialize "+
+					"failed: %v", err)
+				return
+			}
+		}
+
+		// fetch filter hashes and add to cf hashes field
+		for i, blockHash := range hashPtrs {
+			var serializedUtreexo []byte
+			// skip the first index as this index was added so as to enable us
+			// to get the previous filter's header
+			if i == 0 {
+				continue
+			}
+
+			leaves, roots, err := sp.getUtreexoRoots(blockHash)
+			if err != nil {
+				return
+			}
+
+			// serialize the hashes of the utreexo roots hash
+			serializedUtreexo, err = blockchain.SerializeUtreexoRootsHash(leaves, roots)
+			if err != nil {
+				peerLog.Errorf("error serializing utreexoc filter: %v", err)
+				return
+			}
+
+			if len(serializedUtreexo) == 0 {
+				peerLog.Warnf("Could not obtain utreexocfilter for %v",
+					hashList[i])
+				return
+			}
+			hashBytes := chainhash.DoubleHashB(serializedUtreexo)
+
+			if len(hashBytes) == 0 {
+				peerLog.Warnf("Could not obtain CF hash for %v", hashList[i])
+				return
+			}
+
+			// Deserialize the hash.
+			filterHash, err := chainhash.NewHash(hashBytes)
+			if err != nil {
+				peerLog.Warnf("Committed filter hash deserialize "+
+					"failed: %v", err)
+				return
+			}
+
+			headersMsg.AddCFHash(filterHash)
+		}
+		headersMsg.FilterType = msg.FilterType
+		headersMsg.StopHash = msg.StopHash
+
+		sp.QueueMessage(headersMsg, nil)
 
 	default:
 		peerLog.Debug("Filter request for unknown headers for "+
 			"filter: %v", msg.FilterType)
 		return
 	}
+}
 
-	startHeight := int32(msg.StartHeight)
-	maxResults := wire.MaxCFHeadersPerMsg
+// getUtreexoRoots fetches utreexo roots from the appropriate locations, i.e fetches
+// roots for CSN from a different location from utreexoviewpoint and flatfile
+func (sp *serverPeer) getUtreexoRoots(blockHash *chainhash.Hash) (uint64, []*chainhash.Hash, error) {
 
-	// If StartHeight is positive, fetch the predecessor block hash so we
-	// can populate the PrevFilterHeader field.
-	if msg.StartHeight > 0 {
-		startHeight--
-		maxResults++
-	}
+	var leaves uint64
+	var roots []*chainhash.Hash
 
-	// Fetch the hashes from the block index.
-	hashList, err := sp.server.chain.HeightToHashRange(
-		startHeight, &msg.StopHash, maxResults,
-	)
-	if err != nil {
-		peerLog.Debugf("Invalid getcfheaders request: %v", err)
-	}
-
-	// This is possible if StartHeight is one greater that the height of
-	// StopHash, and we pull a valid range of hashes including the previous
-	// filter header.
-	if len(hashList) == 0 || (msg.StartHeight > 0 && len(hashList) == 1) {
-		peerLog.Debug("No results for getcfheaders request")
-		return
-	}
-
-	// Create []*chainhash.Hash from []chainhash.Hash to pass to
-	// FilterHeadersByBlockHashes.
-	hashPtrs := make([]*chainhash.Hash, len(hashList))
-	for i := range hashList {
-		hashPtrs[i] = &hashList[i]
-	}
-
-	// Fetch the raw filter hash bytes from the database for all blocks.
-	filterHashes, err := sp.server.cfIndex.FilterHashesByBlockHashes(
-		hashPtrs, msg.FilterType,
-	)
-	if err != nil {
-		peerLog.Errorf("Error retrieving cfilter hashes: %v", err)
-		return
-	}
-
-	// Generate cfheaders message and send it.
-	headersMsg := wire.NewMsgCFHeaders()
-
-	// Populate the PrevFilterHeader field.
-	if msg.StartHeight > 0 {
-		prevBlockHash := &hashList[0]
-
-		// Fetch the raw committed filter header bytes from the
-		// database.
-		headerBytes, err := sp.server.cfIndex.FilterHeaderByBlockHash(
-			prevBlockHash, msg.FilterType)
+	// For compact state nodes
+	if !cfg.NoUtreexo {
+		viewPoint, err := sp.server.chain.FetchUtreexoViewpoint(blockHash)
 		if err != nil {
-			peerLog.Errorf("Error retrieving CF header: %v", err)
-			return
+			peerLog.Errorf("could not obtain utreexo view: %v", err)
+			return 0, nil, err
 		}
-		if len(headerBytes) == 0 {
-			peerLog.Warnf("Could not obtain CF header for %v", prevBlockHash)
-			return
-		}
-
-		// Deserialize the hash into PrevFilterHeader.
-		err = headersMsg.PrevFilterHeader.SetBytes(headerBytes)
-		if err != nil {
-			peerLog.Warnf("Committed filter header deserialize "+
-				"failed: %v", err)
-			return
-		}
-
-		hashList = hashList[1:]
-		filterHashes = filterHashes[1:]
+		roots = viewPoint.GetRoots()
+		leaves = viewPoint.NumLeaves()
 	}
+	// for bridge nodes
+	if sp.server.utreexoProofIndex != nil {
+		var uleaves uint64
+		var uroots []*chainhash.Hash
+		var err error
+		err = sp.server.db.View(func(dbTx database.Tx) error {
+			uroots, uleaves, err = sp.server.utreexoProofIndex.FetchUtreexoState(dbTx, blockHash)
+			if err != nil {
+				return err
+			}
 
-	// Populate HeaderHashes.
-	for i, hashBytes := range filterHashes {
-		if len(hashBytes) == 0 {
-			peerLog.Warnf("Could not obtain CF hash for %v", hashList[i])
-			return
-		}
-
-		// Deserialize the hash.
-		filterHash, err := chainhash.NewHash(hashBytes)
+			return nil
+		})
 		if err != nil {
-			peerLog.Warnf("Committed filter hash deserialize "+
-				"failed: %v", err)
-			return
+			peerLog.Errorf("error fetching utreexo view for blockhash %s: error: %v", blockHash, err)
+			return 0, nil, err
 		}
-
-		headersMsg.AddCFHash(filterHash)
+		roots = uroots
+		leaves = uleaves
+	} else if sp.server.flatUtreexoProofIndex != nil {
+		height, err := sp.server.chain.BlockHeightByHash(blockHash)
+		if err != nil {
+			peerLog.Errorf("couldn't fetch the block height for blockhash %s from "+
+				"the blockindex. Error: %v", blockHash, err)
+			return 0, nil, err
+		}
+		uroots, uleaves, err := sp.server.flatUtreexoProofIndex.FetchUtreexoState(height)
+		if err != nil {
+			peerLog.Errorf("error fetching utreexo view for blockhash: %s: error: %v", err)
+			return 0, nil, err
+		}
+		roots = uroots
+		leaves = uleaves
 	}
-
-	headersMsg.FilterType = msg.FilterType
-	headersMsg.StopHash = msg.StopHash
-
-	sp.QueueMessage(headersMsg, nil)
+	return leaves, roots, nil
 }
 
 // OnGetCFCheckpt is invoked when a peer receives a getcfcheckpt bitcoin message.
@@ -3227,6 +3403,12 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 		indxLog.Info("Committed filter index is enabled")
 		s.cfIndex = indexers.NewCfIndex(db, chainParams)
 		indexes = append(indexes, s.cfIndex)
+	}
+	if cfg.UtreexoCFilters {
+		indxLog.Info("Utreexo C filter index enabled")
+		s.utreexoCfIndex = indexers.NewUtreexoCfIndex(db, chainParams,
+			s.utreexoProofIndex, s.flatUtreexoProofIndex)
+		indexes = append(indexes, s.utreexoCfIndex)
 	}
 	if cfg.TTLIndex {
 		indxLog.Info("TTL index is enabled")

--- a/wire/msgcfilter.go
+++ b/wire/msgcfilter.go
@@ -17,6 +17,7 @@ type FilterType uint8
 const (
 	// GCSFilterRegular is the regular filter type.
 	GCSFilterRegular FilterType = iota
+	UtreexoCFilter
 )
 
 const (


### PR DESCRIPTION
Add support for new getcfilters message called UtreexoCFilter
When a new block is added, a new UtreexoCFilter filter is created and persisted on the node.
This filter is created by serializing the contents of the roots at that height.
When a node receives a getcfilters message, the logic doesn't change much, it handles it almost identical to how it deals with basic filters.