### PR TITLE
wire: change getutreexosummaries structure

### DIFF
--- a/wire/msggetutreexosummaries.go
+++ b/wire/msggetutreexosummaries.go
@@ -4,48 +4,35 @@
 package wire
 
 import (
+	"encoding/binary"
 	"io"
-
-	"github.com/utreexo/utreexod/chaincfg/chainhash"
 )
 
 // MsgGetUtreexoSummaries implements the Message interface and represents a bitcoin
-// getutreexoheader message. It's used to request the utreexo header at the given
-// block.
+// getutreexosummaries message. It's used to request the utreexo summaries at the given
+// blocks.
 type MsgGetUtreexoSummaries struct {
-	BlockHash    chainhash.Hash
-	IncludeProof bool
+	BlockPosition uint64
 }
 
 // BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
 // This is part of the Message interface implementation.
 func (msg *MsgGetUtreexoSummaries) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) error {
-	_, err := io.ReadFull(r, msg.BlockHash[:])
-	if err != nil {
-		return err
-	}
+	bs := newSerializer()
+	defer bs.free()
 
-	msg.IncludeProof = msg.BlockHash[31] == 2
-	msg.BlockHash[31] = 0
-
-	return nil
+	var err error
+	msg.BlockPosition, err = bs.Uint64(r, binary.LittleEndian)
+	return err
 }
 
 // BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
 // This is part of the Message interface implementation.
 func (msg *MsgGetUtreexoSummaries) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) error {
-	if !msg.IncludeProof {
-		msg.BlockHash[31] = 1
-	} else {
-		msg.BlockHash[31] = 2
-	}
+	bs := newSerializer()
+	defer bs.free()
 
-	_, err := w.Write(msg.BlockHash[:])
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return bs.PutUint64(w, binary.LittleEndian, msg.BlockPosition)
 }
 
 // Command returns the protocol command string for the message.  This is part
@@ -57,11 +44,11 @@ func (msg *MsgGetUtreexoSummaries) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetUtreexoSummaries) MaxPayloadLength(pver uint32) uint32 {
-	return chainhash.HashSize
+	return 8
 }
 
-// NewMsgGetUtreexoSummaries returns a new bitcoin getheaders message that conforms to
+// NewMsgGetUtreexoSummaries returns a new bitcoin getutreexosummaries message that conforms to
 // the Message interface.  See MsgGetUtreexoSummaries for details.
-func NewMsgGetUtreexoSummaries(blockHash chainhash.Hash, includeProof bool) *MsgGetUtreexoSummaries {
-	return &MsgGetUtreexoSummaries{BlockHash: blockHash, IncludeProof: includeProof}
+func NewMsgGetUtreexoSummaries(blockPosition uint64) *MsgGetUtreexoSummaries {
+	return &MsgGetUtreexoSummaries{BlockPosition: blockPosition}
 }

--- a/wire/msggetutreexosummaries_test.go
+++ b/wire/msggetutreexosummaries_test.go
@@ -3,52 +3,29 @@ package wire
 import (
 	"bytes"
 	"testing"
-
-	"github.com/utreexo/utreexod/chaincfg/chainhash"
 )
 
 func TestMsgGetUtreexoHeaderEncode(t *testing.T) {
-	testCases := []struct {
-		hash         chainhash.Hash
-		includeProof bool
-	}{
-		{
-			hash:         genesisHash,
-			includeProof: false,
-		},
-		{
-			hash:         genesisHash,
-			includeProof: true,
-		},
+	beforeMsg := NewMsgGetUtreexoSummaries(5)
+
+	// Encode.
+	var buf bytes.Buffer
+	err := beforeMsg.BtcEncode(&buf, 0, LatestEncoding)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	for _, testCase := range testCases {
-		beforeMsg := NewMsgGetUtreexoSummaries(testCase.hash, testCase.includeProof)
+	serialized := buf.Bytes()
 
-		// Encode.
-		var buf bytes.Buffer
-		err := beforeMsg.BtcEncode(&buf, 0, LatestEncoding)
-		if err != nil {
-			t.Fatal(err)
-		}
+	afterMsg := MsgGetUtreexoSummaries{}
+	r := bytes.NewReader(serialized)
+	err = afterMsg.BtcDecode(r, 0, LatestEncoding)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		serialized := buf.Bytes()
-
-		afterMsg := MsgGetUtreexoSummaries{}
-		r := bytes.NewReader(serialized)
-		err = afterMsg.BtcDecode(r, 0, LatestEncoding)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if !afterMsg.BlockHash.IsEqual(&testCase.hash) {
-			t.Fatalf("expected %v but got %v",
-				testCase.hash, afterMsg.BlockHash)
-		}
-
-		if afterMsg.IncludeProof != testCase.includeProof {
-			t.Fatalf("expected %v but got %v",
-				testCase.includeProof, afterMsg.IncludeProof)
-		}
+	if beforeMsg.BlockPosition != afterMsg.BlockPosition {
+		t.Fatalf("expected %v but got %v",
+			beforeMsg.BlockPosition, afterMsg.BlockPosition)
 	}
 }

--- a/wire/msgutreexoblocksummaries.go
+++ b/wire/msgutreexoblocksummaries.go
@@ -15,7 +15,7 @@ import (
 
 // MaxUtreexoBlockSummaryPerMsg is the maximum number of utreexo headers that can be in a single
 // bitcoin headers message.
-const MaxUtreexoBlockSummaryPerMsg = 100
+const MaxUtreexoBlockSummaryPerMsg = 128
 
 // MsgUtreexoSummaries implements the Message interface and represents a bitcoin
 // utreexoblocksummaries message. It's has the block summaries which is used as a


### PR DESCRIPTION
The changed getutreexosummaries structure asks for a position in the accumulator.
This position allows callers to ask for multiple utreexo summaries in one message
with just an uint64.