### PR TITLE
main: don't require node network

### DIFF
--- a/server.go
+++ b/server.go
@@ -463,10 +463,8 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 		return nil
 	}
 
-	// Reject outbound peers that are not full nodes.
-	wantServices := wire.SFNodeNetwork
-
 	// Also reject outbound peers that aren't utreexo nodes if we're a utreexo csn.
+	var wantServices wire.ServiceFlag
 	if sp.server.chain.IsUtreexoViewActive() {
 		wantServices |= wire.SFNodeUtreexo
 	}


### PR DESCRIPTION
Requiring node network on peers prevent CSNs from connecting to each other. While you can't sync off of a pruned CSN during ibd, you are able to receive txs from them so it's better to not require node network on peers.