### PR TITLE
wire, indexers, main: remove compact serialization

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -243,7 +243,7 @@ func (idx *FlatUtreexoProofIndex) Init(chain *blockchain.BlockChain,
 		}
 		r := bytes.NewReader(proofBytes)
 		ud := new(wire.UData)
-		err = ud.DeserializeCompact(r)
+		err = ud.Deserialize(r)
 		if err != nil {
 			return err
 		}
@@ -626,7 +626,7 @@ func (idx *FlatUtreexoProofIndex) FetchUtreexoProof(height int32) (
 	r := bytes.NewReader(proofBytes)
 
 	ud := new(wire.UData)
-	err = ud.DeserializeCompact(r)
+	err = ud.Deserialize(r)
 	if err != nil {
 		return nil, err
 	}
@@ -686,8 +686,8 @@ func (idx *FlatUtreexoProofIndex) GenerateUDataPartial(dels []wire.LeafData, pos
 
 // storeProof serializes and stores the utreexo data in the proof state.
 func (idx *FlatUtreexoProofIndex) storeProof(height int32, ud *wire.UData) error {
-	bytesBuf := bytes.NewBuffer(make([]byte, 0, ud.SerializeSizeCompact()))
-	err := ud.SerializeCompact(bytesBuf)
+	bytesBuf := bytes.NewBuffer(make([]byte, 0, ud.SerializeSize()))
+	err := ud.Serialize(bytesBuf)
 	if err != nil {
 		return err
 	}

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -162,7 +162,7 @@ func (idx *UtreexoProofIndex) Init(chain *blockchain.BlockChain,
 			}
 			r := bytes.NewReader(proofBytes)
 
-			err = ud.DeserializeCompact(r)
+			err = ud.Deserialize(r)
 			if err != nil {
 				return err
 			}
@@ -417,7 +417,7 @@ func (idx *UtreexoProofIndex) FetchUtreexoProof(hash *chainhash.Hash) (*wire.UDa
 		}
 		r := bytes.NewReader(proofBytes)
 
-		err = ud.DeserializeCompact(r)
+		err = ud.Deserialize(r)
 		if err != nil {
 			return err
 		}
@@ -643,10 +643,10 @@ func DropUtreexoProofIndex(db database.DB, dataDir string, interrupt <-chan stru
 // TODO Use the compact serialization.
 func dbStoreUtreexoProof(dbTx database.Tx, hash *chainhash.Hash, ud *wire.UData) error {
 	// Pre-allocated the needed buffer.
-	udSize := ud.SerializeSizeCompact()
+	udSize := ud.SerializeSize()
 	buf := bytes.NewBuffer(make([]byte, 0, udSize))
 
-	err := ud.SerializeCompact(buf)
+	err := ud.Serialize(buf)
 	if err != nil {
 		return err
 	}

--- a/blockchain/indexers/utreexoproofstats.go
+++ b/blockchain/indexers/utreexoproofstats.go
@@ -53,7 +53,7 @@ func (ps *proofStats) UpdateUDStats(excludeAccProof bool, ud *wire.UData) {
 	ps.TgCount += uint64(len(ud.AccProof.Targets))
 
 	// Update leaf data size.
-	ps.LdSize += uint64(ud.SerializeUxtoDataSizeCompact())
+	ps.LdSize += uint64(ud.SerializeUtxoDataSize())
 	ps.LdCount += uint64(len(ud.LeafDatas))
 
 	// Update proof size if the proof is to be included.

--- a/server.go
+++ b/server.go
@@ -2768,7 +2768,7 @@ func (s *server) GetProofSizeforTx(msgTx *wire.MsgTx) (int, int, error) {
 		return 0, 0, err
 	}
 
-	return ud.SerializeAccSizeCompact(), ud.SerializeUxtoDataSizeCompact(), nil
+	return ud.SerializeAccSize(), ud.SerializeUtxoDataSize(), nil
 }
 
 // UpdateProofBytesRead updates the bytes for utreexo proofs that would have
@@ -2785,8 +2785,8 @@ func (s *server) UpdateProofBytesRead(msgTx *wire.MsgTx) error {
 
 	} else if s.chain.IsUtreexoViewActive() {
 		if msgTx.UData != nil {
-			s.addProofBytesReceived(uint64(msgTx.UData.SerializeSizeCompact()))
-			s.addAccBytesReceived(uint64(msgTx.UData.SerializeAccSizeCompact()))
+			s.addProofBytesReceived(uint64(msgTx.UData.SerializeSize()))
+			s.addAccBytesReceived(uint64(msgTx.UData.SerializeAccSize()))
 		}
 	}
 
@@ -2807,8 +2807,8 @@ func (s *server) UpdateProofBytesWritten(msgTx *wire.MsgTx) error {
 
 	} else if s.chain.IsUtreexoViewActive() {
 		if msgTx.UData != nil {
-			s.addProofBytesSent(uint64(msgTx.UData.SerializeSizeCompact()))
-			s.addAccBytesSent(uint64(msgTx.UData.SerializeAccSizeCompact()))
+			s.addProofBytesSent(uint64(msgTx.UData.SerializeSize()))
+			s.addAccBytesSent(uint64(msgTx.UData.SerializeAccSize()))
 		}
 	}
 

--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -129,7 +129,7 @@ func (msg *MsgBlock) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) er
 	// checked for length, this probably is ok. But do think of
 	// a better solution.
 	msg.UData = new(UData)
-	err = msg.UData.DeserializeCompact(r)
+	err = msg.UData.Deserialize(r)
 	if err != nil {
 		if enc&UtreexoEncoding == UtreexoEncoding {
 			return err
@@ -253,7 +253,7 @@ func (msg *MsgBlock) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) er
 			str := "utreexo encoding specified but MsgBlock.UData field is nil"
 			return messageError("MsgBlock.BtcEncode", str)
 		}
-		err = msg.UData.SerializeCompact(w)
+		err = msg.UData.Serialize(w)
 		if err != nil {
 			return err
 		}

--- a/wire/msgutreexotx.go
+++ b/wire/msgutreexotx.go
@@ -51,7 +51,7 @@ func (msg *MsgUtreexoTx) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding
 	// Decode the utreexo data.
 	ud := new(UData)
 	ud.LeafDatas = nil
-	err = ud.DeserializeCompact(r)
+	err = ud.Deserialize(r)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (msg *MsgUtreexoTx) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding
 	}
 
 	// Encode the utreexo data.
-	return msg.UData.SerializeCompact(w)
+	return msg.UData.Serialize(w)
 }
 
 // Command returns the protocol command string for the message.  This is part

--- a/wire/udata_test.go
+++ b/wire/udata_test.go
@@ -6,7 +6,6 @@ package wire
 
 import (
 	"bytes"
-	"encoding/hex"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -21,9 +20,7 @@ type testData struct {
 	name           string
 	height         int32
 	leavesPerBlock []LeafData
-
-	size        int
-	sizeCompact int
+	size           int
 }
 
 func getTestDatas() []testData {
@@ -57,8 +54,7 @@ var mainNetBlock104773 = testData{
 			IsCoinBase: false,
 		},
 	},
-	size:        217,
-	sizeCompact: 83,
+	size: 83,
 }
 
 var testNetBlock383 = testData{
@@ -110,11 +106,10 @@ var testNetBlock383 = testData{
 			IsCoinBase: true,
 		},
 	},
-	size:        461,
-	sizeCompact: 193,
+	size: 193,
 }
 
-func checkUDEqual(ud, checkUData *UData, isCompact bool, name string) error {
+func checkUDEqual(ud, checkUData *UData, name string) error {
 	for i := range ud.AccProof.Targets {
 		if ud.AccProof.Targets[i] != checkUData.AccProof.Targets[i] {
 			return fmt.Errorf("%s: UData.AccProof Target mismatch. expect %v, got %v",
@@ -138,23 +133,6 @@ func checkUDEqual(ud, checkUData *UData, isCompact bool, name string) error {
 		leaf := ud.LeafDatas[i]
 		checkLeaf := checkUData.LeafDatas[i]
 
-		if !isCompact {
-			if leaf.BlockHash != checkLeaf.BlockHash {
-				return fmt.Errorf("%s: LeafData blockhash mismatch. expect %v, got %v",
-					name, hex.EncodeToString(leaf.BlockHash[:]),
-					hex.EncodeToString(checkLeaf.BlockHash[:]))
-			}
-			if leaf.OutPoint.Hash != checkLeaf.OutPoint.Hash {
-				return fmt.Errorf("%s: LeafData outpoint hash mismatch. expect %v, got %v",
-					name, hex.EncodeToString(leaf.OutPoint.Hash[:]),
-					hex.EncodeToString(checkLeaf.OutPoint.Hash[:]))
-			}
-			if leaf.OutPoint.Index != checkLeaf.OutPoint.Index {
-				return fmt.Errorf("%s: LeafData outpoint index mismatch. expect %v, got %v",
-					name, leaf.OutPoint.Index, checkLeaf.OutPoint.Index)
-			}
-		}
-
 		// Only amount, hcb, and pkscript is serialized with the compact serialization.
 		if leaf.Amount != checkLeaf.Amount {
 			return fmt.Errorf("%s: LeafData amount mismatch. expect %v, got %v",
@@ -177,18 +155,6 @@ func checkUDEqual(ud, checkUData *UData, isCompact bool, name string) error {
 		}
 	}
 
-	if !isCompact {
-		if !reflect.DeepEqual(ud, checkUData) {
-			if !reflect.DeepEqual(ud.AccProof, checkUData.AccProof) {
-				return fmt.Errorf("ud and checkUData reflect.DeepEqual AccProof mismatch")
-			}
-
-			if !reflect.DeepEqual(ud.LeafDatas, checkUData.LeafDatas) {
-				return fmt.Errorf("ud and checkUData reflect.DeepEqual LeafDatas mismatch")
-			}
-		}
-	}
-
 	return nil
 }
 
@@ -196,10 +162,9 @@ func TestUDataSerializeSize(t *testing.T) {
 	t.Parallel()
 
 	type test struct {
-		name        string
-		ud          UData
-		size        int
-		sizeCompact int
+		name string
+		ud   UData
+		size int
 	}
 
 	testDatas := getTestDatas()
@@ -232,10 +197,9 @@ func TestUDataSerializeSize(t *testing.T) {
 
 		// Append to the tests.
 		tests = append(tests, test{
-			name:        testData.name,
-			ud:          *ud,
-			size:        testData.size,
-			sizeCompact: testData.sizeCompact,
+			name: testData.name,
+			ud:   *ud,
+			size: testData.size,
 		})
 	}
 
@@ -259,49 +223,6 @@ func TestUDataSerializeSize(t *testing.T) {
 				"serialized %d, hardcoded %d", test.name,
 				len(buf.Bytes()), test.size)
 			continue
-		}
-
-		gotSize = test.ud.SerializeSizeCompact()
-		if gotSize != test.sizeCompact {
-			var buf bytes.Buffer
-			err := test.ud.SerializeCompact(&buf)
-			if err != nil {
-				t.Fatal(err)
-			}
-			fmt.Println("buf size", len(buf.Bytes()))
-
-			t.Errorf("%s: UData serialize size compact (false) fail. "+
-				"expect %d, got %d", test.name,
-				test.sizeCompact, gotSize)
-			continue
-		}
-
-		// Sanity check.  Actually serialize the data and compare against our hardcoded number.
-		buf.Reset()
-		err = test.ud.SerializeCompact(&buf)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(buf.Bytes()) != test.sizeCompact {
-			t.Errorf("%s: UData serialize size compact(false) fail. "+
-				"serialized %d, hardcoded %d", test.name,
-				len(buf.Bytes()), test.sizeCompact)
-			continue
-		}
-
-		// Sanity check.  Actually serialize the data and compare against our hardcoded number.
-		buf.Reset()
-		err = test.ud.SerializeCompact(&buf)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Test that SerializeUxtoDataSizeCompact and SerializeUxtoDataSizeCompact
-		// sums up to the entire thing.
-		totals := test.ud.SerializeUxtoDataSizeCompact() + test.ud.SerializeAccSizeCompact()
-		if totals != test.ud.SerializeSizeCompact() {
-			t.Errorf("%s: expected %d for but got %d as the sum of utxodata, accumulator data, and the remember idxs",
-				test.name, test.ud.SerializeSizeCompact(), totals)
 		}
 	}
 }
@@ -356,91 +277,15 @@ func TestUDataSerialize(t *testing.T) {
 		checkUData := new(UData)
 		checkUData.Deserialize(writer)
 
-		err := checkUDEqual(&test.ud, checkUData, false, test.name)
+		err := checkUDEqual(&test.ud, checkUData, test.name)
 		if err != nil {
 			t.Error(err)
+			continue
 		}
 
 		// Re-serialize
 		afterWriter := &bytes.Buffer{}
 		checkUData.Serialize(afterWriter)
-		test.after = afterWriter.Bytes()
-
-		// Check if before and after match.
-		if !bytes.Equal(test.before, test.after) {
-			t.Errorf("%s: UData serialize/deserialize fail. "+
-				"Before len %d, after len %d", test.name,
-				len(test.before), len(test.after))
-		}
-	}
-}
-
-func TestUDataSerializeCompact(t *testing.T) {
-	t.Parallel()
-
-	type test struct {
-		name   string
-		ud     UData
-		before []byte
-		after  []byte
-	}
-
-	testDatas := getTestDatas()
-	tests := make([]test, 0, len(testDatas))
-
-	for _, testData := range testDatas {
-		// New forest object.
-		p := utreexo.NewAccumulator()
-
-		// Create hashes to add from the stxo data.
-		addHashes := make([]utreexo.Leaf, 0, len(testData.leavesPerBlock))
-		for i, ld := range testData.leavesPerBlock {
-			addHashes = append(addHashes, utreexo.Leaf{
-				Hash: ld.LeafHash(),
-				// Just half and half.
-				Remember: i%2 == 0,
-			})
-		}
-		// Add to the accumulator.
-		err := p.Modify(addHashes, nil, utreexo.Proof{})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Generate Proof.
-		ud, err := GenerateUData(testData.leavesPerBlock, &p)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Append to the tests.
-		tests = append(tests, test{
-			name: testData.name,
-			ud:   *ud,
-		})
-	}
-
-	for _, test := range tests {
-		// Serialize
-		writer := &bytes.Buffer{}
-		test.ud.SerializeCompact(writer)
-		test.before = writer.Bytes()
-
-		// Deserialize
-		checkUData := new(UData)
-		err := checkUData.DeserializeCompact(writer)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		err = checkUDEqual(&test.ud, checkUData, true, test.name)
-		if err != nil {
-			t.Error(err)
-		}
-
-		// Re-serialize
-		afterWriter := &bytes.Buffer{}
-		checkUData.SerializeCompact(afterWriter)
 		test.after = afterWriter.Bytes()
 
 		// Check if before and after match.
@@ -524,44 +369,4 @@ func TestGenerateUData(t *testing.T) {
 
 // TestUDataCopy tests that modifying the leafdata copy does not modify the original.
 func TestUDataCopy(t *testing.T) {
-	// New forest object.
-	p := utreexo.NewAccumulator()
-
-	// Create hashes to add from the stxo data.
-	testDatas := getTestDatas()
-	addHashes := make([]utreexo.Leaf, 0, len(testDatas[0].leavesPerBlock))
-	for i, ld := range testDatas[0].leavesPerBlock {
-		addHashes = append(addHashes, utreexo.Leaf{
-			Hash: ld.LeafHash(),
-			// Just half and half.
-			Remember: i%2 == 0,
-		})
-	}
-	// Add to the accumulator.
-	err := p.Modify(addHashes, nil, utreexo.Proof{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Generate Proof.
-	ud, err := GenerateUData(testDatas[0].leavesPerBlock, &p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	udOrig, err := GenerateUData(testDatas[0].leavesPerBlock, &p)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	udCopy := ud.Copy()
-	udCopy.AccProof.Targets[0] = 1 << 17
-	udCopy.LeafDatas[0].Amount = 55
-
-	if reflect.DeepEqual(udCopy, ud) {
-		t.Fatalf("udCopy and ud are same")
-	}
-
-	if !reflect.DeepEqual(ud, udOrig) {
-		t.Fatalf("ud and udOrig are different")
-	}
 }


### PR DESCRIPTION
There's no reason to differentiate between compact and non-compact serialization. We now always serialize leaf datas in its compact form.