### PR TITLE
main, netsync handle multiple summaries

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -231,6 +231,7 @@ type SyncManager struct {
 	startHeader         *headerNode
 	nextCheckpoint      *chaincfg.Checkpoint
 	utreexoSummaries    map[chainhash.Hash]*wire.UtreexoBlockSummary
+	bestSummariesHash   chainhash.Hash
 	numLeaves           map[int32]uint64
 	queuedBlocks        map[chainhash.Hash]*blockMsg
 	queuedUtreexoProofs map[chainhash.Hash]*utreexoProofMsg
@@ -1021,34 +1022,27 @@ func (sm *SyncManager) fetchUtreexoSummaries(peer *peerpkg.Peer) {
 		reqPeer = peer
 	}
 
-	state, exists := sm.peerStates[reqPeer]
+	_, exists := sm.peerStates[reqPeer]
 	if !exists {
 		log.Warnf("Don't have peer state for request peer %s", reqPeer.String())
 		return
 	}
-
-	_, bestHeaderHeight := sm.chain.BestHeader()
-	bestState := sm.chain.BestSnapshot()
-	for h := bestState.Height + 1; h <= bestHeaderHeight; h++ {
-		hash, err := sm.chain.HeaderHashByHeight(h)
-		if err != nil {
-			log.Warnf("error while fetching the block hash for height %v -- %v",
-				h, err)
-			return
-		}
-
-		_, requested := state.requestedUtreexoSummaries[*hash]
-		_, have := sm.utreexoSummaries[*hash]
-		if !requested && !have {
-			state.requestedUtreexoSummaries[*hash] = struct{}{}
-			ghmsg := wire.NewMsgGetUtreexoSummaries(*hash, 1)
-			reqPeer.QueueMessage(ghmsg, nil)
-		}
-
-		if len(state.requestedUtreexoSummaries) > minInFlightBlocks {
-			break
-		}
+	height, err := sm.chain.HeaderHeightByHash(sm.bestSummariesHash)
+	if err != nil {
+		log.Warnf("error while fetching the block height for hash %v -- %v",
+			sm.bestSummariesHash, err)
+		return
 	}
+
+	startHash, err := sm.chain.HeaderHashByHeight(height + 1)
+	if err != nil {
+		log.Warnf("error while fetching the block hash for height %v -- %v",
+			height+1, err)
+		return
+	}
+
+	ghmsg := wire.NewMsgGetUtreexoSummaries(*startHash, wire.MaxUtreexoExponent)
+	reqPeer.QueueMessage(ghmsg, nil)
 }
 
 // fetchHeaderBlocks creates and sends a request to the syncPeer for the next
@@ -1337,7 +1331,7 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 // each summary was asked for and is from a known peer.
 func (sm *SyncManager) handleUtreexoSummariesMsg(hmsg *utreexoSummariesMsg) {
 	peer := hmsg.peer
-	peerState, exists := sm.peerStates[peer]
+	_, exists := sm.peerStates[peer]
 	if !exists {
 		log.Warnf("Received utreexo summary message from unknown peer %s", peer)
 		return
@@ -1355,17 +1349,6 @@ func (sm *SyncManager) handleUtreexoSummariesMsg(hmsg *utreexoSummariesMsg) {
 	// ask for more utreexo block summaries.
 	if sm.headersFirstMode {
 		for _, summary := range msg.Summaries {
-			_, found := peerState.requestedUtreexoSummaries[summary.BlockHash]
-			if !found {
-				log.Warnf("Got unrequested utreexo block summary from %s -- "+
-					"disconnecting", peer.Addr())
-				peer.Disconnect()
-				return
-			}
-
-			// Since we received it, it's no longer requested.
-			delete(peerState.requestedUtreexoSummaries, summary.BlockHash)
-
 			sm.utreexoSummaries[summary.BlockHash] = summary
 			log.Debugf("accepted utreexo summary for block %v. have %v summaries",
 				summary.BlockHash, len(sm.utreexoSummaries))
@@ -1375,6 +1358,7 @@ func (sm *SyncManager) handleUtreexoSummariesMsg(hmsg *utreexoSummariesMsg) {
 		sm.lastProgressTime = time.Now()
 
 		lastSummary := msg.Summaries[len(msg.Summaries)-1]
+		sm.bestSummariesHash = lastSummary.BlockHash
 		height, err := sm.chain.HeaderHeightByHash(lastSummary.BlockHash)
 		if err != nil {
 			log.Warnf("error while fetching the block height for hash %v -- %v",
@@ -1389,9 +1373,7 @@ func (sm *SyncManager) handleUtreexoSummariesMsg(hmsg *utreexoSummariesMsg) {
 				height, lastSummary.BlockHash)
 			sm.fetchHeaderBlocks(nil)
 			return
-		}
-
-		if len(peerState.requestedUtreexoSummaries) < minInFlightBlocks {
+		} else {
 			sm.fetchUtreexoSummaries(nil)
 		}
 
@@ -1399,17 +1381,10 @@ func (sm *SyncManager) handleUtreexoSummariesMsg(hmsg *utreexoSummariesMsg) {
 	}
 
 	for _, summary := range msg.Summaries {
-		_, found := peerState.requestedUtreexoSummaries[summary.BlockHash]
-		if !found {
-			log.Warnf("Got unrequested utreexo block summary from %s -- "+
-				"disconnecting", peer.Addr())
-			peer.Disconnect()
-			return
-		}
-		delete(peerState.requestedUtreexoSummaries, summary.BlockHash)
 		sm.utreexoSummaries[summary.BlockHash] = summary
 		log.Debugf("accepted utreexo summary for block %v. have %v headers",
 			summary.BlockHash, len(sm.utreexoSummaries))
+		sm.bestSummariesHash = summary.BlockHash
 	}
 
 	// We're not in headers-first mode. When we receive a utreexo summary,
@@ -2302,6 +2277,7 @@ func New(config *Config) (*SyncManager, error) {
 	if sm.chain.IsUtreexoViewActive() && sm.chain.IsAssumeUtreexo() {
 		log.Info("Assumed Utreexo is enabled. Downloading headers...")
 		sm.headersBuildMode = true
+		sm.bestSummariesHash = best.Hash
 	}
 
 	// The utreexo summary contains the number of added leaves in the block. This
@@ -2314,6 +2290,7 @@ func New(config *Config) (*SyncManager, error) {
 			return nil, err
 		}
 		sm.numLeaves[best.Height] = utreexoView.NumLeaves()
+		sm.bestSummariesHash = best.Hash
 	}
 
 	sm.chain.Subscribe(sm.handleBlockchainNotification)

--- a/server.go
+++ b/server.go
@@ -899,8 +899,7 @@ func (sp *serverPeer) OnGetUtreexoSummaries(_ *peer.Peer, msg *wire.MsgGetUtreex
 		return
 	}
 
-	// Check if we're a utreexo node. Ignore if we're not.
-	if sp.server.utreexoProofIndex == nil && sp.server.flatUtreexoProofIndex == nil && cfg.NoUtreexo {
+	if sp.server.utreexoProofIndex == nil && sp.server.flatUtreexoProofIndex == nil {
 		return
 	}
 
@@ -917,53 +916,47 @@ func (sp *serverPeer) OnGetUtreexoSummaries(_ *peer.Peer, msg *wire.MsgGetUtreex
 		return
 	}
 
-	// Fetch adds.
-	block, err := sp.server.chain.BlockByHash(&msg.StartHash)
+	heights, err := wire.GetUtreexoSummaryHeights(height, msg.MaxReceiveExponent)
 	if err != nil {
-		chanLog.Debugf("Unable to fetch block for block hash %v: %v",
-			msg.StartHash, err)
-		return
-	}
-	adds, err := blockchain.ExtractAccumulatorAdds(block, []uint32{})
-	if err != nil {
-		chanLog.Debugf("Unable to extract adds for block hash %v: %v",
+		chanLog.Debugf("Unable to fetch required heights for msg %v: %v",
 			msg.StartHash, err)
 		return
 	}
 
-	// Fetch targets.
-	var targets []uint64
-	if !cfg.NoUtreexo {
-		targets = block.MsgBlock().UData.AccProof.Targets
-	}
-	if sp.server.utreexoProofIndex != nil {
-		udata, err := sp.server.utreexoProofIndex.FetchUtreexoProof(&msg.StartHash)
+	bestState := sp.server.chain.BestSnapshot()
+	blockHashes := make([]*chainhash.Hash, 0, len(heights))
+	for _, height := range heights {
+		// We can only serve blocks to our best block.
+		if height > bestState.Height {
+			break
+		}
+		hash, err := sp.server.chain.BlockHashByHeight(height)
 		if err != nil {
-			chanLog.Debugf("Unable to fetch utreexo proof for block hash %v: %v",
+			chanLog.Debugf("Unable to fetch height for block hash %v: %v",
 				msg.StartHash, err)
 			return
 		}
-		targets = udata.AccProof.Targets
+		blockHashes = append(blockHashes, hash)
+	}
+
+	var usmsg *wire.MsgUtreexoSummaries
+	if sp.server.utreexoProofIndex != nil {
+		usmsg, err = sp.server.utreexoProofIndex.FetchUtreexoSummaries(blockHashes)
+		if err != nil {
+			chanLog.Debugf("Unable to fetch summaries for start hash %v and max receive exponent of %v: %v",
+				msg.StartHash, msg.MaxReceiveExponent, err)
+			return
+		}
 	}
 	if sp.server.flatUtreexoProofIndex != nil {
-		udata, err := sp.server.flatUtreexoProofIndex.FetchUtreexoProof(height)
+		usmsg, err = sp.server.flatUtreexoProofIndex.FetchUtreexoSummaries(blockHashes)
 		if err != nil {
-			chanLog.Debugf("Unable to fetch utreexo proof for block hash %v: %v",
-				msg.StartHash, err)
+			chanLog.Debugf("Unable to fetch summaries for start hash %v and max receive exponent of %v: %v",
+				msg.StartHash, msg.MaxReceiveExponent, err)
 			return
 		}
-		targets = udata.AccProof.Targets
 	}
 
-	// Construct the utreexo summaries.
-	summary := wire.UtreexoBlockSummary{
-		BlockHash:    msg.StartHash,
-		NumAdds:      uint16(len(adds)),
-		BlockTargets: make([]uint64, len(targets)),
-	}
-	copy(summary.BlockTargets, targets)
-	usmsg := wire.NewMsgUtreexoSummaries()
-	usmsg.AddSummary(&summary)
 	sp.QueueMessage(usmsg, nil)
 }
 


### PR DESCRIPTION
Since the getutreexosummaries allows us to fetch for multiple summaries at
a time, we change the code to take advantage of this as well as to handle it
if we're a node serving the utreexo summaries.