### PR TITLE
wire, indexers, netsync, main: add includeproof bool to getblocksummaries

### DIFF
--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -989,13 +989,13 @@ func compareBlockSummaries(indexes []Indexer, blockHashes []*chainhash.Hash) err
 	for _, indexer := range indexes {
 		switch idxType := indexer.(type) {
 		case *FlatUtreexoProofIndex:
-			flatMsg, err = idxType.FetchUtreexoSummaries(blockHashes)
+			flatMsg, err = idxType.FetchUtreexoSummaries(blockHashes, true)
 			if err != nil {
 				return err
 			}
 
 		case *UtreexoProofIndex:
-			msg, err = idxType.FetchUtreexoSummaries(blockHashes)
+			msg, err = idxType.FetchUtreexoSummaries(blockHashes, true)
 			if err != nil {
 				return err
 			}
@@ -1052,7 +1052,7 @@ func compareBlockSummaryState(indexes []Indexer, blockHash *chainhash.Hash) erro
 				return err
 			}
 
-			flatSummaries, err = idxType.FetchUtreexoSummaries([]*chainhash.Hash{blockHash})
+			flatSummaries, err = idxType.FetchUtreexoSummaries([]*chainhash.Hash{blockHash}, true)
 			if err != nil {
 				return err
 			}
@@ -1072,7 +1072,7 @@ func compareBlockSummaryState(indexes []Indexer, blockHash *chainhash.Hash) erro
 				return err
 			}
 
-			summaries, err = idxType.FetchUtreexoSummaries([]*chainhash.Hash{blockHash})
+			summaries, err = idxType.FetchUtreexoSummaries([]*chainhash.Hash{blockHash}, true)
 			if err != nil {
 				return err
 			}

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -768,13 +768,17 @@ func (idx *UtreexoProofIndex) PruneBlock(_ database.Tx, _ *chainhash.Hash, lastK
 	return idx.Flush(&bestHash, blockchain.FlushRequired, true)
 }
 
-// FetchUtreexoSummaries fetches all the summaries and attaches a proof for those summaries.
-func (idx *UtreexoProofIndex) FetchUtreexoSummaries(blockHashes []*chainhash.Hash) (*wire.MsgUtreexoSummaries, error) {
+// FetchUtreexoSummaries fetches all the summaries and attaches a proof for those summaries if requsted with the includeProof boolean.
+func (idx *UtreexoProofIndex) FetchUtreexoSummaries(blockHashes []*chainhash.Hash, includeProof bool) (*wire.MsgUtreexoSummaries, error) {
 	msg := wire.MsgUtreexoSummaries{
 		Summaries: make([]*wire.UtreexoBlockSummary, 0, len(blockHashes)),
 	}
 
-	leafHashes := make([]utreexo.Hash, 0, len(blockHashes))
+	var leafHashes []utreexo.Hash
+	if includeProof {
+		leafHashes = make([]utreexo.Hash, 0, len(blockHashes))
+	}
+
 	for i := range blockHashes {
 		var prevHash *chainhash.Hash
 		if i == 0 {
@@ -797,21 +801,25 @@ func (idx *UtreexoProofIndex) FetchUtreexoSummaries(blockHashes []*chainhash.Has
 		}
 		msg.Summaries = append(msg.Summaries, summary)
 
-		buf := bytes.NewBuffer(make([]byte, 0, summary.SerializeSize()))
-		err = summary.Serialize(buf)
+		if includeProof {
+			buf := bytes.NewBuffer(make([]byte, 0, summary.SerializeSize()))
+			err = summary.Serialize(buf)
+			if err != nil {
+				return nil, err
+			}
+			hash := sha256.Sum256(buf.Bytes())
+			leafHashes = append(leafHashes, hash)
+		}
+	}
+
+	if includeProof {
+		proof, err := idx.blockSummaryState.Prove(leafHashes)
 		if err != nil {
 			return nil, err
 		}
-		hash := sha256.Sum256(buf.Bytes())
-		leafHashes = append(leafHashes, hash)
-	}
 
-	proof, err := idx.blockSummaryState.Prove(leafHashes)
-	if err != nil {
-		return nil, err
+		msg.ProofHashes = proof.Proof
 	}
-
-	msg.ProofHashes = proof.Proof
 
 	return &msg, nil
 }

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1054,7 +1054,7 @@ func (sm *SyncManager) fetchUtreexoSummaries(peer *peerpkg.Peer) {
 
 	log.Debugf("fetching blocksummaries from %v - %v", startHeight, startHeight+(1<<exponent))
 
-	ghmsg := wire.NewMsgGetUtreexoSummaries(*startHash, exponent)
+	ghmsg := wire.NewMsgGetUtreexoSummaries(*startHash, exponent, true)
 	reqPeer.QueueMessage(ghmsg, nil)
 }
 
@@ -1794,7 +1794,7 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 			if _, exists := sm.requestedBlocks[iv.Hash]; !exists {
 				amUtreexoNode := sm.chain.IsUtreexoViewActive()
 				if amUtreexoNode {
-					ghmsg := wire.NewMsgGetUtreexoSummaries(iv.Hash, 1)
+					ghmsg := wire.NewMsgGetUtreexoSummaries(iv.Hash, 1, false)
 					peer.QueueMessage(ghmsg, nil)
 					continue
 				}

--- a/server.go
+++ b/server.go
@@ -941,7 +941,7 @@ func (sp *serverPeer) OnGetUtreexoSummaries(_ *peer.Peer, msg *wire.MsgGetUtreex
 
 	var usmsg *wire.MsgUtreexoSummaries
 	if sp.server.utreexoProofIndex != nil {
-		usmsg, err = sp.server.utreexoProofIndex.FetchUtreexoSummaries(blockHashes)
+		usmsg, err = sp.server.utreexoProofIndex.FetchUtreexoSummaries(blockHashes, msg.IncludeProof)
 		if err != nil {
 			chanLog.Debugf("Unable to fetch summaries for start hash %v and max receive exponent of %v: %v",
 				msg.StartHash, msg.MaxReceiveExponent, err)
@@ -949,7 +949,7 @@ func (sp *serverPeer) OnGetUtreexoSummaries(_ *peer.Peer, msg *wire.MsgGetUtreex
 		}
 	}
 	if sp.server.flatUtreexoProofIndex != nil {
-		usmsg, err = sp.server.flatUtreexoProofIndex.FetchUtreexoSummaries(blockHashes)
+		usmsg, err = sp.server.flatUtreexoProofIndex.FetchUtreexoSummaries(blockHashes, msg.IncludeProof)
 		if err != nil {
 			chanLog.Debugf("Unable to fetch summaries for start hash %v and max receive exponent of %v: %v",
 				msg.StartHash, msg.MaxReceiveExponent, err)

--- a/wire/msggetutreexosummaries.go
+++ b/wire/msggetutreexosummaries.go
@@ -20,6 +20,7 @@ const AccumulatorRows = 63
 type MsgGetUtreexoSummaries struct {
 	StartHash          chainhash.Hash
 	MaxReceiveExponent uint8
+	IncludeProof       bool
 }
 
 // BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
@@ -32,6 +33,9 @@ func (msg *MsgGetUtreexoSummaries) BtcDecode(r io.Reader, pver uint32, enc Messa
 
 	msg.MaxReceiveExponent = msg.StartHash[31]
 	msg.StartHash[31] = 0
+
+	msg.IncludeProof = msg.StartHash[30] == 1
+	msg.StartHash[30] = 0
 
 	if msg.MaxReceiveExponent > MaxUtreexoExponent {
 		str := fmt.Sprintf("exponent too high in message [max %v, got %v]",
@@ -52,6 +56,9 @@ func (msg *MsgGetUtreexoSummaries) BtcEncode(w io.Writer, pver uint32, enc Messa
 	}
 
 	msg.StartHash[31] = msg.MaxReceiveExponent
+	if msg.IncludeProof {
+		msg.StartHash[30] = 1
+	}
 
 	_, err := w.Write(msg.StartHash[:])
 	if err != nil {
@@ -75,8 +82,8 @@ func (msg *MsgGetUtreexoSummaries) MaxPayloadLength(pver uint32) uint32 {
 
 // NewMsgGetUtreexoSummaries returns a new bitcoin getutreexosummaries message that conforms to
 // the Message interface.  See MsgGetUtreexoSummaries for details.
-func NewMsgGetUtreexoSummaries(blockHash chainhash.Hash, maxReceiveExponent uint8) *MsgGetUtreexoSummaries {
-	return &MsgGetUtreexoSummaries{StartHash: blockHash, MaxReceiveExponent: maxReceiveExponent}
+func NewMsgGetUtreexoSummaries(blockHash chainhash.Hash, maxReceiveExponent uint8, includeProof bool) *MsgGetUtreexoSummaries {
+	return &MsgGetUtreexoSummaries{StartHash: blockHash, MaxReceiveExponent: maxReceiveExponent, IncludeProof: includeProof}
 }
 
 // GetUtreexoSummaryHeights returns the heights of the blocks that we can serve based on the startBlock

--- a/wire/msggetutreexosummaries_test.go
+++ b/wire/msggetutreexosummaries_test.go
@@ -10,39 +10,63 @@ import (
 
 func TestMsgGetUtreexoSummariesEncode(t *testing.T) {
 	testCases := []struct {
-		hash        chainhash.Hash
-		maxExponent uint8
-		shouldErr   bool
+		hash         chainhash.Hash
+		maxExponent  uint8
+		includeProof bool
+		shouldErr    bool
 	}{
 		{
-			hash:        genesisHash,
-			maxExponent: 1,
-			shouldErr:   false,
+			hash:         genesisHash,
+			maxExponent:  1,
+			includeProof: true,
+			shouldErr:    false,
 		},
 		{
-			hash:        genesisHash,
-			maxExponent: 0,
-			shouldErr:   false,
+			hash:         genesisHash,
+			maxExponent:  1,
+			includeProof: false,
+			shouldErr:    false,
 		},
 		{
-			hash:        genesisHash,
-			maxExponent: 8,
-			shouldErr:   false,
+			hash:         genesisHash,
+			maxExponent:  0,
+			includeProof: false,
+			shouldErr:    false,
 		},
 		{
-			hash:        genesisHash,
-			maxExponent: 9,
-			shouldErr:   true,
+			hash:         genesisHash,
+			maxExponent:  0,
+			includeProof: true,
+			shouldErr:    false,
 		},
 		{
-			hash:        genesisHash,
-			maxExponent: 255,
-			shouldErr:   true,
+			hash:         genesisHash,
+			maxExponent:  8,
+			includeProof: true,
+			shouldErr:    false,
+		},
+		{
+			hash:         genesisHash,
+			maxExponent:  8,
+			includeProof: false,
+			shouldErr:    false,
+		},
+		{
+			hash:         genesisHash,
+			maxExponent:  9,
+			includeProof: true,
+			shouldErr:    true,
+		},
+		{
+			hash:         genesisHash,
+			maxExponent:  255,
+			includeProof: true,
+			shouldErr:    true,
 		},
 	}
 
 	for _, testCase := range testCases {
-		beforeMsg := NewMsgGetUtreexoSummaries(testCase.hash, testCase.maxExponent)
+		beforeMsg := NewMsgGetUtreexoSummaries(testCase.hash, testCase.maxExponent, testCase.includeProof)
 
 		// Encode.
 		var buf bytes.Buffer
@@ -75,6 +99,11 @@ func TestMsgGetUtreexoSummariesEncode(t *testing.T) {
 		if afterMsg.MaxReceiveExponent != testCase.maxExponent {
 			t.Fatalf("expected %v but got %v",
 				testCase.maxExponent, afterMsg.MaxReceiveExponent)
+		}
+
+		if afterMsg.IncludeProof != testCase.includeProof {
+			t.Fatalf("expected %v but got %v",
+				testCase.includeProof, afterMsg.IncludeProof)
 		}
 	}
 }


### PR DESCRIPTION
includeproof boolean is added to getutreexoblocksummaries and it allows for requesters
to receive the proof with the utreexoblocksummaries or not.