### PR TITLE
blockchain: remove udata requirement from ExtractAccumulatorAdds

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - version: stable
             clippy: true
-          - version: 1.73.0 # As specified in rust-toolchain
+          - version: 1.78.0 # As specified in rust-toolchain
     steps:
     - uses: actions/checkout@v3
 

--- a/blockchain/utreexoviewpoint.go
+++ b/blockchain/utreexoviewpoint.go
@@ -279,12 +279,6 @@ func ExtractAccumulatorDels(block *btcutil.Block, bestChain *chainView, remember
 func ExtractAccumulatorAdds(block *btcutil.Block, bestChain *chainView, remembers []uint32) (
 	[]utreexo.Leaf, error) {
 
-	// Check that UData field isn't nil before doing anything else.
-	if block.MsgBlock().UData == nil {
-		return nil, fmt.Errorf("ExtractAccumulatorAdds(): block.MsgBlock().UData is nil. " +
-			"Cannot extract utreexo accumulator additions")
-	}
-
 	// outskip is all the txOuts that are referenced by a txIn in the same block
 	// outCount is the count of all outskips.
 	_, outCount, _, outskip := DedupeBlock(block)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.78.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
It's not used in ExtractAccumulatorAdds so we're removing it.