### PR TITLE
wire: req multiple summaries

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1041,7 +1041,7 @@ func (sm *SyncManager) fetchUtreexoSummaries(peer *peerpkg.Peer) {
 		_, have := sm.utreexoSummaries[*hash]
 		if !requested && !have {
 			state.requestedUtreexoSummaries[*hash] = struct{}{}
-			ghmsg := wire.NewMsgGetUtreexoSummaries(*hash, true)
+			ghmsg := wire.NewMsgGetUtreexoSummaries(*hash, 1)
 			reqPeer.QueueMessage(ghmsg, nil)
 		}
 
@@ -1773,7 +1773,7 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 			if _, exists := sm.requestedBlocks[iv.Hash]; !exists {
 				amUtreexoNode := sm.chain.IsUtreexoViewActive()
 				if amUtreexoNode {
-					ghmsg := wire.NewMsgGetUtreexoSummaries(iv.Hash, true)
+					ghmsg := wire.NewMsgGetUtreexoSummaries(iv.Hash, 1)
 					peer.QueueMessage(ghmsg, nil)
 					continue
 				}

--- a/server.go
+++ b/server.go
@@ -904,10 +904,10 @@ func (sp *serverPeer) OnGetUtreexoSummaries(_ *peer.Peer, msg *wire.MsgGetUtreex
 		return
 	}
 
-	height, err := sp.server.chain.BlockHeightByHash(&msg.BlockHash)
+	height, err := sp.server.chain.BlockHeightByHash(&msg.StartHash)
 	if err != nil {
 		chanLog.Debugf("Unable to fetch height for block hash %v: %v",
-			msg.BlockHash, err)
+			msg.StartHash, err)
 		return
 	}
 
@@ -918,16 +918,16 @@ func (sp *serverPeer) OnGetUtreexoSummaries(_ *peer.Peer, msg *wire.MsgGetUtreex
 	}
 
 	// Fetch adds.
-	block, err := sp.server.chain.BlockByHash(&msg.BlockHash)
+	block, err := sp.server.chain.BlockByHash(&msg.StartHash)
 	if err != nil {
 		chanLog.Debugf("Unable to fetch block for block hash %v: %v",
-			msg.BlockHash, err)
+			msg.StartHash, err)
 		return
 	}
 	adds, err := blockchain.ExtractAccumulatorAdds(block, []uint32{})
 	if err != nil {
 		chanLog.Debugf("Unable to extract adds for block hash %v: %v",
-			msg.BlockHash, err)
+			msg.StartHash, err)
 		return
 	}
 
@@ -937,10 +937,10 @@ func (sp *serverPeer) OnGetUtreexoSummaries(_ *peer.Peer, msg *wire.MsgGetUtreex
 		targets = block.MsgBlock().UData.AccProof.Targets
 	}
 	if sp.server.utreexoProofIndex != nil {
-		udata, err := sp.server.utreexoProofIndex.FetchUtreexoProof(&msg.BlockHash)
+		udata, err := sp.server.utreexoProofIndex.FetchUtreexoProof(&msg.StartHash)
 		if err != nil {
 			chanLog.Debugf("Unable to fetch utreexo proof for block hash %v: %v",
-				msg.BlockHash, err)
+				msg.StartHash, err)
 			return
 		}
 		targets = udata.AccProof.Targets
@@ -949,7 +949,7 @@ func (sp *serverPeer) OnGetUtreexoSummaries(_ *peer.Peer, msg *wire.MsgGetUtreex
 		udata, err := sp.server.flatUtreexoProofIndex.FetchUtreexoProof(height)
 		if err != nil {
 			chanLog.Debugf("Unable to fetch utreexo proof for block hash %v: %v",
-				msg.BlockHash, err)
+				msg.StartHash, err)
 			return
 		}
 		targets = udata.AccProof.Targets
@@ -957,7 +957,7 @@ func (sp *serverPeer) OnGetUtreexoSummaries(_ *peer.Peer, msg *wire.MsgGetUtreex
 
 	// Construct the utreexo summaries.
 	summary := wire.UtreexoBlockSummary{
-		BlockHash:    msg.BlockHash,
+		BlockHash:    msg.StartHash,
 		NumAdds:      uint16(len(adds)),
 		BlockTargets: make([]uint64, len(targets)),
 	}


### PR DESCRIPTION
We change the getutreexosummaries message to support requests for multiple block
summaries at once.