### PR TITLE
netsync: don't ask for blocks from peers on the same block height

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -322,6 +322,11 @@ func (sm *SyncManager) startSync() {
 		higherPeers = append(higherPeers, peer)
 	}
 
+	if sm.chain.IsCurrent() && len(higherPeers) == 0 {
+		log.Infof("Caught up to block %s(%d)", best.Hash.String(), best.Height)
+		return
+	}
+
 	// Pick randomly from the set of peers greater than our block height,
 	// falling back to a random peer of the same height if none are greater.
 	//


### PR DESCRIPTION
When we're all caught up and we have a new peer, we'll ask for blocks from peers that we're on the same height. Since these peers don't have any blocks to send us, they don't reply and we disconnect from them as they timeout.

To prevent this, we don't ask for blocks if the chain thinks we're current and do not have a peer that reports having a higher block.