### PR TITLE
blockchain, main, wire, indexers: change MsgUtreexoTx serialization

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -657,10 +657,13 @@ func (idx *FlatUtreexoProofIndex) GenerateUDataPartial(dels []wire.LeafData, pos
 	ud := new(wire.UData)
 	ud.LeafDatas = dels
 
-	// Get the positions of the targets of delHashes.
-	delHashes, err := wire.HashesFromLeafDatas(ud.LeafDatas)
-	if err != nil {
-		return nil, err
+	delHashes := make([]utreexo.Hash, 0, len(dels))
+	for _, del := range dels {
+		// We can't calculate the correct hash if the leaf data is in
+		// the compact state.
+		if !del.IsUnconfirmed() {
+			delHashes = append(delHashes, del.LeafHash())
+		}
 	}
 
 	hashes := make([]utreexo.Hash, len(positions))

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -451,10 +451,13 @@ func (idx *UtreexoProofIndex) GenerateUDataPartial(dels []wire.LeafData, positio
 	ud := new(wire.UData)
 	ud.LeafDatas = dels
 
-	// Get the positions of the targets of delHashes.
-	delHashes, err := wire.HashesFromLeafDatas(ud.LeafDatas)
-	if err != nil {
-		return nil, err
+	delHashes := make([]utreexo.Hash, 0, len(dels))
+	for _, del := range dels {
+		// We can't calculate the correct hash if the leaf data is in
+		// the compact state.
+		if !del.IsUnconfirmed() {
+			delHashes = append(delHashes, del.LeafHash())
+		}
 	}
 
 	hashes := make([]utreexo.Hash, len(positions))

--- a/blockchain/utreexoviewpoint.go
+++ b/blockchain/utreexoviewpoint.go
@@ -916,7 +916,7 @@ func (b *BlockChain) VerifyUData(ud *wire.UData, txIns []*wire.TxIn, remember bo
 
 	delHashes := make([]utreexo.Hash, 0, len(ud.LeafDatas))
 	for _, ld := range ud.LeafDatas {
-		if ld.IsCompact() {
+		if ld.IsCompact() || ld.IsUnconfirmed() {
 			continue
 		}
 

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -325,13 +325,14 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 				MinRelayTxFee:        1000, // 1 Satoshi per byte
 				MaxTxVersion:         1,
 			},
-			ChainParams:      chainParams,
-			FetchUtxoView:    chain.FetchUtxoView,
-			BestHeight:       chain.BestHeight,
-			MedianTimePast:   chain.MedianTimePast,
-			CalcSequenceLock: chain.CalcSequenceLock,
-			SigCache:         nil,
-			AddrIndex:        nil,
+			ChainParams:         chainParams,
+			FetchUtxoView:       chain.FetchUtxoView,
+			IsUtreexoViewActive: func() bool { return false },
+			BestHeight:          chain.BestHeight,
+			MedianTimePast:      chain.MedianTimePast,
+			CalcSequenceLock:    chain.CalcSequenceLock,
+			SigCache:            nil,
+			AddrIndex:           nil,
 		}),
 	}
 

--- a/wire/leaf.go
+++ b/wire/leaf.go
@@ -476,8 +476,6 @@ func (l *LeafData) SerializeSizeCompact() int {
 
 // SerializeCompact encodes the LeafData to w using the compact leaf data serialization format.
 func (l *LeafData) SerializeCompact(w io.Writer) error {
-	// If the tx is unconfirmed, write the unconfirmed marker and
-	// return immediately.
 	if l.IsUnconfirmed() {
 		return nil
 	}

--- a/wire/msgutreexotx.go
+++ b/wire/msgutreexotx.go
@@ -141,7 +141,7 @@ func (msg *MsgUtreexoTx) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding
 	// Go through the TxIns and mark the ones that are not confirmed with a 1 in the LSB.
 	for i := range msg.TxIn {
 		msg.TxIn[i].PreviousOutPoint.Index <<= 1
-		if msg.LeafDatas[i].Equal(emptyLd) {
+		if msg.LeafDatas[i].IsUnconfirmed() {
 			msg.TxIn[i].PreviousOutPoint.Index |= 1
 		}
 	}
@@ -154,9 +154,6 @@ func (msg *MsgUtreexoTx) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding
 
 	// Write the actual leaf datas.
 	for _, ld := range msg.LeafDatas {
-		if ld.IsUnconfirmed() {
-			continue
-		}
 		err = ld.SerializeCompact(w)
 		if err != nil {
 			return err


### PR DESCRIPTION
Biggest changes:

1: MsgUtreexoTx now includes the LeafDatas and the Proof directly instead of having UData as a field.
2: Each TxIn's OutPoint.Index now also encodes if the OutPoint being addressed is confirmed or not.
3: The count of the LeafData is no longer written. The count is implied by the len(TxIn) and if each LeafData is confirmed or not.
4: Various code changes to account for the fact that there's LeafDatas that are for unconfirmed TxIns exist within the slice of LeafDatas.