### PR TITLE
wire: update invvect types

### DIFF
--- a/wire/invvect.go
+++ b/wire/invvect.go
@@ -37,7 +37,9 @@ const (
 	InvTypeTx                   InvType = 1
 	InvTypeBlock                InvType = 2
 	InvTypeFilteredBlock        InvType = 3
-	InvTypeUtreexoProofHash     InvType = 4
+	InvTypeCompactBlock         InvType = 4
+	InvTypeWTXIDTx              InvType = 5
+	InvTypeUtreexoProofHash     InvType = 6
 	InvTypeWitnessBlock         InvType = InvTypeBlock | InvWitnessFlag
 	InvTypeUtreexoBlock         InvType = InvTypeBlock | InvUtreexoFlag
 	InvTypeWitnessUtreexoBlock  InvType = InvTypeBlock | InvWitnessFlag | InvUtreexoFlag


### PR DESCRIPTION
InvTypeUtreexoProofHash was assigned 4 but since there's existing bitcoin messages that already took the spot, we need to use something else.

Adding the other types to not confuse myself.