### PR TITLE
indexers, main: fix off by one root error

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -413,11 +413,6 @@ func (idx *FlatUtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.
 		}
 	}
 
-	err = idx.storeRoots(block.Height(), idx.utreexoState.state)
-	if err != nil {
-		return err
-	}
-
 	addHashes := make([]utreexo.Hash, 0, len(adds))
 	for _, add := range adds {
 		addHashes = append(addHashes, add.Hash)
@@ -426,6 +421,11 @@ func (idx *FlatUtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.
 	idx.mtx.Lock()
 	err = idx.utreexoState.state.Modify(adds, delHashes, ud.AccProof)
 	idx.mtx.Unlock()
+	if err != nil {
+		return err
+	}
+
+	err = idx.storeRoots(block.Height(), idx.utreexoState.state)
 	if err != nil {
 		return err
 	}
@@ -581,7 +581,7 @@ func (idx *FlatUtreexoProofIndex) getUndoData(block *btcutil.Block) (uint64, []u
 func (idx *FlatUtreexoProofIndex) DisconnectBlock(dbTx database.Tx, block *btcutil.Block,
 	stxos []blockchain.SpentTxOut) error {
 
-	state, err := idx.fetchRoots(block.Height())
+	state, err := idx.fetchRoots(block.Height() - 1)
 	if err != nil {
 		return err
 	}

--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -355,7 +355,7 @@ func testUtreexoProof(block *btcutil.Block, chain *blockchain.BlockChain, indexe
 				return err
 			}
 
-			flatStump, err = idxType.fetchRoots(block.Height())
+			flatStump, err = idxType.fetchRoots(block.Height() - 1)
 			if err != nil {
 				return err
 			}
@@ -367,8 +367,12 @@ func testUtreexoProof(block *btcutil.Block, chain *blockchain.BlockChain, indexe
 				return err
 			}
 
+			prevHash, err := chain.BlockHashByHeight(block.Height() - 1)
+			if err != nil {
+				return err
+			}
 			err = idxType.db.View(func(dbTx database.Tx) error {
-				stump, err = dbFetchUtreexoState(dbTx, block.Hash())
+				stump, err = dbFetchUtreexoState(dbTx, prevHash)
 				if err != nil {
 					return err
 				}

--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -168,7 +168,7 @@ func csnTestChain(testName string) (*blockchain.BlockChain, *chaincfg.Params, fu
 // to end.
 func compareUtreexoIdx(start, end int32, pruned bool, chain *blockchain.BlockChain, indexes []Indexer) error {
 	// Check that the newly added data to both of the indexes are equal.
-	for b := start; b < end; b++ {
+	for b := start; b <= end; b++ {
 		// Declare the utreexo data and the undo blocks that we'll be
 		// comparing.
 		var utreexoUD, flatUD *wire.UData
@@ -253,32 +253,6 @@ func compareUtreexoIdx(start, end int32, pruned bool, chain *blockchain.BlockCha
 			err := fmt.Errorf("Fetched root data differ for "+
 				"utreexo proof index and flat utreexo proof index at height %d", b)
 			return err
-		}
-	}
-
-	// Compare the current utreexo state.
-	var expectRoots []*chainhash.Hash
-	var expectNumLeaves uint64
-	for _, indexer := range indexes {
-		switch idxType := indexer.(type) {
-		case *UtreexoProofIndex:
-			expectRoots, expectNumLeaves = idxType.FetchCurrentUtreexoState()
-		}
-	}
-	for _, indexer := range indexes {
-		switch idxType := indexer.(type) {
-		case *FlatUtreexoProofIndex:
-			roots, numLeaves := idxType.FetchCurrentUtreexoState()
-
-			if !reflect.DeepEqual(roots, expectRoots) {
-				return fmt.Errorf("expected roots of:\n%v\nbut got:\n%v",
-					expectRoots, roots)
-			}
-
-			if numLeaves != expectNumLeaves {
-				return fmt.Errorf("expected numLeaves of %v but got %v",
-					expectNumLeaves, numLeaves)
-			}
 		}
 	}
 
@@ -759,16 +733,20 @@ func TestBridgeNodePruneUndoDataGen(t *testing.T) {
 
 	// Grab the utreexo state and numLeaves.
 	for _, indexer := range indexes {
+		state := chain.BestSnapshot()
 		switch idxType := indexer.(type) {
 		case *FlatUtreexoProofIndex:
-			utreexoState, numLeaves := idxType.FetchCurrentUtreexoState()
+			utreexoState, numLeaves, err := idxType.FetchUtreexoState(state.Height)
+			if err != nil {
+				t.Fatal(err)
+			}
 			utreexoStates = append(utreexoStates, utreexoState)
 			utreexoNumLeaves = append(utreexoNumLeaves, numLeaves)
 		}
 	}
 
 	nextBlock := btcutil.NewBlock(params.GenesisBlock)
-	for i := int32(0); i < maxHeight; i++ {
+	for i := int32(1); i <= maxHeight; i++ {
 		newBlock, newSpendableOuts, err := blockchain.AddBlock(chain, nextBlock, nextSpends)
 		if err != nil {
 			t.Fatal(err)
@@ -791,7 +769,10 @@ func TestBridgeNodePruneUndoDataGen(t *testing.T) {
 		for _, indexer := range indexes {
 			switch idxType := indexer.(type) {
 			case *FlatUtreexoProofIndex:
-				utreexoState, numLeaves := idxType.FetchCurrentUtreexoState()
+				utreexoState, numLeaves, err := idxType.FetchUtreexoState(i)
+				if err != nil {
+					t.Fatal(err)
+				}
 				utreexoStates = append(utreexoStates, utreexoState)
 				utreexoNumLeaves = append(utreexoNumLeaves, numLeaves)
 			}
@@ -804,7 +785,19 @@ func TestBridgeNodePruneUndoDataGen(t *testing.T) {
 				expectRoots := utreexoStates[len(utreexoStates)-1]
 				expectNumLeaves := utreexoNumLeaves[len(utreexoNumLeaves)-1]
 
-				utreexoState, numLeaves := idxType.FetchCurrentUtreexoState()
+				var utreexoState []*chainhash.Hash
+				var numLeaves uint64
+				err = idxType.db.View(func(dbTx database.Tx) error {
+					hash, err := idxType.chain.BlockHashByHeight(i)
+					if err != nil {
+						t.Fatal(err)
+					}
+					utreexoState, numLeaves, err = idxType.FetchUtreexoState(dbTx, hash)
+					return err
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
 				if expectNumLeaves != numLeaves {
 					t.Fatalf("expected numLeaves of %v but got %v",
 						expectNumLeaves, numLeaves)
@@ -940,7 +933,10 @@ func TestBridgeNodePruneUndoDataGen(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				utreexoState, numLeaves := idxType.FetchCurrentUtreexoState()
+				utreexoState, numLeaves, err := idxType.FetchUtreexoState(block.Height() - 1)
+				if err != nil {
+					t.Fatal(err)
+				}
 				if numLeaves != expectNumLeaves {
 					t.Fatalf("expected numLeaves of %v but got %v",
 						expectNumLeaves, numLeaves)
@@ -959,7 +955,19 @@ func TestBridgeNodePruneUndoDataGen(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				utreexoState, numLeaves := idxType.FetchCurrentUtreexoState()
+				var utreexoState []*chainhash.Hash
+				var numLeaves uint64
+				err = idxType.db.Update(func(dbTx database.Tx) error {
+					hash, err := idxType.chain.BlockHashByHeight(block.Height() - 1)
+					if err != nil {
+						t.Fatal(err)
+					}
+					utreexoState, numLeaves, err = idxType.FetchUtreexoState(dbTx, hash)
+					return err
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
 				if !reflect.DeepEqual(expectState, utreexoState) {
 					t.Fatalf("height %v, expected roots of:\n%v\nbut got:\n%v",
 						i, expectState, utreexoState)

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -176,38 +176,6 @@ func dbFetchUtreexoStateConsistency(db *leveldb.DB) (*chainhash.Hash, uint64, er
 	return bestHash, binary.LittleEndian.Uint64(buf[:8]), nil
 }
 
-// FetchCurrentUtreexoState returns the current utreexo state.
-func (idx *UtreexoProofIndex) FetchCurrentUtreexoState() ([]*chainhash.Hash, uint64) {
-	idx.mtx.RLock()
-	defer idx.mtx.RUnlock()
-
-	roots := idx.utreexoState.state.GetRoots()
-	chainhashRoots := make([]*chainhash.Hash, len(roots))
-
-	for i, root := range roots {
-		newRoot := chainhash.Hash(root)
-		chainhashRoots[i] = &newRoot
-	}
-
-	return chainhashRoots, idx.utreexoState.state.GetNumLeaves()
-}
-
-// FetchCurrentUtreexoState returns the current utreexo state.
-func (idx *FlatUtreexoProofIndex) FetchCurrentUtreexoState() ([]*chainhash.Hash, uint64) {
-	idx.mtx.RLock()
-	defer idx.mtx.RUnlock()
-
-	roots := idx.utreexoState.state.GetRoots()
-
-	chainhashRoots := make([]*chainhash.Hash, len(roots))
-	for i, root := range roots {
-		newRoot := chainhash.Hash(root)
-		chainhashRoots[i] = &newRoot
-	}
-
-	return chainhashRoots, idx.utreexoState.state.GetNumLeaves()
-}
-
 // FetchUtreexoState returns the utreexo state at the desired block.
 func (idx *UtreexoProofIndex) FetchUtreexoState(dbTx database.Tx, blockHash *chainhash.Hash) ([]*chainhash.Hash, uint64, error) {
 	stump, err := dbFetchUtreexoState(dbTx, blockHash)


### PR DESCRIPTION
The utreexo root was saved before the modification with the justification that it was easier for reorgs. This mistake is now corrected.