### PR TITLE
blockchain, netsync: no more headers-first list

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -118,7 +118,7 @@ func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags)
 // returned.
 //
 // This function MUST be called with the chain lock held (for writes).
-func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader, checkHeaderSanity bool) (*blockNode, error) {
+func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader, flags BehaviorFlags) (*blockNode, error) {
 	// Avoid validating the header again if its validation status is already
 	// known.  Invalid headers are never added to the block index, so if there
 	// is an entry for the block hash, the header itself is known to be valid.
@@ -134,12 +134,11 @@ func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader, checkHeade
 	}
 
 	// Perform context-free sanity checks on the block header.
-	if checkHeaderSanity {
-		err := checkBlockHeaderSanity(header, b.chainParams.PowLimit, b.timeSource, BFNone)
-		if err != nil {
-			return nil, err
-		}
+	err := checkBlockHeaderSanity(header, b.chainParams.PowLimit, b.timeSource, flags)
+	if err != nil {
+		return nil, err
 	}
+
 	// Orphan headers are not allowed and this function should never be called
 	// with the genesis block.
 	prevHash := &header.PrevBlock
@@ -159,7 +158,7 @@ func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader, checkHeade
 
 	// The block must pass all of the validation rules which depend on the
 	// position of the block within the block chain.
-	err := b.checkBlockHeaderContext(header, prevNode, BFNone)
+	err = b.checkBlockHeaderContext(header, prevNode, flags)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -114,11 +114,12 @@ func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags)
 //
 // In the case the block header is already known, the associated block node is
 // examined to determine if the block is already known to be invalid, in which
-// case an appropriate error will be returned.  Otherwise, the block node is
-// returned.
+// case an appropriate error will be returned.
+//
+// The returned bool indicates if the header extended the best chain of headers.
 //
 // This function MUST be called with the chain lock held (for writes).
-func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader, flags BehaviorFlags) (*blockNode, error) {
+func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader, flags BehaviorFlags) (bool, error) {
 	// Avoid validating the header again if its validation status is already
 	// known.  Invalid headers are never added to the block index, so if there
 	// is an entry for the block hash, the header itself is known to be valid.
@@ -127,16 +128,16 @@ func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader, flags Beha
 	hash := header.BlockHash()
 	if node := b.index.LookupNode(&hash); node != nil {
 		if err := b.checkKnownInvalidBlock(node); err != nil {
-			return nil, err
+			return false, err
 		}
 
-		return node, nil
+		return false, nil
 	}
 
 	// Perform context-free sanity checks on the block header.
 	err := checkBlockHeaderSanity(header, b.chainParams.PowLimit, b.timeSource, flags)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 
 	// Orphan headers are not allowed and this function should never be called
@@ -145,7 +146,7 @@ func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader, flags Beha
 	prevNode := b.index.LookupNode(prevHash)
 	if prevNode == nil {
 		str := fmt.Sprintf("previous block %s is not known", prevHash)
-		return nil, ruleError(ErrMissingParent, str)
+		return false, ruleError(ErrMissingParent, str)
 	}
 
 	// There is no need to validate the header if an ancestor is already known
@@ -153,14 +154,14 @@ func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader, flags Beha
 	prevNodeStatus := b.index.NodeStatus(prevNode)
 	if prevNodeStatus.KnownInvalid() {
 		str := fmt.Sprintf("previous block %s is known to be invalid", prevHash)
-		return nil, ruleError(ErrInvalidAncestorBlock, str)
+		return false, ruleError(ErrInvalidAncestorBlock, str)
 	}
 
 	// The block must pass all of the validation rules which depend on the
 	// position of the block within the block chain.
 	err = b.checkBlockHeaderContext(header, prevNode, flags)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 
 	// Create a new block node for the block and add it to the block index.
@@ -171,5 +172,42 @@ func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader, flags Beha
 	newNode := newBlockNode(header, prevNode)
 	b.index.AddNode(newNode)
 
-	return newNode, nil
+	// Check if the header extends the best header tip.
+	isMainChain := false
+	parentHash := &header.PrevBlock
+	if parentHash.IsEqual(&b.bestHeader.Tip().hash) {
+		// This header is now the end of the best headers.
+		b.bestHeader.SetTip(newNode)
+		isMainChain = true
+		return isMainChain, nil
+	}
+
+	// We're extending (or creating) a side chain, but the cumulative
+	// work for this new side chain is not enough to make it the new chain.
+	if newNode.workSum.Cmp(b.bestHeader.Tip().workSum) <= 0 {
+		// Log information about how the header is forking the chain.
+		fork := b.bestHeader.FindFork(newNode)
+		if fork.hash.IsEqual(parentHash) {
+			log.Infof("FORK: BlockHeader %v(%v) forks the chain at block %v(%v) "+
+				"but did not have enough work to be the "+
+				"main chain", newNode.hash, newNode.height, fork.hash, fork.height)
+		} else {
+			log.Infof("EXTEND FORK: BlockHeader %v(%v) extends a side chain "+
+				"which forks the chain at block %v(%v)",
+				newNode.hash, newNode.height, fork.hash, fork.height)
+		}
+
+		return false, nil
+	}
+
+	prevTip := b.bestHeader.Tip()
+	log.Infof("NEW BEST HEADER CHAIN: BlockHeader %v(%v) is now a longer "+
+		"PoW chain than the previous header tip of %v(%v).",
+		newNode.hash, newNode.height,
+		prevTip.hash, prevTip.height)
+
+	b.bestHeader.SetTip(newNode)
+	isMainChain = true
+
+	return isMainChain, nil
 }

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1632,6 +1632,15 @@ func (b *BlockChain) BestSnapshot() *BestState {
 	return snapshot
 }
 
+// BestHeader returns the hash and the height of the best header.
+func (b *BlockChain) BestHeader() (chainhash.Hash, int32) {
+	b.chainLock.RLock()
+	defer b.chainLock.RUnlock()
+
+	best := b.bestHeader.Tip()
+	return best.hash, best.height
+}
+
 // TipStatus is the status of a chain tip.
 type TipStatus byte
 
@@ -1839,6 +1848,53 @@ func (b *BlockChain) BlockHashByHeight(blockHeight int32) (*chainhash.Hash, erro
 	}
 
 	return &node.hash, nil
+}
+
+// IsValidHeader checks that we've already checked that this header connects to the
+// chain of headers and did not receive an invalid state.
+func (b *BlockChain) IsValidHeader(blockHash *chainhash.Hash) bool {
+	node := b.index.LookupNode(blockHash)
+	if node == nil || !b.bestHeader.Contains(node) {
+		return false
+	}
+
+	if node.status == statusValidateFailed ||
+		node.status == statusInvalidAncestor {
+		return false
+	}
+
+	return true
+}
+
+// LatestBlockLocatorByHeader returns a block locator for the latest known tip of the
+// header chain.
+//
+// This function is safe for concurrent access.
+func (b *BlockChain) LatestBlockLocatorByHeader() (BlockLocator, error) {
+	b.chainLock.RLock()
+	locator := b.bestHeader.BlockLocator(nil)
+	b.chainLock.RUnlock()
+	return locator, nil
+}
+
+// HeaderHashByHeight returns the block header's hash given its height.
+func (b *BlockChain) HeaderHashByHeight(blockHeight int32) (*chainhash.Hash, error) {
+	node := b.bestHeader.NodeByHeight(blockHeight)
+	if node == nil || !b.bestHeader.Contains(node) {
+		return nil, fmt.Errorf("blockheight %v not found", blockHeight)
+	}
+
+	return &node.hash, nil
+}
+
+// HeaderHeightByHash returns the height of the header given its hash.
+func (b *BlockChain) HeaderHeightByHash(blockHash chainhash.Hash) (int32, error) {
+	node := b.index.LookupNode(&blockHash)
+	if node == nil || !b.bestHeader.Contains(node) {
+		return -1, fmt.Errorf("blockhash %v not found", blockHash)
+	}
+
+	return node.height, nil
 }
 
 // HeightRange returns a range of block hashes for the given start and end

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -172,8 +172,12 @@ type BlockChain struct {
 	//
 	// bestChain tracks the current active chain by making use of an
 	// efficient chain view into the block index.
-	index     *blockIndex
-	bestChain *chainView
+	//
+	// bestHeader tracks the current active header chain. The tip is the last
+	// header we have on the block index.
+	index      *blockIndex
+	bestChain  *chainView
+	bestHeader *chainView
 
 	// The UTXO state holds a cached view of the UTXO state of the chain.
 	//
@@ -2529,6 +2533,7 @@ func New(config *Config) (*BlockChain, error) {
 		utreexoView:         config.UtreexoView,
 		hashCache:           config.HashCache,
 		bestChain:           newChainView(nil),
+		bestHeader:          newChainView(nil),
 		orphans:             make(map[chainhash.Hash]*orphanBlock),
 		prevOrphans:         make(map[chainhash.Hash][]*orphanBlock),
 		warningCaches:       newThresholdCaches(vbNumBits),

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1184,6 +1184,7 @@ func (b *BlockChain) createChainState() error {
 	node := newBlockNode(header, nil)
 	node.status = statusDataStored | statusValid
 	b.bestChain.SetTip(node)
+	b.bestHeader.SetTip(node)
 
 	// Add the new node to the index which is used for faster lookups.
 	b.index.addNode(node)
@@ -1392,6 +1393,7 @@ func (b *BlockChain) initChainState() error {
 				"chain tip %s in block index", state.hash))
 		}
 		b.bestChain.SetTip(tip)
+		b.bestHeader.SetTip(tip)
 
 		// Load the raw block bytes for the best block.
 		blockBytes, err := dbTx.FetchBlock(&state.hash)

--- a/blockchain/fullblocktests/common_test.go
+++ b/blockchain/fullblocktests/common_test.go
@@ -31,7 +31,7 @@ func (g *chaingenHarness) AcceptHeader(blockName string) {
 
 	// Determine if the header is already known before attempting to process it.
 	alreadyHaveHeader := g.chain.IndexLookupNode(&blockHash) != nil
-	err := g.chain.ProcessBlockHeader(header)
+	err := g.chain.ProcessBlockHeader(header, blockchain.BFNone)
 	if err != nil {
 		g.t.Fatalf("block header %q (hash %s) should have been "+
 			"accepted: %v", blockName, blockHash, err)
@@ -86,7 +86,7 @@ func (g *chaingenHarness) RejectHeader(blockName string, code blockchain.ErrorCo
 	// Determine if the header is already known before attempting to process it.
 	alreadyHaveHeader := g.chain.IndexLookupNode(&blockHash) != nil
 
-	err := g.chain.ProcessBlockHeader(header)
+	err := g.chain.ProcessBlockHeader(header, blockchain.BFNone)
 	if err == nil {
 		g.t.Fatalf("block header %q (hash %s) should not have been "+
 			"accepted", blockName, blockHash)

--- a/blockchain/fullblocktests/common_test.go
+++ b/blockchain/fullblocktests/common_test.go
@@ -31,7 +31,7 @@ func (g *chaingenHarness) AcceptHeader(blockName string) {
 
 	// Determine if the header is already known before attempting to process it.
 	alreadyHaveHeader := g.chain.IndexLookupNode(&blockHash) != nil
-	err := g.chain.ProcessBlockHeader(header, blockchain.BFNone)
+	_, err := g.chain.ProcessBlockHeader(header, blockchain.BFNone)
 	if err != nil {
 		g.t.Fatalf("block header %q (hash %s) should have been "+
 			"accepted: %v", blockName, blockHash, err)
@@ -86,7 +86,7 @@ func (g *chaingenHarness) RejectHeader(blockName string, code blockchain.ErrorCo
 	// Determine if the header is already known before attempting to process it.
 	alreadyHaveHeader := g.chain.IndexLookupNode(&blockHash) != nil
 
-	err := g.chain.ProcessBlockHeader(header, blockchain.BFNone)
+	_, err := g.chain.ProcessBlockHeader(header, blockchain.BFNone)
 	if err == nil {
 		g.t.Fatalf("block header %q (hash %s) should not have been "+
 			"accepted", blockName, blockHash)

--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -166,17 +166,15 @@ func (b *BlockChain) checkKnownInvalidBlock(node *blockNode) error {
 // are already known to be a part of an invalid branch.  This means headers must
 // be processed in order.
 //
+// The returned boolean indicates whether or not the header was in the main chain
+// or not.
+//
 // This function is safe for concurrent access.
-func (b *BlockChain) ProcessBlockHeader(header *wire.BlockHeader, flags BehaviorFlags) error {
+func (b *BlockChain) ProcessBlockHeader(header *wire.BlockHeader, flags BehaviorFlags) (bool, error) {
 	b.chainLock.Lock()
 	defer b.chainLock.Unlock()
 
-	_, err := b.maybeAcceptBlockHeader(header, flags)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return b.maybeAcceptBlockHeader(header, flags)
 }
 
 // ProcessBlock is the main workhorse for handling insertion of new blocks into

--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -155,7 +155,7 @@ func (b *BlockChain) checkKnownInvalidBlock(node *blockNode) error {
 // headers into the block chain using headers-first semantics.  It includes
 // functionality such as rejecting headers that do not connect to an existing
 // known header, ensuring headers follow all rules that do not depend on having
-// all ancestor block data available, and insertion into the block index.
+// all ancestor block header data available, and insertion into the block index.
 //
 // Block headers that have already been inserted are ignored, unless they have
 // subsequently been marked invalid, in which case an appropriate error is
@@ -167,14 +167,15 @@ func (b *BlockChain) checkKnownInvalidBlock(node *blockNode) error {
 // be processed in order.
 //
 // This function is safe for concurrent access.
-func (b *BlockChain) ProcessBlockHeader(header *wire.BlockHeader) error {
+func (b *BlockChain) ProcessBlockHeader(header *wire.BlockHeader, flags BehaviorFlags) error {
 	b.chainLock.Lock()
 	defer b.chainLock.Unlock()
-	const checkHeaderSanity = true
-	_, err := b.maybeAcceptBlockHeader(header, checkHeaderSanity)
+
+	_, err := b.maybeAcceptBlockHeader(header, flags)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/blockchain/process_test.go
+++ b/blockchain/process_test.go
@@ -58,6 +58,9 @@ func TestProcessBlockHeader(t *testing.T) {
 	chain, params, tearDown := utxoCacheTestChain("TestProcessBlockHeader")
 	defer tearDown()
 
+	// Generate and process the intial 10 block headers.
+	//
+	// 	genesis -> 1  -> 2  -> ...  -> 10 (active)
 	headers := chainedHeaders(&params.GenesisBlock.Header, params, 0, 10)
 	for _, header := range headers {
 		err := chain.ProcessBlockHeader(header, BFNone)
@@ -66,14 +69,33 @@ func TestProcessBlockHeader(t *testing.T) {
 		}
 	}
 
+	// Check that the tip is correct.
+	lastHeader := headers[len(headers)-1]
+	lastHeaderHash := lastHeader.BlockHash()
+	tipNode := chain.bestHeader.Tip()
+	if !tipNode.hash.IsEqual(&lastHeaderHash) {
+		t.Fatalf("expected %v but got %v", lastHeaderHash.String(), tipNode.hash.String())
+	}
+	if tipNode.status != statusNone {
+		t.Fatalf("expected statusNone but got %v", tipNode.status)
+	}
+	if tipNode.height != int32(len(headers)) {
+		t.Fatalf("expected height of %v but got %v", len(headers), tipNode.height)
+	}
+
 	// Create sidechain block headers.
+	//
+	// 	genesis -> 1  -> 2  -> 3  -> 4  -> 5  -> ... -> 10 (active)
+	//                                            \-> 6  -> ... -> 8 (valid-fork)
 	blockHash := headers[4].BlockHash()
 	node := chain.IndexLookupNode(&blockHash)
+	forkHeight := node.height
 	sideChainHeaders := chainedHeaders(headers[4], params, node.height, 3)
+	sidechainTip := sideChainHeaders[len(sideChainHeaders)-1]
 
 	// Test that the last block header fails as it's missing the previous block
 	// header.
-	err := chain.ProcessBlockHeader(sideChainHeaders[len(sideChainHeaders)-1], BFNone)
+	err := chain.ProcessBlockHeader(sidechainTip, BFNone)
 	if err == nil {
 		err := fmt.Errorf("sideChainHeader %v passed verification but "+
 			"should've failed verification"+
@@ -89,5 +111,58 @@ func TestProcessBlockHeader(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+	}
+
+	// Check that the tip is still the same as before.
+	if !tipNode.hash.IsEqual(&lastHeaderHash) {
+		t.Fatalf("expected %v but got %v", lastHeaderHash.String(), tipNode.hash.String())
+	}
+	if tipNode.status != statusNone {
+		t.Fatalf("expected statusNone but got %v", tipNode.status)
+	}
+	if tipNode.height != int32(len(headers)) {
+		t.Fatalf("expected height of %v but got %v", len(headers), tipNode.height)
+	}
+
+	// Verify that the side-chain extending headers verify.
+	sidechainExtendingHeaders := chainedHeaders(sidechainTip, params, forkHeight+int32(len(sideChainHeaders)), 10)
+	for _, header := range sidechainExtendingHeaders {
+		err := chain.ProcessBlockHeader(header, BFNone)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create more sidechain block headers so that it becomes the active chain.
+	//
+	// 	genesis -> 1  -> 2  -> 3  -> 4  -> 5  -> ... -> 10 (valid-fork)
+	//                                            \-> 6  -> ... -> 18 (active)
+	lastSidechainHeader := sidechainExtendingHeaders[len(sidechainExtendingHeaders)-1]
+	lastSidechainHeaderHash := lastSidechainHeader.BlockHash()
+
+	// Check that the tip is now different.
+	tipNode = chain.bestHeader.Tip()
+	if !tipNode.hash.IsEqual(&lastSidechainHeaderHash) {
+		t.Fatalf("expected %v but got %v", lastSidechainHeaderHash.String(), tipNode.hash.String())
+	}
+	if tipNode.status != statusNone {
+		t.Fatalf("expected statusNone but got %v", tipNode.status)
+	}
+	if tipNode.height != int32(len(sideChainHeaders)+len(sidechainExtendingHeaders))+forkHeight {
+		t.Fatalf("expected height of %v but got %v", len(headers), tipNode.height)
+	}
+
+	// Extend the original headers and check it still verifies.
+	extendedOrigHeaders := chainedHeaders(lastHeader, params, int32(len(headers)), 2)
+	for _, header := range extendedOrigHeaders {
+		err := chain.ProcessBlockHeader(header, BFNone)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Check that the tip didn't change.
+	if !tipNode.hash.IsEqual(&lastSidechainHeaderHash) {
+		t.Fatalf("expected %v but got %v", lastSidechainHeaderHash.String(), tipNode.hash.String())
 	}
 }

--- a/blockchain/process_test.go
+++ b/blockchain/process_test.go
@@ -60,7 +60,7 @@ func TestProcessBlockHeader(t *testing.T) {
 
 	headers := chainedHeaders(&params.GenesisBlock.Header, params, 0, 10)
 	for _, header := range headers {
-		err := chain.ProcessBlockHeader(header)
+		err := chain.ProcessBlockHeader(header, BFNone)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -73,7 +73,7 @@ func TestProcessBlockHeader(t *testing.T) {
 
 	// Test that the last block header fails as it's missing the previous block
 	// header.
-	err := chain.ProcessBlockHeader(sideChainHeaders[len(sideChainHeaders)-1])
+	err := chain.ProcessBlockHeader(sideChainHeaders[len(sideChainHeaders)-1], BFNone)
 	if err == nil {
 		err := fmt.Errorf("sideChainHeader %v passed verification but "+
 			"should've failed verification"+
@@ -85,7 +85,7 @@ func TestProcessBlockHeader(t *testing.T) {
 
 	// Verify that the side-chain headers verify.
 	for _, header := range sideChainHeaders {
-		err := chain.ProcessBlockHeader(header)
+		err := chain.ProcessBlockHeader(header, BFNone)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1303,7 +1303,7 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		sm.resetHeaderState(&best.Hash, best.Height)
 
 		for _, blockHeader := range msg.Headers {
-			err := sm.chain.ProcessBlockHeader(blockHeader)
+			err := sm.chain.ProcessBlockHeader(blockHeader, blockchain.BFNone)
 			if err != nil {
 				log.Warnf("Received block header from peer %v "+
 					"failed header verification -- disconnecting",
@@ -1364,7 +1364,8 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		for _, blockHeader := range msg.Headers {
 			finalHeader = blockHeader
 
-			err := sm.chain.ProcessBlockHeader(blockHeader)
+			err := sm.chain.ProcessBlockHeader(blockHeader,
+				blockchain.BFFastAdd|blockchain.BFNoPoWCheck)
 			if err != nil {
 				log.Warnf("Received block header that does not "+
 					"properly connect to the chain from peer %s "+
@@ -1446,7 +1447,7 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		var finalHeader *wire.BlockHeader
 		for _, blockHeader := range msg.Headers {
 			blockHash := blockHeader.BlockHash()
-			err := sm.chain.ProcessBlockHeader(blockHeader)
+			err := sm.chain.ProcessBlockHeader(blockHeader, blockchain.BFNone)
 			if err != nil {
 				log.Warnf("Received block header that did not "+
 					"pass verification from peer %s "+

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1303,7 +1303,7 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		sm.resetHeaderState(&best.Hash, best.Height)
 
 		for _, blockHeader := range msg.Headers {
-			err := sm.chain.ProcessBlockHeader(blockHeader, blockchain.BFNone)
+			_, err := sm.chain.ProcessBlockHeader(blockHeader, blockchain.BFNone)
 			if err != nil {
 				log.Warnf("Received block header from peer %v "+
 					"failed header verification -- disconnecting",
@@ -1364,7 +1364,7 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		for _, blockHeader := range msg.Headers {
 			finalHeader = blockHeader
 
-			err := sm.chain.ProcessBlockHeader(blockHeader,
+			_, err := sm.chain.ProcessBlockHeader(blockHeader,
 				blockchain.BFFastAdd|blockchain.BFNoPoWCheck)
 			if err != nil {
 				log.Warnf("Received block header that does not "+
@@ -1447,7 +1447,7 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		var finalHeader *wire.BlockHeader
 		for _, blockHeader := range msg.Headers {
 			blockHash := blockHeader.BlockHash()
-			err := sm.chain.ProcessBlockHeader(blockHeader, blockchain.BFNone)
+			_, err := sm.chain.ProcessBlockHeader(blockHeader, blockchain.BFNone)
 			if err != nil {
 				log.Warnf("Received block header that did not "+
 					"pass verification from peer %s "+


### PR DESCRIPTION
Since we now accept headers for new block announcements, it's impossible to distinguish between
new block announcements and headers received from ibd in the same code block.

We change the code to rely on `ProcessBlockHeader` for block header connection and for figuring out
best chain selection instead of a strict "does this blockheader connect to the previous one".

This avoids errors that happens during ibd where a block header is rejected and a peer is banned because
of new header announcements that fail to connect as the node does not have the entire chain of headers yet.