### PR TITLE
blockchain: don't assign header as the best tip on maybeAcceptBlockHeader

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -172,7 +172,5 @@ func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader, checkHeade
 	newNode := newBlockNode(header, prevNode)
 	b.index.AddNode(newNode)
 
-	// This node is now the end of the best chain.
-	b.bestChain.SetTip(newNode)
 	return newNode, nil
 }


### PR DESCRIPTION
maybeAcceptBlockHeader verified the passed in block header and set it as the best tip on it passing verification. However, since the best tip is used for marking a block that's passed all verification and headers verification isn't complete verification, we remove the code for adding the blockNode as the best tip.

This allows us to use the ProcessBlockHeader code for verification of a header without accepting it as well.