### PR TITLE
main: bump version to 0.4.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -17,8 +17,8 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	appMajor uint = 0
-	appMinor uint = 3
-	appPatch uint = 1
+	appMinor uint = 4
+	appPatch uint = 0
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
Backwards incompatible P2P changes and the change to make recoverable bridge node possible are enough to require a minor version bump.