### PR TITLE
netsync: don't sync based on peer's last block

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -985,7 +985,7 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 		}
 	}
 
-	lastHeight := sm.syncPeer.LastBlock()
+	_, lastHeight := sm.chain.BestHeader()
 	if bmsg.block.Height() < lastHeight {
 		if sm.startHeader != nil && len(state.requestedBlocks) == 0 {
 			sm.fetchHeaderBlocks(nil)
@@ -1376,7 +1376,8 @@ func (sm *SyncManager) handleUtreexoSummariesMsg(hmsg *utreexoSummariesMsg) {
 			return
 		}
 
-		if height == peer.LastBlock() {
+		_, lastHeight := sm.chain.BestHeader()
+		if height == lastHeight {
 			log.Infof("Received utreexo summaries to block "+
 				"%d/hash %s. Fetching blocks",
 				height, lastSummary.BlockHash)


### PR DESCRIPTION
Since this value is subject to change, basing on this value may cause inconsistencies during ibd. Better to base off of the best header height which is local.