### PR TITLE
wire: change maxgetblocks to exponent

### DIFF
--- a/wire/msggetutreexosummaries_test.go
+++ b/wire/msggetutreexosummaries_test.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
@@ -9,39 +10,39 @@ import (
 
 func TestMsgGetUtreexoSummariesEncode(t *testing.T) {
 	testCases := []struct {
-		hash         chainhash.Hash
-		maxRecBlocks uint8
-		shouldErr    bool
+		hash        chainhash.Hash
+		maxExponent uint8
+		shouldErr   bool
 	}{
 		{
-			hash:         genesisHash,
-			maxRecBlocks: 1,
-			shouldErr:    false,
+			hash:        genesisHash,
+			maxExponent: 1,
+			shouldErr:   false,
 		},
 		{
-			hash:         genesisHash,
-			maxRecBlocks: 0,
-			shouldErr:    false,
+			hash:        genesisHash,
+			maxExponent: 0,
+			shouldErr:   false,
 		},
 		{
-			hash:         genesisHash,
-			maxRecBlocks: 100,
-			shouldErr:    false,
+			hash:        genesisHash,
+			maxExponent: 8,
+			shouldErr:   false,
 		},
 		{
-			hash:         genesisHash,
-			maxRecBlocks: 128,
-			shouldErr:    true,
+			hash:        genesisHash,
+			maxExponent: 9,
+			shouldErr:   true,
 		},
 		{
-			hash:         genesisHash,
-			maxRecBlocks: 255,
-			shouldErr:    true,
+			hash:        genesisHash,
+			maxExponent: 255,
+			shouldErr:   true,
 		},
 	}
 
 	for _, testCase := range testCases {
-		beforeMsg := NewMsgGetUtreexoSummaries(testCase.hash, testCase.maxRecBlocks)
+		beforeMsg := NewMsgGetUtreexoSummaries(testCase.hash, testCase.maxExponent)
 
 		// Encode.
 		var buf bytes.Buffer
@@ -71,9 +72,64 @@ func TestMsgGetUtreexoSummariesEncode(t *testing.T) {
 				testCase.hash, afterMsg.StartHash)
 		}
 
-		if afterMsg.MaxReceiveBlocks != testCase.maxRecBlocks {
+		if afterMsg.MaxReceiveExponent != testCase.maxExponent {
 			t.Fatalf("expected %v but got %v",
-				testCase.maxRecBlocks, afterMsg.MaxReceiveBlocks)
+				testCase.maxExponent, afterMsg.MaxReceiveExponent)
+		}
+	}
+}
+
+func TestGetUtreexoSummaryHeight(t *testing.T) {
+	testCases := []struct {
+		height          int32
+		exponent        uint8
+		expectedHeights []int32
+	}{
+		{
+			height:          0,
+			exponent:        1,
+			expectedHeights: []int32{0, 1},
+		},
+
+		{
+			height:          1,
+			exponent:        1,
+			expectedHeights: []int32{1},
+		},
+
+		{
+			height:          1,
+			exponent:        0,
+			expectedHeights: []int32{1},
+		},
+
+		{
+			height:          8,
+			exponent:        3,
+			expectedHeights: []int32{8, 9, 10, 11, 12, 13, 14, 15},
+		},
+
+		{
+			height:          8,
+			exponent:        3,
+			expectedHeights: []int32{8, 9, 10, 11, 12, 13, 14, 15},
+		},
+
+		{
+			height:          9,
+			exponent:        3,
+			expectedHeights: []int32{9, 10, 11, 12, 13, 14, 15},
+		},
+	}
+
+	for _, testCase := range testCases {
+		got, err := GetUtreexoSummaryHeights(testCase.height, testCase.exponent)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(testCase.expectedHeights, got) {
+			t.Fatalf("expected %v, got %v", testCase.expectedHeights, got)
 		}
 	}
 }

--- a/wire/msgutreexoblocksummaries.go
+++ b/wire/msgutreexoblocksummaries.go
@@ -13,9 +13,13 @@ import (
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
 )
 
+// MaxUtreexoExponent is the maximum exponent you can ask for in a bitcoin getutreexosummaries
+// message.
+const MaxUtreexoExponent = 8
+
 // MaxUtreexoBlockSummaryPerMsg is the maximum number of utreexo headers that can be in a single
 // bitcoin headers message.
-const MaxUtreexoBlockSummaryPerMsg = 100
+const MaxUtreexoBlockSummaryPerMsg = 1 << MaxUtreexoExponent
 
 // MsgUtreexoSummaries implements the Message interface and represents a bitcoin
 // utreexoblocksummaries message. It's has the block summaries which is used as a


### PR DESCRIPTION
We change the getutreexosummaries message to only allow for blocks in powers of 2 by changing the maxblocks to exponent.