### PR TITLE
netsync: fix bug in peer selection logic

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1091,9 +1091,15 @@ func (sm *SyncManager) fetchUtreexoHeaders(peer *peerpkg.Peer) {
 		return
 	}
 
+	// Can't fetch if both are nil.
+	if peer == nil && sm.syncPeer == nil {
+		log.Warnf("fetchUtreexoHeader called with syncPeer and peer as nil")
+		return
+	}
+
 	// Default to the syncPeer unless we're given a peer by the caller.
 	reqPeer := sm.syncPeer
-	if reqPeer == nil {
+	if peer != nil {
 		reqPeer = peer
 	}
 
@@ -1134,9 +1140,15 @@ func (sm *SyncManager) fetchHeaderBlocks(peer *peerpkg.Peer) {
 		return
 	}
 
+	// Can't fetch if both are nil.
+	if peer == nil && sm.syncPeer == nil {
+		log.Warnf("fetchHeaderBlocks called with syncPeer and peer as nil")
+		return
+	}
+
 	// Default to the syncPeer unless we're given a peer by the caller.
 	reqPeer := sm.syncPeer
-	if reqPeer == nil {
+	if peer != nil {
 		reqPeer = peer
 	}
 


### PR DESCRIPTION
On fetchHeaderBlocks and fetchUtreexoHeaders, we make sure that both the syncPeer and the passed in peer are not nil. We also only prefer the passed in peer if it is not nil.