### PR TITLE
wire, electrum, netsync, wallet, main: remove udata from MsgTx

### DIFF
--- a/electrum/server.go
+++ b/electrum/server.go
@@ -521,7 +521,6 @@ func handleTransactionBroadcast(s *ElectrumServer, cmd *btcjson.Request, conn ne
 			Message: "Failed to prove the tx in the utreexo accumulator: " + err.Error(),
 		}
 	}
-	tx.MsgTx().UData = udata
 
 	acceptedTxs, err := s.cfg.Mempool.ProcessTransaction(tx, udata, false, false, 0)
 	if err != nil {

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1611,7 +1611,11 @@ out:
 				msg.reply <- struct{}{}
 
 			case *utreexoTxMsg:
-				sm.handleTxMsg(&msg.utreexoTx.Tx, msg.peer, msg.utreexoTx.MsgUtreexoTx().UData)
+				sm.handleTxMsg(&msg.utreexoTx.Tx, msg.peer,
+					&wire.UData{
+						AccProof:  msg.utreexoTx.MsgUtreexoTx().AccProof,
+						LeafDatas: msg.utreexoTx.MsgUtreexoTx().LeafDatas,
+					})
 				msg.reply <- struct{}{}
 
 			case *blockMsg:

--- a/server.go
+++ b/server.go
@@ -2786,11 +2786,6 @@ func (s *server) UpdateProofBytesRead(msgTx *wire.MsgTx) error {
 		s.addProofBytesReceived(uint64(utxoDataSize))
 		s.addAccBytesReceived(uint64(accSize))
 
-	} else if s.chain.IsUtreexoViewActive() {
-		if msgTx.UData != nil {
-			s.addProofBytesReceived(uint64(msgTx.UData.SerializeSize()))
-			s.addAccBytesReceived(uint64(msgTx.UData.SerializeAccSize()))
-		}
 	}
 
 	return nil
@@ -2807,12 +2802,6 @@ func (s *server) UpdateProofBytesWritten(msgTx *wire.MsgTx) error {
 		}
 		s.addProofBytesSent(uint64(utxoDataSize))
 		s.addAccBytesSent(uint64(accSize))
-
-	} else if s.chain.IsUtreexoViewActive() {
-		if msgTx.UData != nil {
-			s.addProofBytesSent(uint64(msgTx.UData.SerializeSize()))
-			s.addAccBytesSent(uint64(msgTx.UData.SerializeAccSize()))
-		}
 	}
 
 	return nil

--- a/wallet/watchonly.go
+++ b/wallet/watchonly.go
@@ -183,7 +183,6 @@ func (tx RelevantTxData) MarshalJSON() ([]byte, error) {
 	}
 
 	txBuf := bytes.NewBuffer(make([]byte, 0, tx.Tx.SerializeSize()))
-	tx.Tx.UData = nil
 	err := tx.Tx.Serialize(txBuf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize tx %s. Error %v",
@@ -963,8 +962,6 @@ func (wm *WatchOnlyWalletManager) filterBlock(block *btcutil.Block) ([]uint32, [
 				Tx:          tx.MsgTx(),
 			}
 
-			// Explicitly set to nil as we won't be fetching the udata from here.
-			relevantTx.Tx.UData = nil
 			wm.wallet.RelevantTxs[*tx.Hash()] = relevantTx
 
 			inIdx++

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -317,7 +317,6 @@ type MsgTx struct {
 	Version  int32
 	TxIn     []*TxIn
 	TxOut    []*TxOut
-	UData    *UData
 	LockTime uint32
 }
 

--- a/wire/msgutreexotx.go
+++ b/wire/msgutreexotx.go
@@ -130,7 +130,7 @@ func (msg *MsgUtreexoTx) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding
 	// Go through the TxIns and mark the ones that are not confirmed with a 1 in the LSB.
 	for i := range msg.TxIn {
 		msg.TxIn[i].PreviousOutPoint.Index <<= 1
-		if msg.UData.LeafDatas[i].Equal(emptyLd) {
+		if msg.LeafDatas[i].Equal(emptyLd) {
 			msg.TxIn[i].PreviousOutPoint.Index |= 1
 		}
 	}


### PR DESCRIPTION
Since we're using MsgUtreexoTx, we have no need for the UData field in MsgTx.