### PR TITLE
netsync, main: use utreexo proof message to validate blocks

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -169,6 +169,7 @@ type peerSyncState struct {
 	requestedTxns           map[chainhash.Hash]struct{}
 	requestedBlocks         map[chainhash.Hash]struct{}
 	requestedUtreexoHeaders map[chainhash.Hash]struct{}
+	requestedUtreexoProofs  map[chainhash.Hash]struct{}
 }
 
 // limitAdd is a helper function for maps that require a maximum limit by
@@ -586,6 +587,7 @@ func (sm *SyncManager) handleNewPeerMsg(peer *peerpkg.Peer) {
 		requestedTxns:           make(map[chainhash.Hash]struct{}),
 		requestedBlocks:         make(map[chainhash.Hash]struct{}),
 		requestedUtreexoHeaders: make(map[chainhash.Hash]struct{}),
+		requestedUtreexoProofs:  make(map[chainhash.Hash]struct{}),
 	}
 
 	// Start syncing by choosing the best candidate if needed.

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -143,6 +143,9 @@ type MessageListeners struct {
 	// OnUtreexoHeader is invoked when a peer receives a headers bitcoin message.
 	OnUtreexoHeader func(p *Peer, msg *wire.MsgUtreexoHeader)
 
+	// OnUtreexoProof is invoked when a peer receives a utreexo proof bitcoin message.
+	OnUtreexoProof func(p *Peer, msg *wire.MsgUtreexoProof)
+
 	// OnGetUtreexoProof is invoked when a peer receives a utreexo proof bitcoin message.
 	OnGetUtreexoProof func(p *Peer, msg *wire.MsgGetUtreexoProof)
 
@@ -1481,6 +1484,11 @@ out:
 		case *wire.MsgUtreexoHeader:
 			if p.cfg.Listeners.OnUtreexoHeader != nil {
 				p.cfg.Listeners.OnUtreexoHeader(p, msg)
+			}
+
+		case *wire.MsgUtreexoProof:
+			if p.cfg.Listeners.OnUtreexoProof != nil {
+				p.cfg.Listeners.OnUtreexoProof(p, msg)
 			}
 
 		case *wire.MsgGetUtreexoProof:

--- a/server.go
+++ b/server.go
@@ -1378,6 +1378,11 @@ func (sp *serverPeer) OnGetUtreexoProof(_ *peer.Peer, msg *wire.MsgGetUtreexoPro
 	sp.QueueMessage(&utreexoProof, nil)
 }
 
+// OnUtreexoProof is invoked when a peer receives a utreexoproof bitcoin message.
+func (sp *serverPeer) OnUtreexoProof(_ *peer.Peer, msg *wire.MsgUtreexoProof) {
+	sp.server.syncManager.QueueUtreexoProof(msg, sp.Peer)
+}
+
 // enforceNodeBloomFlag disconnects the peer if the server is not configured to
 // allow bloom filters.  Additionally, if the peer has negotiated to a protocol
 // version  that is high enough to observe the bloom filter service support bit,
@@ -2614,6 +2619,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 			OnInv:              sp.OnInv,
 			OnHeaders:          sp.OnHeaders,
 			OnUtreexoHeader:    sp.OnUtreexoHeader,
+			OnUtreexoProof:     sp.OnUtreexoProof,
 			OnGetUtreexoProof:  sp.OnGetUtreexoProof,
 			OnGetData:          sp.OnGetData,
 			OnGetBlocks:        sp.OnGetBlocks,


### PR DESCRIPTION
The utreexo proofs are no longer included in the block message. Instead, they're
separated out into their own message so the SyncManager needs to handle requesting
and handling both the block and the utreexo proof message.

In the changes made here, we keep track of the numLeaves from the utreexoHeaders and
we hold onto them as they're needed when constructing the GetUtreexoProof message.
Then we request the GetUtreexoProof message and request them while fetching the blocks
and add them to the blocks while processing the block messages.