### PR TITLE
blockchain: refactor code to separate out accumulator verification and modification

### DIFF
--- a/blockchain/utreexoviewpoint.go
+++ b/blockchain/utreexoviewpoint.go
@@ -184,7 +184,7 @@ func BlockToDelOPs(
 }
 
 // DedupeBlock takes a bitcoin block, and returns two int slices: the indexes of
-// inputs, and idexes of outputs which can be removed.  These are indexes
+// inputs, and indexes of outputs which can be removed.  These are indexes
 // within the block as a whole, even the coinbase tx.
 // So the coinbase tx in & output numbers affect the skip lists even though
 // the coinbase ins/outs can never be deduped.  it's simpler that way.

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1075,7 +1075,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *btcutil.Block,
 	// If utreexo accumulators are enabled, then check that the accumulator
 	// proof is ok.  Then convert the msgBlock.UData into UtxoViewpoint.
 	if utreexoView != nil {
-		err := utreexoView.ProcessUData(block, b.bestChain, block.MsgBlock().UData)
+		err := utreexoView.VerifyUData(block, b.bestChain, block.MsgBlock().UData)
 		if err != nil {
 			return fmt.Errorf("checkConnectBlock fail. error: %v", err)
 		}


### PR DESCRIPTION
The accumulator verification and modification was being done in a single function. This meant that if the accumulator verification passed while signature validation failed, the node would be left at an inconsistent state. The change here prevents that from being possible.