### PR TITLE
peer: add debug message for readMessage

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1034,6 +1034,8 @@ func (p *Peer) readMessage(encoding wire.MessageEncoding) (wire.Message, []byte,
 		p.cfg.Listeners.OnRead(p, n, msg, err)
 	}
 	if err != nil {
+		log.Debugf("error reading message from peer %v. %v",
+			p.String(), err)
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
For each message that wasn't successfully read, there will now be a debug message indicating which peer and what error it was.