### PR TITLE
blockchain: change HaveBlock behavior

### DIFF
--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -316,9 +316,9 @@ func newBlockIndex(db database.DB, chainParams *chaincfg.Params) *blockIndex {
 // This function is safe for concurrent access.
 func (bi *blockIndex) HaveBlock(hash *chainhash.Hash) bool {
 	bi.RLock()
-	_, hasBlock := bi.index[*hash]
+	node, hasBlock := bi.index[*hash]
 	bi.RUnlock()
-	return hasBlock
+	return hasBlock && node.status.HaveData()
 }
 
 // LookupNode returns the block node identified by the provided hash.  It will


### PR DESCRIPTION
Since ProcessBlockHeader will add the block header as a blockNode to the blockIndex, the HaveBlock function will incorrectly state that the block exists when only the header exists.

Because of this, we check that the node exists and also check the node's status to see if the data is stored.