### PR TITLE
chaincfg, wire, main, netsync: verify the proof in the blocksummary

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -961,6 +961,25 @@ func CustomSignetParams(challenge []byte, dnsSeeds []DNSSeed) Params {
 
 		AssumeUtreexoPoint: assumeUtreexoPoint,
 
+		BlockSummary: BlockSummaryState{
+			Stump: utreexo.Stump{
+				Roots: []utreexo.Hash{
+					newUtreexoHashFromStr("9f3cf6680295898e482aafa0c272e0cddbb02d6c85ffe8779af7a83a98f0bfcf"),
+					newUtreexoHashFromStr("5322929519c3e0f4019abcf7fde63a38c1fa453f6770ddddb8aa5023b3bd3e04"),
+					newUtreexoHashFromStr("a5bd7902c7e1d0a6f38feda71fabf253c048418ec6954fc315ce447dd398b7bb"),
+					newUtreexoHashFromStr("ca79fd34a91f64095d7425e15676c09f56066e53d863ea9142c23f352c058d17"),
+					newUtreexoHashFromStr("c319d0c400fc13b2b87cef8a69b6e998261b57c4dfd0decd12139ae8b07e8a21"),
+					newUtreexoHashFromStr("48a30aae6dbc363543bf57daa2f976595293aa95de91ab1954bdc722c39ab578"),
+					newUtreexoHashFromStr("c9c19f0d20db613e5b0892feee4235539aa9192e78a1bf9b4b29f98d96630bec"),
+					newUtreexoHashFromStr("6152bc4b7e1d6cf5bb6d77ee41e44bd16c2f3597d8b6768d159193cc4cbe6382"),
+					newUtreexoHashFromStr("e3a2ff83faf47bf917ff2dbcf095bd023ec67eeee7ad7e69770ffc47f9487063"),
+					newUtreexoHashFromStr("b91b638da8fca806ce88d5276f766cd2cb2c11e5764fffe34ddac459c70557ad"),
+				},
+				NumLeaves: 237_799,
+			},
+			BlockHash: newHashFromStr("0000005c1627c2b4f818f43a8e7b03fb580e562d7e44eb66b0e43293fcb7a073"),
+		},
+
 		// Consensus rule change deployments.
 		//
 		// The miner confirmation window is defined as:

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -97,6 +97,13 @@ type AssumeUtreexo struct {
 	MedianTime  time.Time       // Median time as per CalcPastMedianTime.
 }
 
+// BlockSummaryState is the pre-committed summary roots that allows nodes during ibd
+// to verifies the received summaries.
+type BlockSummaryState struct {
+	Stump     utreexo.Stump
+	BlockHash *chainhash.Hash
+}
+
 // DNSSeed identifies a DNS seed.
 type DNSSeed struct {
 	// Host defines the hostname of the seed.
@@ -253,6 +260,10 @@ type Params struct {
 	// AssumeUtreexoPoint is the utreexo roots that a utreexo node can
 	// start off of.
 	AssumeUtreexoPoint AssumeUtreexo
+
+	// BlockSummary is committed so that nodes during ibd are able to check
+	// the received block summaries from other peers.
+	BlockSummary BlockSummaryState
 
 	// These fields are related to voting on consensus rule changes as
 	// defined by BIP0009.

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -5,6 +5,8 @@
 package netsync
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"math/rand"
 	"net"
 	"os"
@@ -1349,6 +1351,42 @@ func (sm *SyncManager) handleUtreexoSummariesMsg(hmsg *utreexoSummariesMsg) {
 	if len(msg.Summaries) == 0 {
 		log.Warnf("Received empty utreexo summary message from peer %s "+
 			"-- disconnecting", peer)
+		peer.Disconnect()
+		return
+	}
+
+	// Put together a proof.
+	delHashes := make([]utreexo.Hash, 0, len(msg.Summaries))
+	targets := make([]uint64, 0, len(msg.Summaries))
+	for _, summary := range msg.Summaries {
+		height, _ := sm.chain.HeaderHeightByHash(summary.BlockHash)
+
+		// Skip trying to prove this if the our committed accumulator cannot be used.
+		if height >= int32(sm.chainParams.BlockSummary.Stump.NumLeaves) {
+			break
+		}
+		targets = append(targets, uint64(height))
+
+		buf := bytes.NewBuffer(make([]byte, 0, summary.SerializeSize()))
+		err := summary.Serialize(buf)
+		if err != nil {
+			log.Warnf("failed to serialize block summary from %s %v -- "+
+				"disconnecting", peer.Addr(), err)
+			peer.Disconnect()
+			return
+		}
+		delHashes = append(delHashes, sha256.Sum256(buf.Bytes()))
+	}
+	proof := utreexo.Proof{
+		Targets: targets,
+		Proof:   msg.ProofHashes,
+	}
+
+	// Verify the block summary.
+	_, err := utreexo.Verify(sm.chainParams.BlockSummary.Stump, delHashes, proof)
+	if err != nil {
+		log.Warnf("Got utreexo block summary from %s failed validation %v -- "+
+			"disconnecting", peer.Addr(), err)
 		peer.Disconnect()
 		return
 	}

--- a/server.go
+++ b/server.go
@@ -911,11 +911,12 @@ func (sp *serverPeer) OnGetUtreexoSummaries(_ *peer.Peer, msg *wire.MsgGetUtreex
 
 	// If we're pruned and the requested block is beyond the point where pruned blocks
 	// are able to serve blocks, just ignore the message.
-	if cfg.Prune != 0 && height >= sp.server.chain.BestSnapshot().Height-288 {
+	bestHeight := sp.server.chain.BestSnapshot().Height
+	if cfg.Prune != 0 && height >= bestHeight-288 {
 		return
 	}
 
-	heights, err := wire.GetUtreexoSummaryHeights(height, msg.MaxReceiveExponent)
+	heights, err := wire.GetUtreexoSummaryHeights(height, bestHeight, msg.MaxReceiveExponent)
 	if err != nil {
 		chanLog.Debugf("Unable to fetch required heights for msg %v: %v",
 			msg.StartHash, err)

--- a/wire/msggetutreexosummaries.go
+++ b/wire/msggetutreexosummaries.go
@@ -103,3 +103,23 @@ func GetUtreexoSummaryHeights(startBlock, bestHeight int32, exponent uint8) ([]i
 	return heights, nil
 }
 
+// GetUtreexoExponent returns the ideal value to request as much as possible while also not
+// going over the endHeight.
+func GetUtreexoExponent(startBlock, endHeight, bestHeight int32) uint8 {
+	numLeaves := uint64(bestHeight + 1)
+	subtree, _, _, _ := utreexo.DetectOffset(uint64(startBlock), numLeaves)
+
+	exponent := uint8(0)
+	for ; exponent < MaxUtreexoExponent; exponent++ {
+		height := uint64(startBlock + (1 << exponent))
+		if height > uint64(endHeight) {
+			break
+		}
+		gotSubTree, _, _, _ := utreexo.DetectOffset(height, numLeaves)
+		if subtree != gotSubTree {
+			break
+		}
+	}
+
+	return exponent
+}

--- a/wire/msggetutreexosummaries.go
+++ b/wire/msggetutreexosummaries.go
@@ -81,25 +81,25 @@ func NewMsgGetUtreexoSummaries(blockHash chainhash.Hash, maxReceiveExponent uint
 
 // GetUtreexoSummaryHeights returns the heights of the blocks that we can serve based on the startBlock
 // and the exponent. The returned heights are such that they always minimize the proof size.
-func GetUtreexoSummaryHeights(startBlock int32, exponent uint8) ([]int32, error) {
-	parentPos, err := utreexo.ParentMany(uint64(startBlock), exponent, AccumulatorRows)
-	if err != nil {
-		return nil, err
-	}
-	startPos, err := utreexo.ChildMany(parentPos, exponent, AccumulatorRows)
-	if err != nil {
-		return nil, err
-	}
+func GetUtreexoSummaryHeights(startBlock, bestHeight int32, exponent uint8) ([]int32, error) {
 	count := int32(1 << exponent)
+	numLeaves := uint64(bestHeight + 1)
 
+	endPos := startBlock + count
+	if endPos > bestHeight {
+		endPos = bestHeight
+	}
+
+	subtree, _, _, _ := utreexo.DetectOffset(uint64(startBlock), numLeaves)
 	heights := make([]int32, 0, count)
-	for i := int32(0); i < count; i++ {
-		height := i + int32(startPos)
-		if height < startBlock {
-			continue
+	for i := startBlock; i <= endPos; i++ {
+		got, _, _, _ := utreexo.DetectOffset(uint64(i), numLeaves)
+		if got != subtree {
+			break
 		}
-		heights = append(heights, i+int32(startPos))
+		heights = append(heights, i)
 	}
 
 	return heights, nil
 }
+

--- a/wire/msggetutreexosummaries_test.go
+++ b/wire/msggetutreexosummaries_test.go
@@ -82,48 +82,55 @@ func TestMsgGetUtreexoSummariesEncode(t *testing.T) {
 func TestGetUtreexoSummaryHeight(t *testing.T) {
 	testCases := []struct {
 		height          int32
+		bestHeight      int32
 		exponent        uint8
 		expectedHeights []int32
 	}{
 		{
 			height:          0,
+			bestHeight:      2,
 			exponent:        1,
 			expectedHeights: []int32{0, 1},
 		},
 
 		{
 			height:          1,
+			bestHeight:      1,
 			exponent:        1,
 			expectedHeights: []int32{1},
 		},
 
 		{
 			height:          1,
+			bestHeight:      1,
 			exponent:        0,
 			expectedHeights: []int32{1},
 		},
 
 		{
 			height:          8,
+			bestHeight:      20,
 			exponent:        3,
 			expectedHeights: []int32{8, 9, 10, 11, 12, 13, 14, 15},
 		},
 
 		{
 			height:          8,
+			bestHeight:      20,
 			exponent:        3,
 			expectedHeights: []int32{8, 9, 10, 11, 12, 13, 14, 15},
 		},
 
 		{
 			height:          9,
+			bestHeight:      20,
 			exponent:        3,
 			expectedHeights: []int32{9, 10, 11, 12, 13, 14, 15},
 		},
 	}
 
 	for _, testCase := range testCases {
-		got, err := GetUtreexoSummaryHeights(testCase.height, testCase.exponent)
+		got, err := GetUtreexoSummaryHeights(testCase.height, testCase.bestHeight, testCase.exponent)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
We now verify the proof in the blocksummary against the pre-committed
block summary accumulator. This prevents malicious peers to spam block summaries
during ibd.