### PR TITLE
wire, main, peer, netsync: utreexo header messages

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1536,9 +1536,11 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 			}
 		}
 
+		addIv := *iv
+		addIv.Type &^= wire.InvUtreexoFlag
 		// Add the inventory to the cache of known inventory
 		// for the peer.
-		peer.AddKnownInventory(iv)
+		peer.AddKnownInventory(&addIv)
 
 		// Ignore inventory when we're in headers-first mode.
 		if sm.headersFirstMode {

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -155,6 +155,10 @@ type MessageListeners struct {
 	// message.
 	OnGetHeaders func(p *Peer, msg *wire.MsgGetHeaders)
 
+	// OnGetUtreexoHeader is invoked when a peer receives a getutreexoheader bitcoin
+	// message.
+	OnGetUtreexoHeader func(p *Peer, msg *wire.MsgGetUtreexoHeader)
+
 	// OnGetCFilters is invoked when a peer receives a getcfilters bitcoin
 	// message.
 	OnGetCFilters func(p *Peer, msg *wire.MsgGetCFilters)
@@ -1486,6 +1490,11 @@ out:
 		case *wire.MsgGetHeaders:
 			if p.cfg.Listeners.OnGetHeaders != nil {
 				p.cfg.Listeners.OnGetHeaders(p, msg)
+			}
+
+		case *wire.MsgGetUtreexoHeader:
+			if p.cfg.Listeners.OnGetUtreexoHeader != nil {
+				p.cfg.Listeners.OnGetUtreexoHeader(p, msg)
 			}
 
 		case *wire.MsgGetCFilters:

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1933,10 +1933,13 @@ func (p *Peer) QueueInventory(invVects []*wire.InvVect) {
 	for i := 0; i < len(invVects); i++ {
 		ty := invVects[i].Type
 
+		iv := *invVects[i]
+		iv.Type &^= wire.InvUtreexoFlag
+
 		// Don't add the inventory to the send queue if the peer is already
 		// known to have it.
 		if ty != wire.InvTypeUtreexoProofHash &&
-			p.knownInventory.Contains(invVects[i]) {
+			p.knownInventory.Contains(iv) {
 
 			invVects = append(invVects[:i], invVects[i+1:]...)
 			i--

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -140,6 +140,9 @@ type MessageListeners struct {
 	// OnHeaders is invoked when a peer receives a headers bitcoin message.
 	OnHeaders func(p *Peer, msg *wire.MsgHeaders)
 
+	// OnUtreexoHeader is invoked when a peer receives a headers bitcoin message.
+	OnUtreexoHeader func(p *Peer, msg *wire.MsgUtreexoHeader)
+
 	// OnNotFound is invoked when a peer receives a notfound bitcoin
 	// message.
 	OnNotFound func(p *Peer, msg *wire.MsgNotFound)
@@ -1470,6 +1473,11 @@ out:
 		case *wire.MsgHeaders:
 			if p.cfg.Listeners.OnHeaders != nil {
 				p.cfg.Listeners.OnHeaders(p, msg)
+			}
+
+		case *wire.MsgUtreexoHeader:
+			if p.cfg.Listeners.OnUtreexoHeader != nil {
+				p.cfg.Listeners.OnUtreexoHeader(p, msg)
 			}
 
 		case *wire.MsgNotFound:

--- a/server.go
+++ b/server.go
@@ -696,6 +696,12 @@ func (sp *serverPeer) OnHeaders(_ *peer.Peer, msg *wire.MsgHeaders) {
 	sp.server.syncManager.QueueHeaders(msg, sp.Peer)
 }
 
+// OnUtreexoHeader is invoked when a peer receives a utreexo header bitcoin
+// message.  The message is passed down to the sync manager.
+func (sp *serverPeer) OnUtreexoHeader(_ *peer.Peer, msg *wire.MsgUtreexoHeader) {
+	sp.server.syncManager.QueueUtreexoHeader(msg, sp.Peer)
+}
+
 // handleGetData is invoked when a peer receives a getdata bitcoin message and
 // is used to deliver block and transaction information.
 func (sp *serverPeer) OnGetData(_ *peer.Peer, msg *wire.MsgGetData) {
@@ -2540,6 +2546,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 			OnBlock:            sp.OnBlock,
 			OnInv:              sp.OnInv,
 			OnHeaders:          sp.OnHeaders,
+			OnUtreexoHeader:    sp.OnUtreexoHeader,
 			OnGetData:          sp.OnGetData,
 			OnGetBlocks:        sp.OnGetBlocks,
 			OnGetHeaders:       sp.OnGetHeaders,

--- a/server.go
+++ b/server.go
@@ -964,7 +964,7 @@ func (sp *serverPeer) OnGetUtreexoHeader(_ *peer.Peer, msg *wire.MsgGetUtreexoHe
 			return
 		}
 
-		udata, err := sp.server.flatUtreexoProofIndex.FetchUtreexoProof(height, false)
+		udata, err := sp.server.flatUtreexoProofIndex.FetchUtreexoProof(height)
 		if err != nil {
 			chanLog.Debugf("Unable to fetch utreexo proof for block hash %v: %v",
 				msg.BlockHash, err)
@@ -2532,29 +2532,30 @@ func disconnectPeer(peerList map[int32]*serverPeer, compareFunc func(*serverPeer
 func newPeerConfig(sp *serverPeer) *peer.Config {
 	return &peer.Config{
 		Listeners: peer.MessageListeners{
-			OnVersion:      sp.OnVersion,
-			OnVerAck:       sp.OnVerAck,
-			OnMemPool:      sp.OnMemPool,
-			OnTx:           sp.OnTx,
-			OnUtreexoTx:    sp.OnUtreexoTx,
-			OnBlock:        sp.OnBlock,
-			OnInv:          sp.OnInv,
-			OnHeaders:      sp.OnHeaders,
-			OnGetData:      sp.OnGetData,
-			OnGetBlocks:    sp.OnGetBlocks,
-			OnGetHeaders:   sp.OnGetHeaders,
-			OnGetCFilters:  sp.OnGetCFilters,
-			OnGetCFHeaders: sp.OnGetCFHeaders,
-			OnGetCFCheckpt: sp.OnGetCFCheckpt,
-			OnFeeFilter:    sp.OnFeeFilter,
-			OnFilterAdd:    sp.OnFilterAdd,
-			OnFilterClear:  sp.OnFilterClear,
-			OnFilterLoad:   sp.OnFilterLoad,
-			OnGetAddr:      sp.OnGetAddr,
-			OnAddr:         sp.OnAddr,
-			OnRead:         sp.OnRead,
-			OnWrite:        sp.OnWrite,
-			OnNotFound:     sp.OnNotFound,
+			OnVersion:          sp.OnVersion,
+			OnVerAck:           sp.OnVerAck,
+			OnMemPool:          sp.OnMemPool,
+			OnTx:               sp.OnTx,
+			OnUtreexoTx:        sp.OnUtreexoTx,
+			OnBlock:            sp.OnBlock,
+			OnInv:              sp.OnInv,
+			OnHeaders:          sp.OnHeaders,
+			OnGetData:          sp.OnGetData,
+			OnGetBlocks:        sp.OnGetBlocks,
+			OnGetHeaders:       sp.OnGetHeaders,
+			OnGetUtreexoHeader: sp.OnGetUtreexoHeader,
+			OnGetCFilters:      sp.OnGetCFilters,
+			OnGetCFHeaders:     sp.OnGetCFHeaders,
+			OnGetCFCheckpt:     sp.OnGetCFCheckpt,
+			OnFeeFilter:        sp.OnFeeFilter,
+			OnFilterAdd:        sp.OnFilterAdd,
+			OnFilterClear:      sp.OnFilterClear,
+			OnFilterLoad:       sp.OnFilterLoad,
+			OnGetAddr:          sp.OnGetAddr,
+			OnAddr:             sp.OnAddr,
+			OnRead:             sp.OnRead,
+			OnWrite:            sp.OnWrite,
+			OnNotFound:         sp.OnNotFound,
 
 			// Note: The reference client currently bans peers that send alerts
 			// not signed with its key.  We could verify against their key, but

--- a/wire/message.go
+++ b/wire/message.go
@@ -28,37 +28,38 @@ const MaxMessagePayload = (1024 * 1024 * 32) // 32MB
 
 // Commands used in bitcoin message headers which describe the type of message.
 const (
-	CmdVersion      = "version"
-	CmdVerAck       = "verack"
-	CmdGetAddr      = "getaddr"
-	CmdAddr         = "addr"
-	CmdGetBlocks    = "getblocks"
-	CmdInv          = "inv"
-	CmdGetData      = "getdata"
-	CmdNotFound     = "notfound"
-	CmdBlock        = "block"
-	CmdTx           = "tx"
-	CmdUtreexoTx    = "utreexotx"
-	CmdGetHeaders   = "getheaders"
-	CmdHeaders      = "headers"
-	CmdPing         = "ping"
-	CmdPong         = "pong"
-	CmdAlert        = "alert"
-	CmdMemPool      = "mempool"
-	CmdFilterAdd    = "filteradd"
-	CmdFilterClear  = "filterclear"
-	CmdFilterLoad   = "filterload"
-	CmdMerkleBlock  = "merkleblock"
-	CmdReject       = "reject"
-	CmdSendHeaders  = "sendheaders"
-	CmdFeeFilter    = "feefilter"
-	CmdGetCFilters  = "getcfilters"
-	CmdGetCFHeaders = "getcfheaders"
-	CmdGetCFCheckpt = "getcfcheckpt"
-	CmdCFilter      = "cfilter"
-	CmdCFHeaders    = "cfheaders"
-	CmdCFCheckpt    = "cfcheckpt"
-	CmdSendAddrV2   = "sendaddrv2"
+	CmdVersion       = "version"
+	CmdVerAck        = "verack"
+	CmdGetAddr       = "getaddr"
+	CmdAddr          = "addr"
+	CmdGetBlocks     = "getblocks"
+	CmdInv           = "inv"
+	CmdGetData       = "getdata"
+	CmdNotFound      = "notfound"
+	CmdBlock         = "block"
+	CmdTx            = "tx"
+	CmdUtreexoTx     = "utreexotx"
+	CmdGetHeaders    = "getheaders"
+	CmdHeaders       = "headers"
+	CmdUtreexoHeader = "uheader"
+	CmdPing          = "ping"
+	CmdPong          = "pong"
+	CmdAlert         = "alert"
+	CmdMemPool       = "mempool"
+	CmdFilterAdd     = "filteradd"
+	CmdFilterClear   = "filterclear"
+	CmdFilterLoad    = "filterload"
+	CmdMerkleBlock   = "merkleblock"
+	CmdReject        = "reject"
+	CmdSendHeaders   = "sendheaders"
+	CmdFeeFilter     = "feefilter"
+	CmdGetCFilters   = "getcfilters"
+	CmdGetCFHeaders  = "getcfheaders"
+	CmdGetCFCheckpt  = "getcfcheckpt"
+	CmdCFilter       = "cfilter"
+	CmdCFHeaders     = "cfheaders"
+	CmdCFCheckpt     = "cfcheckpt"
+	CmdSendAddrV2    = "sendaddrv2"
 )
 
 // MessageEncoding represents the wire message encoding format to be used.
@@ -146,6 +147,9 @@ func makeEmptyMessage(command string) (Message, error) {
 
 	case CmdHeaders:
 		msg = &MsgHeaders{}
+
+	case CmdUtreexoHeader:
+		msg = &MsgUtreexoHeader{}
 
 	case CmdAlert:
 		msg = &MsgAlert{}

--- a/wire/message.go
+++ b/wire/message.go
@@ -28,38 +28,39 @@ const MaxMessagePayload = (1024 * 1024 * 32) // 32MB
 
 // Commands used in bitcoin message headers which describe the type of message.
 const (
-	CmdVersion       = "version"
-	CmdVerAck        = "verack"
-	CmdGetAddr       = "getaddr"
-	CmdAddr          = "addr"
-	CmdGetBlocks     = "getblocks"
-	CmdInv           = "inv"
-	CmdGetData       = "getdata"
-	CmdNotFound      = "notfound"
-	CmdBlock         = "block"
-	CmdTx            = "tx"
-	CmdUtreexoTx     = "utreexotx"
-	CmdGetHeaders    = "getheaders"
-	CmdHeaders       = "headers"
-	CmdUtreexoHeader = "uheader"
-	CmdPing          = "ping"
-	CmdPong          = "pong"
-	CmdAlert         = "alert"
-	CmdMemPool       = "mempool"
-	CmdFilterAdd     = "filteradd"
-	CmdFilterClear   = "filterclear"
-	CmdFilterLoad    = "filterload"
-	CmdMerkleBlock   = "merkleblock"
-	CmdReject        = "reject"
-	CmdSendHeaders   = "sendheaders"
-	CmdFeeFilter     = "feefilter"
-	CmdGetCFilters   = "getcfilters"
-	CmdGetCFHeaders  = "getcfheaders"
-	CmdGetCFCheckpt  = "getcfcheckpt"
-	CmdCFilter       = "cfilter"
-	CmdCFHeaders     = "cfheaders"
-	CmdCFCheckpt     = "cfcheckpt"
-	CmdSendAddrV2    = "sendaddrv2"
+	CmdVersion          = "version"
+	CmdVerAck           = "verack"
+	CmdGetAddr          = "getaddr"
+	CmdAddr             = "addr"
+	CmdGetBlocks        = "getblocks"
+	CmdInv              = "inv"
+	CmdGetData          = "getdata"
+	CmdNotFound         = "notfound"
+	CmdBlock            = "block"
+	CmdTx               = "tx"
+	CmdUtreexoTx        = "utreexotx"
+	CmdGetHeaders       = "getheaders"
+	CmdGetUtreexoHeader = "getuheader"
+	CmdHeaders          = "headers"
+	CmdUtreexoHeader    = "uheader"
+	CmdPing             = "ping"
+	CmdPong             = "pong"
+	CmdAlert            = "alert"
+	CmdMemPool          = "mempool"
+	CmdFilterAdd        = "filteradd"
+	CmdFilterClear      = "filterclear"
+	CmdFilterLoad       = "filterload"
+	CmdMerkleBlock      = "merkleblock"
+	CmdReject           = "reject"
+	CmdSendHeaders      = "sendheaders"
+	CmdFeeFilter        = "feefilter"
+	CmdGetCFilters      = "getcfilters"
+	CmdGetCFHeaders     = "getcfheaders"
+	CmdGetCFCheckpt     = "getcfcheckpt"
+	CmdCFilter          = "cfilter"
+	CmdCFHeaders        = "cfheaders"
+	CmdCFCheckpt        = "cfcheckpt"
+	CmdSendAddrV2       = "sendaddrv2"
 )
 
 // MessageEncoding represents the wire message encoding format to be used.
@@ -144,6 +145,9 @@ func makeEmptyMessage(command string) (Message, error) {
 
 	case CmdGetHeaders:
 		msg = &MsgGetHeaders{}
+
+	case CmdGetUtreexoHeader:
+		msg = &MsgGetUtreexoHeader{}
 
 	case CmdHeaders:
 		msg = &MsgHeaders{}

--- a/wire/msggetutreexoheader.go
+++ b/wire/msggetutreexoheader.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+package wire
+
+import (
+	"io"
+
+	"github.com/utreexo/utreexod/chaincfg/chainhash"
+)
+
+// MsgGetUtreexoHeader implements the Message interface and represents a bitcoin
+// getutreexoheader message. It's used to request the utreexo header at the given
+// block.
+type MsgGetUtreexoHeader struct {
+	BlockHash chainhash.Hash
+}
+
+// BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgGetUtreexoHeader) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) error {
+	_, err := io.ReadFull(r, msg.BlockHash[:])
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgGetUtreexoHeader) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) error {
+	_, err := w.Write(msg.BlockHash[:])
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgGetUtreexoHeader) Command() string {
+	return CmdGetUtreexoHeader
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgGetUtreexoHeader) MaxPayloadLength(pver uint32) uint32 {
+	return chainhash.HashSize
+}
+
+// NewMsgGetUtreexoHeader returns a new bitcoin getheaders message that conforms to
+// the Message interface.  See MsgGetUtreexoHeader for details.
+func NewMsgGetUtreexoHeader(blockHash chainhash.Hash) *MsgGetUtreexoHeader {
+	return &MsgGetUtreexoHeader{BlockHash: blockHash}
+}

--- a/wire/msgutreexoheader.go
+++ b/wire/msgutreexoheader.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2024 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+package wire
+
+import (
+	"io"
+
+	"github.com/utreexo/utreexod/chaincfg/chainhash"
+)
+
+// MaxUtreexoHeaderPayload the amount of inputs a block can possibly have multiplied by the size
+// of uint64.
+const MaxUtreexoHeaderPayload = (28_000 * 8)
+
+// MsgUtreexoHeader implements the Message interface and represents a bitcoin
+// utreexo block header message. It's used to provide the positions of the inputs
+// that are being spent in the given block.
+type MsgUtreexoHeader struct {
+	BlockHash chainhash.Hash
+	NumAdds   uint16
+	Targets   []uint64
+}
+
+// BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+// See Deserialize for decoding block headers stored to disk, such as in a
+// database, as opposed to decoding block headers from the wire.
+func (h *MsgUtreexoHeader) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) error {
+	return readUtreexoHeader(r, pver, h)
+}
+
+// BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+// See Serialize for encoding block headers to be stored to disk, such as in a
+// database, as opposed to encoding block headers for the wire.
+func (h *MsgUtreexoHeader) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) error {
+	return writeUtreexoHeader(w, pver, h)
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (h *MsgUtreexoHeader) Command() string {
+	return CmdUtreexoHeader
+}
+
+// Deserialize decodes a block header from r into the receiver using a format
+// that is suitable for long-term storage such as a database while respecting
+// the Version field.
+func (h *MsgUtreexoHeader) Deserialize(r io.Reader) error {
+	// At the current time, there is no difference between the wire encoding
+	// at protocol version 0 and the stable long-term storage format.  As
+	// a result, make use of readUtreexoHeader.
+	return readUtreexoHeader(r, 0, h)
+}
+
+// Serialize encodes a block header from r into the receiver using a format
+// that is suitable for long-term storage such as a database while respecting
+// the Version field.
+func (h *MsgUtreexoHeader) Serialize(w io.Writer) error {
+	// At the current time, there is no difference between the wire encoding
+	// at protocol version 0 and the stable long-term storage format.  As
+	// a result, make use of writeUtreexoHeader.
+	return writeUtreexoHeader(w, 0, h)
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (h *MsgUtreexoHeader) MaxPayloadLength(pver uint32) uint32 {
+	// BlockHash size + uint16 size + Num headers (varInt) + the max payload of the targets.
+	return chainhash.HashSize + 2 + MaxVarIntPayload + MaxUtreexoHeaderPayload
+}
+
+// NewMsgUtreexoHeader returns a new MsgUtreexoHeader using the provided version, previous
+// block hash, merkle root hash, difficulty bits, and nonce used to generate the
+// block with defaults for the remaining fields.
+func NewMsgUtreexoHeader(blockHash chainhash.Hash,
+	numAdds uint16, targets []uint64) *MsgUtreexoHeader {
+
+	return &MsgUtreexoHeader{
+		BlockHash: blockHash,
+		NumAdds:   numAdds,
+		Targets:   targets,
+	}
+}
+
+// readBlockHeader reads a bitcoin block header from r.  See Deserialize for
+// decoding block headers stored to disk, such as in a database, as opposed to
+// decoding from the wire.
+func readUtreexoHeader(r io.Reader, _ uint32, bh *MsgUtreexoHeader) error {
+	_, err := io.ReadFull(r, bh.BlockHash[:])
+	if err != nil {
+		return err
+	}
+
+	bs := newSerializer()
+	defer bs.free()
+
+	bh.NumAdds, err = bs.Uint16(r, littleEndian)
+	if err != nil {
+		return err
+	}
+
+	count, err := ReadVarInt(r, 0)
+	if err != nil {
+		return err
+	}
+
+	bh.Targets = make([]uint64, count)
+	for i := range bh.Targets {
+		bh.Targets[i], err = ReadVarInt(r, 0)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeBlockHeader writes a bitcoin block header to w.  See Serialize for
+// encoding block headers to be stored to disk, such as in a database, as
+// opposed to encoding for the wire.
+func writeUtreexoHeader(w io.Writer, _ uint32, bh *MsgUtreexoHeader) error {
+	_, err := w.Write(bh.BlockHash[:])
+	if err != nil {
+		return err
+	}
+
+	bs := newSerializer()
+	defer bs.free()
+
+	err = bs.PutUint16(w, littleEndian, bh.NumAdds)
+	if err != nil {
+		return err
+	}
+
+	err = WriteVarInt(w, 0, uint64(len(bh.Targets)))
+	if err != nil {
+		return err
+	}
+
+	for _, t := range bh.Targets {
+		err = WriteVarInt(w, 0, t)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
We introduce MsgUtreexoHeader and GetMsgUtreexoHeader messages that's used to communicate the positions of the leaves in the utreexo accumulator that are being spent in a given block.