### PR TITLE
indexers: add genesis block to the root and block summary accumulators

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -183,7 +183,7 @@ func (idx *FlatUtreexoProofIndex) initUtreexoRootsState() error {
 	idx.utreexoRootsState = utreexo.NewAccumulator()
 
 	bestHeight := idx.rootsState.BestHeight()
-	for h := int32(1); h <= bestHeight; h++ {
+	for h := int32(0); h <= bestHeight; h++ {
 		stump, err := idx.fetchRoots(h)
 		if err != nil {
 			return err

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -211,7 +211,7 @@ func (idx *FlatUtreexoProofIndex) initBlockSummaryState() error {
 
 	var prevNumLeaves uint64
 	bestHeight := idx.proofState.BestHeight()
-	for h := int32(1); h <= bestHeight; h++ {
+	for h := int32(0); h <= bestHeight; h++ {
 		blockHash, err := idx.chain.BlockHashByHeight(h)
 		if err != nil {
 			return err
@@ -721,7 +721,7 @@ func (idx *FlatUtreexoProofIndex) FetchUtreexoProof(height int32) (
 	*wire.UData, error) {
 
 	if height == 0 {
-		return nil, fmt.Errorf("No Utreexo Proof for height %d", height)
+		return &wire.UData{}, nil
 	}
 
 	if idx.config.Pruned {

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -94,6 +94,11 @@ func (idx *UtreexoProofIndex) NeedsInputs() bool {
 func (idx *UtreexoProofIndex) initUtreexoRootsState(bestHeight int32) error {
 	idx.utreexoRootsState = utreexo.NewAccumulator()
 
+	// The bestHeight is always -1 during initialization. We change this
+	// to 0 so that the genesis block gets connected.
+	if bestHeight == -1 {
+		bestHeight = 0
+	}
 	for h := int32(0); h <= bestHeight; h++ {
 		hash, err := idx.chain.BlockHashByHeight(h)
 		if err != nil {
@@ -130,7 +135,7 @@ func (idx *UtreexoProofIndex) initBlockSummaryState(bestHeight int32) error {
 	idx.blockSummaryState = utreexo.NewAccumulator()
 
 	var prevNumLeaves uint64
-	for h := int32(1); h <= bestHeight; h++ {
+	for h := int32(0); h <= bestHeight; h++ {
 		blockHash, err := idx.chain.BlockHashByHeight(h)
 		if err != nil {
 			return err
@@ -536,6 +541,9 @@ func (idx *UtreexoProofIndex) FetchUtreexoProof(hash *chainhash.Hash) (*wire.UDa
 		proofBytes, err := dbFetchUtreexoProofEntry(dbTx, hash)
 		if err != nil {
 			return err
+		}
+		if proofBytes == nil {
+			return nil
 		}
 		r := bytes.NewReader(proofBytes)
 

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -94,7 +94,7 @@ func (idx *UtreexoProofIndex) NeedsInputs() bool {
 func (idx *UtreexoProofIndex) initUtreexoRootsState(bestHeight int32) error {
 	idx.utreexoRootsState = utreexo.NewAccumulator()
 
-	for h := int32(1); h <= bestHeight; h++ {
+	for h := int32(0); h <= bestHeight; h++ {
 		hash, err := idx.chain.BlockHashByHeight(h)
 		if err != nil {
 			return err
@@ -965,6 +965,9 @@ func dbStoreUtreexoState(dbTx database.Tx, hash *chainhash.Hash, p utreexo.Utree
 func dbFetchUtreexoState(dbTx database.Tx, hash *chainhash.Hash) (utreexo.Stump, error) {
 	stateBucket := dbTx.Metadata().Bucket(utreexoParentBucketKey).Bucket(utreexoStateKey)
 	serialized := stateBucket.Get(hash[:])
+	if serialized == nil {
+		return utreexo.Stump{}, nil
+	}
 
 	numLeaves, roots, err := blockchain.DeserializeUtreexoRoots(serialized)
 	if err != nil {


### PR DESCRIPTION
The change makes the leaf positions correspond with the block height,
avoiding off by one errors.