### PR TITLE
wire, netsync: change MsgUtreexoTx serialization

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1611,7 +1611,7 @@ out:
 				msg.reply <- struct{}{}
 
 			case *utreexoTxMsg:
-				sm.handleTxMsg(&msg.utreexoTx.Tx, msg.peer, &msg.utreexoTx.MsgUtreexoTx().UData)
+				sm.handleTxMsg(&msg.utreexoTx.Tx, msg.peer, msg.utreexoTx.MsgUtreexoTx().UData)
 				msg.reply <- struct{}{}
 
 			case *blockMsg:

--- a/server.go
+++ b/server.go
@@ -1642,8 +1642,9 @@ func (s *server) pushTxMsg(sp *serverPeer, hash *chainhash.Hash, packedPositions
 			}
 
 			utreexoTx = &wire.MsgUtreexoTx{
-				MsgTx: *tx.MsgTx(),
-				UData: *ud,
+				MsgTx:     *tx.MsgTx(),
+				LeafDatas: ud.LeafDatas,
+				AccProof:  ud.AccProof,
 			}
 		}
 	}
@@ -1671,8 +1672,9 @@ func (s *server) pushTxMsg(sp *serverPeer, hash *chainhash.Hash, packedPositions
 			}
 
 			utreexoTx = &wire.MsgUtreexoTx{
-				MsgTx: *tx.MsgTx(),
-				UData: *ud,
+				MsgTx:     *tx.MsgTx(),
+				LeafDatas: ud.LeafDatas,
+				AccProof:  ud.AccProof,
 			}
 		}
 	} else if s.flatUtreexoProofIndex != nil {
@@ -1696,8 +1698,9 @@ func (s *server) pushTxMsg(sp *serverPeer, hash *chainhash.Hash, packedPositions
 			}
 
 			utreexoTx = &wire.MsgUtreexoTx{
-				MsgTx: *tx.MsgTx(),
-				UData: *ud,
+				MsgTx:     *tx.MsgTx(),
+				LeafDatas: ud.LeafDatas,
+				AccProof:  ud.AccProof,
 			}
 		}
 	}

--- a/wire/leaf.go
+++ b/wire/leaf.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"bytes"
 	"crypto/sha512"
 	"encoding/hex"
 	"encoding/json"
@@ -29,16 +30,22 @@ var (
 	// empty is useful when comparing against BlockHash to see if it hasn't been
 	// initialized.
 	empty chainhash.Hash
+
+	// emptyLd is useful when comparing against LeafData to see if it hasn't been
+	// initialized.
+	emptyLd LeafData
 )
 
 // LeafData is all the data that goes into a leaf in the utreexo accumulator.
 // The data here serve two roles: commitments and data needed for verification.
 //
-// Commitment:   BlockHash is included in the LeafData to commit to a block.
-// Verification: OutPoint is the OutPoint for the utxo being referenced.
+// Commitment:
+//   - BlockHash is included in the LeafData to commit to a block.
 //
-//	Height, IsCoinbase, Amount, and PkScript is the data needed for
-//	tx verification (script, signatures, etc).
+// Verification:
+//   - OutPoint is the OutPoint for the utxo being referenced.
+//   - Height, IsCoinbase, Amount, and PkScript is the data needed for
+//     tx verification (script, signatures, etc).
 type LeafData struct {
 	BlockHash             chainhash.Hash
 	OutPoint              OutPoint
@@ -47,6 +54,17 @@ type LeafData struct {
 	Amount                int64
 	ReconstructablePkType PkType
 	PkScript              []byte
+}
+
+// Equal returns if the passed in LeafData is equal to this one.
+func (l *LeafData) Equal(other LeafData) bool {
+	return l.BlockHash == other.BlockHash &&
+		l.OutPoint == other.OutPoint &&
+		l.Height == other.Height &&
+		l.IsCoinBase == other.IsCoinBase &&
+		l.Amount == other.Amount &&
+		l.ReconstructablePkType == other.ReconstructablePkType &&
+		bytes.Equal(l.PkScript, other.PkScript)
 }
 
 // Copy creates a deep copy of the leafdata so the original does not get modified

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -95,7 +95,7 @@ func TestMessage(t *testing.T) {
 		{msgGetData, msgGetData, pver, MainNet, 25},
 		{msgNotFound, msgNotFound, pver, MainNet, 25},
 		{msgTx, msgTx, pver, MainNet, 34},
-		{msgUtreexoTx, msgUtreexoTx, pver, MainNet, 37},
+		{msgUtreexoTx, msgUtreexoTx, pver, MainNet, 36},
 		{msgPing, msgPing, pver, MainNet, 32},
 		{msgPong, msgPong, pver, MainNet, 32},
 		{msgGetHeaders, msgGetHeaders, pver, MainNet, 61},


### PR DESCRIPTION
Biggest change made here is to do `PreviousOutPoint.Index <<= 1` and use the LSB to indicate if the
TxIn is confirmed or not. This is mainly done to give ordering to the LeafDatas and the TxIns. Without
this, it's hard to tell which LeafData is for which TxIn.