### PR TITLE
wire: add MsgGetUtreexoRoot

### DIFF
--- a/wire/message.go
+++ b/wire/message.go
@@ -63,6 +63,7 @@ const (
 	CmdSendAddrV2       = "sendaddrv2"
 	CmdUtreexoProof     = "uproof"
 	CmdGetUtreexoProof  = "getuproof"
+	CmdGetUtreexoRoot   = "geturoot"
 )
 
 // MessageEncoding represents the wire message encoding format to be used.
@@ -162,6 +163,9 @@ func makeEmptyMessage(command string) (Message, error) {
 
 	case CmdGetUtreexoProof:
 		msg = &MsgGetUtreexoProof{}
+
+	case CmdGetUtreexoRoot:
+		msg = &MsgGetUtreexoRoot{}
 
 	case CmdAlert:
 		msg = &MsgAlert{}

--- a/wire/msggetutreexoroot.go
+++ b/wire/msggetutreexoroot.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"io"
+
+	"github.com/utreexo/utreexod/chaincfg/chainhash"
+)
+
+// MsgGetUtreexoRoot implements the Message interface and represents a bitcoin
+// getutreexoroot message. It's used to request the utreexo roots at the given
+// block.
+type MsgGetUtreexoRoot struct {
+	BlockHash chainhash.Hash
+}
+
+// BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgGetUtreexoRoot) BtcDecode(r io.Reader, _ uint32, _ MessageEncoding) error {
+	_, err := io.ReadFull(r, msg.BlockHash[:])
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgGetUtreexoRoot) BtcEncode(w io.Writer, _ uint32, _ MessageEncoding) error {
+	_, err := w.Write(msg.BlockHash[:])
+	return err
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgGetUtreexoRoot) Command() string {
+	return CmdGetUtreexoRoot
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver.  This is part of the Message interface implementation.
+func (msg *MsgGetUtreexoRoot) MaxPayloadLength(_ uint32) uint32 {
+	return chainhash.HashSize
+}
+
+// NewMsgGetUtreexoRoot returns a new bitcoin getheaders message that conforms to
+// the Message interface.  See MsgGetUtreexoRoot for details.
+func NewMsgGetUtreexoRoot(blockHash chainhash.Hash) *MsgGetUtreexoRoot {
+	return &MsgGetUtreexoRoot{BlockHash: blockHash}
+}

--- a/wire/msggetutreexoroot_test.go
+++ b/wire/msggetutreexoroot_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2025 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/utreexo/utreexod/chaincfg/chainhash"
+)
+
+var genesisHash = chainhash.Hash([chainhash.HashSize]byte{ // Make go vet happy.
+	0x6f, 0xe2, 0x8c, 0x0a, 0xb6, 0xf1, 0xb3, 0x72,
+	0xc1, 0xa6, 0xa2, 0x46, 0xae, 0x63, 0xf7, 0x4f,
+	0x93, 0x1e, 0x83, 0x65, 0xe1, 0x5a, 0x08, 0x9c,
+	0x68, 0xd6, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00,
+})
+
+func TestMsgGetUtreexoRootEncode(t *testing.T) {
+	testCases := []struct {
+		hash chainhash.Hash
+	}{
+		{
+			hash: genesisHash,
+		},
+	}
+
+	for _, testCase := range testCases {
+		beforeMsg := NewMsgGetUtreexoRoot(testCase.hash)
+
+		// Encode.
+		var buf bytes.Buffer
+		err := beforeMsg.BtcEncode(&buf, 0, LatestEncoding)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		serialized := buf.Bytes()
+
+		afterMsg := MsgGetUtreexoRoot{}
+		r := bytes.NewReader(serialized)
+		err = afterMsg.BtcDecode(r, 0, LatestEncoding)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !afterMsg.BlockHash.IsEqual(&testCase.hash) {
+			t.Fatalf("expected %v but got %v",
+				testCase.hash, afterMsg.BlockHash)
+		}
+	}
+}


### PR DESCRIPTION
MsgGetUtreexoRoot can be used to ask peers to send the utreexo roots and the proof for it.