### PR TITLE
netsync, main: always download headers for blocks

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1598,15 +1598,8 @@ func (sm *SyncManager) handleUtreexoHeaderMsg(hmsg *utreexoHeaderMsg) {
 	log.Debugf("accepted utreexo header for block %v. have %v headers",
 		msg.BlockHash, len(sm.utreexoHeaders))
 
-	if !sm.headersFirstMode {
-		sm.requestedBlocks[msg.BlockHash] = struct{}{}
-	}
 	peerState.requestedBlocks[msg.BlockHash] = struct{}{}
-
-	gdmsg := wire.NewMsgGetData()
-	iv := wire.NewInvVect(wire.InvTypeWitnessUtreexoBlock, &msg.BlockHash)
-	gdmsg.AddInvVect(iv)
-	peer.QueueMessage(gdmsg, nil)
+	sm.fetchHeaderBlocks(peer)
 }
 
 // handleNotFoundMsg handles notfound messages from all peers.

--- a/server.go
+++ b/server.go
@@ -521,6 +521,10 @@ func (sp *serverPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 // to kick start communication with them.
 func (sp *serverPeer) OnVerAck(_ *peer.Peer, _ *wire.MsgVerAck) {
 	sp.server.AddPeer(sp)
+
+	// Let the peer know that we prefer headers over invs for block annoucements.
+	sendHeadersMsg := wire.NewMsgSendHeaders()
+	sp.QueueMessage(sendHeadersMsg, nil)
 }
 
 // OnMemPool is invoked when a peer receives a mempool bitcoin message.


### PR DESCRIPTION
We change the code to handle headers and request headers from peers for
new block messages. This allows utreexo nodes to use the same code for
syncing up during ibd for new blocks as well.