### PR TITLE
wire: don't allocate if udata count is 0

### DIFF
--- a/wire/udata.go
+++ b/wire/udata.go
@@ -247,6 +247,9 @@ func (ud *UData) DeserializeCompact(r io.Reader) error {
 	if err != nil {
 		return err
 	}
+	if udCount == 0 {
+		return nil
+	}
 	ud.LeafDatas = make([]LeafData, udCount)
 
 	for i := range ud.LeafDatas {


### PR DESCRIPTION
Done for equality so that reflect.DeepEqual() returns true. If we allocate then it's not equal.