### PR TITLE
mempool, netsync, electrum, main, peer: Use utreexotx

### DIFF
--- a/electrum/server.go
+++ b/electrum/server.go
@@ -523,7 +523,7 @@ func handleTransactionBroadcast(s *ElectrumServer, cmd *btcjson.Request, conn ne
 	}
 	tx.MsgTx().UData = udata
 
-	acceptedTxs, err := s.cfg.Mempool.ProcessTransaction(tx, false, false, 0)
+	acceptedTxs, err := s.cfg.Mempool.ProcessTransaction(tx, udata, false, false, 0)
 	if err != nil {
 		// When the error is a rule error, it means the transaction was
 		// simply rejected as opposed to something actually going wrong,

--- a/mempool/interface.go
+++ b/mempool/interface.go
@@ -47,7 +47,7 @@ type TxMempool interface {
 	// error is nil, the list will include the passed transaction itself
 	// along with any additional orphan transactions that were added as a
 	// result of the passed one being accepted.
-	ProcessTransaction(tx *btcutil.Tx, allowOrphan,
+	ProcessTransaction(tx *btcutil.Tx, utreexoData *wire.UData, allowOrphan,
 		rateLimit bool, tag Tag) ([]*TxDesc, error)
 
 	// RemoveTransaction removes the passed transaction from the mempool.

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -406,7 +406,7 @@ func (ctx *testContext) addSignedTx(inputs []spendableOutput,
 		ctx.harness.chain.SetMedianTimePast(time.Now())
 	} else {
 		acceptedTxns, err := ctx.harness.txPool.ProcessTransaction(
-			tx, true, false, 0,
+			tx, nil, true, false, 0,
 		)
 		if err != nil {
 			ctx.t.Fatalf("unable to process transaction: %v", err)
@@ -475,7 +475,7 @@ func TestSimpleOrphanChain(t *testing.T) {
 	// Ensure the orphans are accepted (only up to the maximum allowed so
 	// none are evicted).
 	for _, tx := range chainedTxns[1 : maxOrphans+1] {
-		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, true,
+		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, nil, true,
 			false, 0)
 		if err != nil {
 			t.Fatalf("ProcessTransaction: failed to accept valid "+
@@ -498,7 +498,7 @@ func TestSimpleOrphanChain(t *testing.T) {
 	// all get accepted.  Notice the accept orphans flag is also false here
 	// to ensure it has no bearing on whether or not already existing
 	// orphans in the pool are linked.
-	acceptedTxns, err := harness.txPool.ProcessTransaction(chainedTxns[0],
+	acceptedTxns, err := harness.txPool.ProcessTransaction(chainedTxns[0], nil,
 		false, false, 0)
 	if err != nil {
 		t.Fatalf("ProcessTransaction: failed to accept valid "+
@@ -537,7 +537,7 @@ func TestOrphanReject(t *testing.T) {
 
 	// Ensure orphans are rejected when the allow orphans flag is not set.
 	for _, tx := range chainedTxns[1:] {
-		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, false,
+		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, nil, false,
 			false, 0)
 		if err == nil {
 			t.Fatalf("ProcessTransaction: did not fail on orphan "+
@@ -594,7 +594,7 @@ func TestOrphanEviction(t *testing.T) {
 	// Add enough orphans to exceed the max allowed while ensuring they are
 	// all accepted.  This will cause an eviction.
 	for _, tx := range chainedTxns[1:] {
-		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, true,
+		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, nil, true,
 			false, 0)
 		if err != nil {
 			t.Fatalf("ProcessTransaction: failed to accept valid "+
@@ -658,7 +658,7 @@ func TestBasicOrphanRemoval(t *testing.T) {
 	// Ensure the orphans are accepted (only up to the maximum allowed so
 	// none are evicted).
 	for _, tx := range chainedTxns[1 : maxOrphans+1] {
-		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, true,
+		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, nil, true,
 			false, 0)
 		if err != nil {
 			t.Fatalf("ProcessTransaction: failed to accept valid "+
@@ -733,7 +733,7 @@ func TestOrphanChainRemoval(t *testing.T) {
 	// Ensure the orphans are accepted (only up to the maximum allowed so
 	// none are evicted).
 	for _, tx := range chainedTxns[1 : maxOrphans+1] {
-		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, true,
+		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, nil, true,
 			false, 0)
 		if err != nil {
 			t.Fatalf("ProcessTransaction: failed to accept valid "+
@@ -796,7 +796,7 @@ func TestMultiInputOrphanDoubleSpend(t *testing.T) {
 	// Start by adding the orphan transactions from the generated chain
 	// except the final one.
 	for _, tx := range chainedTxns[1:maxOrphans] {
-		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, true,
+		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, nil, true,
 			false, 0)
 		if err != nil {
 			t.Fatalf("ProcessTransaction: failed to accept valid "+
@@ -822,7 +822,7 @@ func TestMultiInputOrphanDoubleSpend(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create signed tx: %v", err)
 	}
-	acceptedTxns, err := harness.txPool.ProcessTransaction(doubleSpendTx,
+	acceptedTxns, err := harness.txPool.ProcessTransaction(doubleSpendTx, nil,
 		true, false, 0)
 	if err != nil {
 		t.Fatalf("ProcessTransaction: failed to accept valid orphan %v",
@@ -841,7 +841,7 @@ func TestMultiInputOrphanDoubleSpend(t *testing.T) {
 	//
 	// This will cause the shared output to become a concrete spend which
 	// will in turn must cause the double spending orphan to be removed.
-	acceptedTxns, err = harness.txPool.ProcessTransaction(chainedTxns[0],
+	acceptedTxns, err = harness.txPool.ProcessTransaction(chainedTxns[0], nil,
 		false, false, 0)
 	if err != nil {
 		t.Fatalf("ProcessTransaction: failed to accept valid tx %v", err)
@@ -889,7 +889,7 @@ func TestCheckSpend(t *testing.T) {
 		t.Fatalf("unable to create transaction chain: %v", err)
 	}
 	for _, tx := range chainedTxns {
-		_, err := harness.txPool.ProcessTransaction(tx, true,
+		_, err := harness.txPool.ProcessTransaction(tx, nil, true,
 			false, 0)
 		if err != nil {
 			t.Fatalf("ProcessTransaction: failed to accept "+
@@ -1817,7 +1817,7 @@ func TestRBF(t *testing.T) {
 			// it's not a valid one, we should see the error
 			// expected by the test.
 			_, err = ctx.harness.txPool.ProcessTransaction(
-				replacementTx, false, false, 0,
+				replacementTx, nil, false, false, 0,
 			)
 			if testCase.err == "" && err != nil {
 				ctx.t.Fatalf("expected no error when "+

--- a/mempool/mocks.go
+++ b/mempool/mocks.go
@@ -73,7 +73,7 @@ func (m *MockTxMempool) HaveTransaction(hash *chainhash.Hash) bool {
 // free-standing transactions into the memory pool. It includes functionality
 // such as rejecting duplicate transactions, ensuring transactions follow all
 // rules, orphan transaction handling, and insertion into the memory pool.
-func (m *MockTxMempool) ProcessTransaction(tx *btcutil.Tx, allowOrphan,
+func (m *MockTxMempool) ProcessTransaction(tx *btcutil.Tx, utreexoData *wire.UData, allowOrphan,
 	rateLimit bool, tag Tag) ([]*TxDesc, error) {
 
 	args := m.Called(tx, allowOrphan, rateLimit, tag)

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1749,8 +1749,10 @@ func (sm *SyncManager) handleBlockchainNotification(notification *blockchain.Not
 
 		// Reinsert all of the transactions (except the coinbase) into
 		// the transaction pool.
+		//
+		// TODO handle txs here for utreexo nodes.
 		for _, tx := range block.Transactions()[1:] {
-			_, _, err := sm.txMemPool.MaybeAcceptTransaction(tx,
+			_, _, err := sm.txMemPool.MaybeAcceptTransaction(tx, nil,
 				false, false)
 			if err != nil {
 				// Remove the transaction and all transactions

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -100,6 +100,14 @@ type txMsg struct {
 	reply chan struct{}
 }
 
+// utreexoTxMsg packages a bitcoin utreexo tx message and the peer it came from together
+// so the block handler has access to that information.
+type utreexoTxMsg struct {
+	utreexoTx *btcutil.UtreexoTx
+	peer      *peerpkg.Peer
+	reply     chan struct{}
+}
+
 // getSyncPeerMsg is a message type to be sent across the message channel for
 // retrieving the current sync peer.
 type getSyncPeerMsg struct {
@@ -591,8 +599,7 @@ func (sm *SyncManager) updateSyncPeer(dcSyncPeer bool) {
 }
 
 // handleTxMsg handles transaction messages from all peers.
-func (sm *SyncManager) handleTxMsg(tmsg *txMsg) {
-	peer := tmsg.peer
+func (sm *SyncManager) handleTxMsg(tx *btcutil.Tx, peer *peerpkg.Peer, utreexoData *wire.UData) {
 	state, exists := sm.peerStates[peer]
 	if !exists {
 		log.Warnf("Received tx message from unknown peer %s", peer)
@@ -607,7 +614,7 @@ func (sm *SyncManager) handleTxMsg(tmsg *txMsg) {
 	// spec to proliferate.  While this is not ideal, there is no check here
 	// to disconnect peers for sending unsolicited transactions to provide
 	// interoperability.
-	txHash := tmsg.tx.Hash()
+	txHash := tx.Hash()
 
 	// Ignore transactions that we have already rejected.  Do not
 	// send a reject message here because if the transaction was already
@@ -620,7 +627,7 @@ func (sm *SyncManager) handleTxMsg(tmsg *txMsg) {
 
 	// Process the transaction to include validation, insertion in the
 	// memory pool, orphan handling, etc.
-	acceptedTxs, err := sm.txMemPool.ProcessTransaction(tmsg.tx, nil,
+	acceptedTxs, err := sm.txMemPool.ProcessTransaction(tx, utreexoData,
 		true, true, mempool.Tag(peer.ID()))
 
 	// Remove transaction from request maps. Either the mempool/chain
@@ -1380,9 +1387,7 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 			// Add it to the request queue.
 			state.requestQueue = append(state.requestQueue, iv)
 
-			// If the inv is for a utreexo tx, then also pop off the utreexo
-			// proof hash invs and add it to the request queue.
-			if peer.IsUtreexoEnabled() {
+			if sm.chain.IsUtreexoViewActive() {
 				switch iv.Type {
 				case wire.InvTypeTx:
 				case wire.InvTypeWitnessTx:
@@ -1549,7 +1554,7 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 					}
 
 					// Add in the utreexo flag then add the tx inv.
-					iv.Type |= wire.InvUtreexoFlag
+					iv.Type = wire.InvTypeUtreexoTx
 					gdmsg.AddInvVect(iv)
 					numRequested++
 
@@ -1597,7 +1602,11 @@ out:
 				sm.handleNewPeerMsg(msg.peer)
 
 			case *txMsg:
-				sm.handleTxMsg(msg)
+				sm.handleTxMsg(msg.tx, msg.peer, nil)
+				msg.reply <- struct{}{}
+
+			case *utreexoTxMsg:
+				sm.handleTxMsg(&msg.utreexoTx.Tx, msg.peer, &msg.utreexoTx.MsgUtreexoTx().UData)
 				msg.reply <- struct{}{}
 
 			case *blockMsg:
@@ -1789,6 +1798,19 @@ func (sm *SyncManager) QueueTx(tx *btcutil.Tx, peer *peerpkg.Peer, done chan str
 	}
 
 	sm.msgChan <- &txMsg{tx: tx, peer: peer, reply: done}
+}
+
+// QueueUtreexoTx adds the passed transaction message and peer to the block handling
+// queue. Responds to the done channel argument after the utreexo tx message is
+// processed.
+func (sm *SyncManager) QueueUtreexoTx(tx *btcutil.UtreexoTx, peer *peerpkg.Peer, done chan struct{}) {
+	// Don't accept more transactions if we're shutting down.
+	if atomic.LoadInt32(&sm.shutdown) != 0 {
+		done <- struct{}{}
+		return
+	}
+
+	sm.msgChan <- &utreexoTxMsg{utreexoTx: tx, peer: peer, reply: done}
 }
 
 // QueueBlock adds the passed block message and peer to the block handling

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -620,7 +620,7 @@ func (sm *SyncManager) handleTxMsg(tmsg *txMsg) {
 
 	// Process the transaction to include validation, insertion in the
 	// memory pool, orphan handling, etc.
-	acceptedTxs, err := sm.txMemPool.ProcessTransaction(tmsg.tx,
+	acceptedTxs, err := sm.txMemPool.ProcessTransaction(tmsg.tx, nil,
 		true, true, mempool.Tag(peer.ID()))
 
 	// Remove transaction from request maps. Either the mempool/chain

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -117,6 +117,9 @@ type MessageListeners struct {
 	// OnTx is invoked when a peer receives a tx bitcoin message.
 	OnTx func(p *Peer, msg *wire.MsgTx)
 
+	// OnUtreexoTx is invoked when a peer receives a utreexo tx bitcoin message.
+	OnUtreexoTx func(p *Peer, msg *wire.MsgUtreexoTx)
+
 	// OnBlock is invoked when a peer receives a block bitcoin message.
 	OnBlock func(p *Peer, msg *wire.MsgBlock, buf []byte)
 
@@ -1175,6 +1178,7 @@ func (p *Peer) maybeAddDeadline(pendingResponses map[string]time.Time, msgCmd st
 		pendingResponses[wire.CmdBlock] = deadline
 		pendingResponses[wire.CmdMerkleBlock] = deadline
 		pendingResponses[wire.CmdTx] = deadline
+		pendingResponses[wire.CmdUtreexoTx] = deadline
 		pendingResponses[wire.CmdNotFound] = deadline
 
 	case wire.CmdGetHeaders:
@@ -1234,10 +1238,13 @@ out:
 					fallthrough
 				case wire.CmdTx:
 					fallthrough
+				case wire.CmdUtreexoTx:
+					fallthrough
 				case wire.CmdNotFound:
 					delete(pendingResponses, wire.CmdBlock)
 					delete(pendingResponses, wire.CmdMerkleBlock)
 					delete(pendingResponses, wire.CmdTx)
+					delete(pendingResponses, wire.CmdUtreexoTx)
 					delete(pendingResponses, wire.CmdNotFound)
 
 				default:
@@ -1437,6 +1444,11 @@ out:
 		case *wire.MsgTx:
 			if p.cfg.Listeners.OnTx != nil {
 				p.cfg.Listeners.OnTx(p, msg)
+			}
+
+		case *wire.MsgUtreexoTx:
+			if p.cfg.Listeners.OnUtreexoTx != nil {
+				p.cfg.Listeners.OnUtreexoTx(p, msg)
 			}
 
 		case *wire.MsgBlock:

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4273,7 +4273,7 @@ func handleSearchRawTransactions(s *rpcServer, cmd interface{}, closeChan <-chan
 // rpcProcessTx checks that the tx is accepted into the mempool and relays it to peers
 // and other processes.
 func (s *rpcServer) rpcProcessTx(tx *btcutil.Tx, allowOrphan, rateLimit bool) error {
-	acceptedTxs, err := s.cfg.TxMemPool.ProcessTransaction(tx, allowOrphan, rateLimit, 0)
+	acceptedTxs, err := s.cfg.TxMemPool.ProcessTransaction(tx, nil, allowOrphan, rateLimit, 0)
 	if err != nil {
 		// When the error is a rule error, it means the transaction was
 		// simply rejected as opposed to something actually going wrong,

--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -234,8 +234,15 @@ func (msg *MsgBlock) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) er
 		return err
 	}
 
+	// Unset UtreexoEncoding for the encoding that we'll pass off to the
+	// tx.BtcDecode().  This is done as tx.BtcDecode() expects Utreexo
+	// Proofs to be appended to each tx if UtreexoEncoding bit is turned on.
+	// However, this only applies to mempool txs and there are no separate
+	// Utreexo Proofs for individual txs as the MsgBlock contains a proof
+	// for all the txs.
+	txEncoding := enc &^ UtreexoEncoding
 	for _, tx := range msg.Transactions {
-		err = tx.BtcEncode(w, pver, enc)
+		err = tx.BtcEncode(w, pver, txEncoding)
 		if err != nil {
 			return err
 		}

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -679,14 +679,6 @@ func (msg *MsgTx) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) error
 		scriptPool.Return(pkScript)
 	}
 
-	if enc&UtreexoEncoding == UtreexoEncoding {
-		msg.UData = new(UData)
-		err = msg.UData.DeserializeCompact(r)
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -784,17 +776,6 @@ func (msg *MsgTx) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) error
 	err = bs.PutUint32(w, littleEndian, msg.LockTime)
 	if err != nil {
 		return err
-	}
-
-	if enc&UtreexoEncoding == UtreexoEncoding {
-		// AccProof can be nil for transactions that are included in
-		// a block.
-		if msg.UData != nil {
-			err = msg.UData.SerializeCompact(w)
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	return nil


### PR DESCRIPTION
We favor utreexotx instead of having a separate utreexo encoding for a transaction message.
The code here changes the code so that CSNs ask for utreexotxs and the CSNs and bridges
send over utreexotxs.