### PR TITLE
main: fix txtotals count

### DIFF
--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -516,8 +516,8 @@ var helpDescsEnUS = map[string]string{
 	"getnettotalsresult-timemillis":     "Number of milliseconds since 1 Jan 1970 GMT",
 
 	// GetTxTotalsResult help.
-	"gettxtotalsresult-totaltxbytesrecv":    "Total tx bytes received",
-	"gettxtotalsresult-totaltxbytessent":    "Total tx bytes sent",
+	"gettxtotalsresult-totaltxbytesrecv":    "Total tx bytes received (includes all utreexo data)",
+	"gettxtotalsresult-totaltxbytessent":    "Total tx bytes sent (includes all utreexo data)",
 	"gettxtotalsresult-totalproofbytesrecv": "Total utxo data bytes received",
 	"gettxtotalsresult-totalproofbytessent": "Total utxo data bytes sent",
 	"gettxtotalsresult-totalaccbytesrecv":   "Total accumulator proof bytes received",


### PR DESCRIPTION
TxTotals were only updating for the bridge nodes and it was generating proofs on the fly to calculate the size. Now the totals are kept track with CSNs and the size of the received MsgUtreexoTx is recorded.