### PR TITLE
netsync: make log more specific

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1368,8 +1368,8 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 			blockHash := blockHeader.BlockHash()
 			err := sm.chain.ProcessBlockHeader(blockHeader)
 			if err != nil {
-				log.Warnf("Received block header that does not "+
-					"properly connect to the chain from peer %s "+
+				log.Warnf("Received block header that did not "+
+					"pass verification from peer %s "+
 					"-- disconnecting", peer.Addr())
 				peer.Disconnect()
 				return


### PR DESCRIPTION
Instead of stating that the header failed to connect, state that the header failed header validation.