### PR TITLE
indexers, btcjson, main: add rpcserver commands for blocksummarysstate

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -1072,6 +1072,18 @@ func (idx *FlatUtreexoProofIndex) fetchBlockSummary(blockHash *chainhash.Hash) (
 	}, nil
 }
 
+// FetchSummariesRoots returns the roots of the block summary state and the blockhash they were
+// at when the roots were fetched.
+func (idx *FlatUtreexoProofIndex) FetchSummariesRoots() (utreexo.Stump, chainhash.Hash) {
+	stump := utreexo.Stump{
+		Roots:     idx.blockSummaryState.GetRoots(),
+		NumLeaves: idx.blockSummaryState.GetNumLeaves(),
+	}
+	besthash := idx.chain.BestSnapshot().Hash
+
+	return stump, besthash
+}
+
 // FetchMsgUtreexoRoot returns a complete utreexoroot bitcoin message on the requested block.
 func (idx *FlatUtreexoProofIndex) FetchMsgUtreexoRoot(blockHash *chainhash.Hash) (*wire.MsgUtreexoRoot, error) {
 	height, err := idx.chain.BlockHeightByHash(blockHash)

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -857,6 +857,18 @@ func (idx *UtreexoProofIndex) fetchBlockSummary(blockHash, prevHash *chainhash.H
 	}, nil
 }
 
+// FetchSummariesRoots returns the roots of the block summary state and the blockhash they were
+// at when the roots were fetched.
+func (idx *UtreexoProofIndex) FetchSummariesRoots() (utreexo.Stump, chainhash.Hash) {
+	stump := utreexo.Stump{
+		Roots:     idx.blockSummaryState.GetRoots(),
+		NumLeaves: idx.blockSummaryState.GetNumLeaves(),
+	}
+	besthash := idx.chain.BestSnapshot().Hash
+
+	return stump, besthash
+}
+
 // FetchMsgUtreexoRoot returns a complete utreexoroot bitcoin message on the requested block.
 func (idx *UtreexoProofIndex) FetchMsgUtreexoRoot(blockHash *chainhash.Hash) (*wire.MsgUtreexoRoot, error) {
 	var stump utreexo.Stump

--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -824,6 +824,15 @@ func NewGetUtreexoRootsCmd(blockhash string) *GetUtreexoRootsCmd {
 	}
 }
 
+// GetUtreexoBlockSummaryRootsCmd defines the utreexoblocksummaryroots
+type GetUtreexoBlockSummaryRootsCmd struct{}
+
+// NewGetUtreexoBlockSummaryRootsCmd returns a new instance which can be used
+// to issue a getutreexoblocksummaryroots JSON-RPC command.
+func NewGetUtreexoBlockSummaryRootsCmd() *GetUtreexoBlockSummaryRootsCmd {
+	return &GetUtreexoBlockSummaryRootsCmd{}
+}
+
 // GetWorkCmd defines the getwork JSON-RPC command.
 type GetWorkCmd struct {
 	Data *string
@@ -1340,6 +1349,7 @@ func init() {
 	MustRegisterCmd("gettxoutsetinfo", (*GetTxOutSetInfoCmd)(nil), flags)
 	MustRegisterCmd("getutreexoproof", (*GetUtreexoProofCmd)(nil), flags)
 	MustRegisterCmd("getutreexoroots", (*GetUtreexoRootsCmd)(nil), flags)
+	MustRegisterCmd("getutreexoblocksummaryroots", (*GetUtreexoBlockSummaryRootsCmd)(nil), flags)
 	MustRegisterCmd("getwork", (*GetWorkCmd)(nil), flags)
 	MustRegisterCmd("getwatchonlybalance", (*GetWatchOnlyBalanceCmd)(nil), flags)
 	MustRegisterCmd("help", (*HelpCmd)(nil), flags)

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -941,6 +941,13 @@ type GetUtreexoRootsResult struct {
 	NumLeaves uint64   `json:"numleaves"`
 }
 
+// GetUtreexoBlockSummaryRootsResult models the data from the getutreexoblocksummaryroots command.
+type GetUtreexoBlockSummaryRootsResult struct {
+	Roots     []string `json:"roots"`
+	NumLeaves uint64   `json:"numleaves"`
+	BlockHash string   `json:"blockhash"`
+}
+
 // ProveWatchOnlyChainTipInclusionVerboseResult models the data from the
 // provewatchonlychaintipinclusion command when the verbose flag is set.  When the
 // verbose flag is not set, just the hex-encoded string of the entire proof

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -622,6 +622,14 @@ var helpDescsEnUS = map[string]string{
 	"getutreexorootsresult-numleaves": "The number of leaves committed in the accumulator at the given block",
 	"getutreexorootsresult-roots":     "The roots of the accumulator at the given block",
 
+	// GetUtreexoBlockSummaryRoots help.
+	"getutreexoblocksummaryroots--synopsis": "Returns the utreexo roots, number of leaves, and the blockhash of the utreexo block summary accumulator",
+
+	// GetUtreexoBlockSummaryRootsResult help.
+	"getutreexoblocksummaryrootsresult-roots":     "The roots of the block summary accumulator",
+	"getutreexoblocksummaryrootsresult-numleaves": "The number of leaves committed in the roots of the block summary accumulator",
+	"getutreexoblocksummaryrootsresult-blockhash": "The block hash for the roots and the numleaves",
+
 	// GetWatchOnlyBalanceCmd help.
 	"getwatchonlybalance--synopsis": "Returns the total balance of the watch only wallet",
 	"getwatchonlybalance--result0":  "The total balance of the watch only wallet in satoshis",
@@ -937,6 +945,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getmnemonicwords":                   {(*[]string)(nil)},
 	"getnettotals":                       {(*btcjson.GetNetTotalsResult)(nil)},
 	"gettxtotals":                        {(*btcjson.GetTxTotalsResult)(nil)},
+	"getutreexoblocksummaryroots":        {(*btcjson.GetUtreexoBlockSummaryRootsResult)(nil)},
 	"getutreexoproof":                    {(*btcjson.GetUtreexoProofVerboseResult)(nil)},
 	"getutreexoroots":                    {(*btcjson.GetUtreexoRootsResult)(nil)},
 	"getwatchonlybalance":                {(*int64)(nil)},


### PR DESCRIPTION
`getutreexosummaryroots` call is added so that we'll be able to easily update the
committed block summary roots in the binary.