### PR TITLE
wire: add proof hashes to msgutreexoheader

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -832,14 +832,14 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 
 		udata := wire.UData{
 			AccProof: utreexo.Proof{
-				Targets: utreexoHeader.Targets,
+				Targets: utreexoHeader.BlockTargets,
 				Proof:   utreexoProofMsg.proof.ProofHashes,
 			},
 			LeafDatas: utreexoProofMsg.proof.LeafDatas,
 		}
 
 		bmsg.block.MsgBlock().UData = &udata
-		bmsg.block.MsgBlock().UData.AccProof.Targets = utreexoHeader.Targets
+		bmsg.block.MsgBlock().UData.AccProof.Targets = utreexoHeader.BlockTargets
 	}
 
 	// Process the block based off the headers if we're still in headers-first mode.
@@ -1162,7 +1162,7 @@ func (sm *SyncManager) fetchHeaderBlocks(peer *peerpkg.Peer) {
 				syncPeerState.requestedUtreexoProofs[*hash] = struct{}{}
 
 				msg := wire.ConstructGetProofMsg(
-					hash, sm.numLeaves[h-1], utreexoHeader.Targets)
+					hash, sm.numLeaves[h-1], utreexoHeader.BlockTargets)
 				reqPeer.QueueMessage(msg, nil)
 			}
 		}

--- a/server.go
+++ b/server.go
@@ -957,11 +957,11 @@ func (sp *serverPeer) OnGetUtreexoHeader(_ *peer.Peer, msg *wire.MsgGetUtreexoHe
 
 	// Construct the utreexo header.
 	blockHeader := wire.MsgUtreexoHeader{
-		BlockHash: msg.BlockHash,
-		NumAdds:   uint16(len(adds)),
-		Targets:   make([]uint64, len(targets)),
+		BlockHash:    msg.BlockHash,
+		NumAdds:      uint16(len(adds)),
+		BlockTargets: make([]uint64, len(targets)),
 	}
-	copy(blockHeader.Targets, targets)
+	copy(blockHeader.BlockTargets, targets)
 	sp.QueueMessage(&blockHeader, nil)
 }
 

--- a/wire/msgutreexoheader_test.go
+++ b/wire/msgutreexoheader_test.go
@@ -6,27 +6,57 @@ package wire
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 
+	"github.com/utreexo/utreexo"
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
 )
 
-func TestUtreexoBlockHeaderSerializeSize(t *testing.T) {
+func TestUtreexoBlockHeaderSerialize(t *testing.T) {
 	tests := []struct {
 		data MsgUtreexoHeader
 	}{
 		{
 			data: MsgUtreexoHeader{
-				BlockHash: chainhash.HashH([]byte{1}),
-				NumAdds:   8,
-				Targets:   []uint64{14181, 484518},
+				BlockHash:    chainhash.HashH([]byte{1}),
+				NumAdds:      8,
+				BlockTargets: []uint64{14181, 484518},
+				ProofTargets: []uint64{33, 34, 35, 36, 37, 38},
+				ProofHashes: []utreexo.Hash{
+					utreexo.Hash(chainhash.HashH([]byte{1})),
+					utreexo.Hash(chainhash.HashH([]byte{2})),
+					utreexo.Hash(chainhash.HashH([]byte{3})),
+					utreexo.Hash(chainhash.HashH([]byte{4})),
+				},
 			},
 		},
 		{
 			data: MsgUtreexoHeader{
-				BlockHash: chainhash.HashH([]byte{5}),
-				NumAdds:   1544,
-				Targets:   []uint64{14181, 484518, 11774, 148185, 189416854, 15481, 18518, 2},
+				BlockHash:    chainhash.HashH([]byte{1}),
+				NumAdds:      8,
+				BlockTargets: []uint64{14181, 484518},
+			},
+		},
+		{
+			data: MsgUtreexoHeader{
+				BlockHash:    chainhash.HashH([]byte{5}),
+				NumAdds:      1544,
+				BlockTargets: []uint64{14181, 484518, 11774, 148185, 189416854, 15481, 18518, 2},
+				ProofTargets: []uint64{84154, 84155, 84156, 84157, 84158, 84159, 84160, 84161, 84162, 84163, 84164, 84165},
+				ProofHashes: []utreexo.Hash{
+					utreexo.Hash(chainhash.HashH([]byte{6})),
+					utreexo.Hash(chainhash.HashH([]byte{7})),
+					utreexo.Hash(chainhash.HashH([]byte{8})),
+					utreexo.Hash(chainhash.HashH([]byte{9})),
+				},
+			},
+		},
+		{
+			data: MsgUtreexoHeader{
+				BlockHash:    chainhash.HashH([]byte{5}),
+				NumAdds:      1544,
+				BlockTargets: []uint64{14181, 484518, 11774, 148185, 189416854, 15481, 18518, 2},
 			},
 		},
 	}
@@ -38,10 +68,24 @@ func TestUtreexoBlockHeaderSerializeSize(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expected := len(buf.Bytes())
-		got := test.data.SerializeSize()
-		if got != expected {
-			t.Fatalf("expected %v, got %v", expected, got)
+		b := buf.Bytes()
+
+		// Check size.
+		expectedSize := len(b)
+		gotSize := test.data.SerializeSize()
+		if gotSize != expectedSize {
+			t.Fatalf("expected %v, got %v", expectedSize, gotSize)
+		}
+
+		// Check data.
+		r := bytes.NewBuffer(b)
+		got := MsgUtreexoHeader{}
+		err = got.Deserialize(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, test.data) {
+			t.Fatalf("expected %v, got %v", test.data, got)
 		}
 	}
 }


### PR DESCRIPTION
The proof hashes prove that the utreexoheader was included in the accumulator hashes that were committed in the binary.