### PR TITLE
wire, netsync: add includeproof bool to getutreexoheader

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1041,7 +1041,7 @@ func (sm *SyncManager) fetchUtreexoHeaders(peer *peerpkg.Peer) {
 		_, have := sm.utreexoHeaders[*hash]
 		if !requested && !have {
 			state.requestedUtreexoHeaders[*hash] = struct{}{}
-			ghmsg := wire.NewMsgGetUtreexoHeader(*hash)
+			ghmsg := wire.NewMsgGetUtreexoHeader(*hash, true)
 			reqPeer.QueueMessage(ghmsg, nil)
 		}
 
@@ -1755,7 +1755,7 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 			if _, exists := sm.requestedBlocks[iv.Hash]; !exists {
 				amUtreexoNode := sm.chain.IsUtreexoViewActive()
 				if amUtreexoNode {
-					ghmsg := wire.NewMsgGetUtreexoHeader(iv.Hash)
+					ghmsg := wire.NewMsgGetUtreexoHeader(iv.Hash, true)
 					peer.QueueMessage(ghmsg, nil)
 					continue
 				}

--- a/wire/msggetutreexoheader.go
+++ b/wire/msggetutreexoheader.go
@@ -13,7 +13,8 @@ import (
 // getutreexoheader message. It's used to request the utreexo header at the given
 // block.
 type MsgGetUtreexoHeader struct {
-	BlockHash chainhash.Hash
+	BlockHash    chainhash.Hash
+	IncludeProof bool
 }
 
 // BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
@@ -24,12 +25,21 @@ func (msg *MsgGetUtreexoHeader) BtcDecode(r io.Reader, pver uint32, enc MessageE
 		return err
 	}
 
+	msg.IncludeProof = msg.BlockHash[31] == 2
+	msg.BlockHash[31] = 0
+
 	return nil
 }
 
 // BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
 // This is part of the Message interface implementation.
 func (msg *MsgGetUtreexoHeader) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) error {
+	if !msg.IncludeProof {
+		msg.BlockHash[31] = 1
+	} else {
+		msg.BlockHash[31] = 2
+	}
+
 	_, err := w.Write(msg.BlockHash[:])
 	if err != nil {
 		return err
@@ -52,6 +62,6 @@ func (msg *MsgGetUtreexoHeader) MaxPayloadLength(pver uint32) uint32 {
 
 // NewMsgGetUtreexoHeader returns a new bitcoin getheaders message that conforms to
 // the Message interface.  See MsgGetUtreexoHeader for details.
-func NewMsgGetUtreexoHeader(blockHash chainhash.Hash) *MsgGetUtreexoHeader {
-	return &MsgGetUtreexoHeader{BlockHash: blockHash}
+func NewMsgGetUtreexoHeader(blockHash chainhash.Hash, includeProof bool) *MsgGetUtreexoHeader {
+	return &MsgGetUtreexoHeader{BlockHash: blockHash, IncludeProof: includeProof}
 }

--- a/wire/msggetutreexoheader_test.go
+++ b/wire/msggetutreexoheader_test.go
@@ -1,0 +1,54 @@
+package wire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/utreexo/utreexod/chaincfg/chainhash"
+)
+
+func TestMsgGetUtreexoHeaderEncode(t *testing.T) {
+	testCases := []struct {
+		hash         chainhash.Hash
+		includeProof bool
+	}{
+		{
+			hash:         genesisHash,
+			includeProof: false,
+		},
+		{
+			hash:         genesisHash,
+			includeProof: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		beforeMsg := NewMsgGetUtreexoHeader(testCase.hash, testCase.includeProof)
+
+		// Encode.
+		var buf bytes.Buffer
+		err := beforeMsg.BtcEncode(&buf, 0, LatestEncoding)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		serialized := buf.Bytes()
+
+		afterMsg := MsgGetUtreexoHeader{}
+		r := bytes.NewReader(serialized)
+		err = afterMsg.BtcDecode(r, 0, LatestEncoding)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !afterMsg.BlockHash.IsEqual(&testCase.hash) {
+			t.Fatalf("expected %v but got %v",
+				testCase.hash, afterMsg.BlockHash)
+		}
+
+		if afterMsg.IncludeProof != testCase.includeProof {
+			t.Fatalf("expected %v but got %v",
+				testCase.includeProof, afterMsg.IncludeProof)
+		}
+	}
+}


### PR DESCRIPTION
Since utreexoheader includes proofs that could be beyond the what the ibd-ing node has the roots for, it's good to have a method to omit what's not necessary. The bool here allows the requester to do just that.