### PR TITLE
blockchain: fix bug in setting the bestHeader chainView

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -172,6 +172,11 @@ func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader, flags Beha
 	newNode := newBlockNode(header, prevNode)
 	b.index.AddNode(newNode)
 
+	err = b.index.flushToDB()
+	if err != nil {
+		return false, err
+	}
+
 	// Check if the header extends the best header tip.
 	isMainChain := false
 	parentHash := &header.PrevBlock

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1386,6 +1386,9 @@ func (b *BlockChain) initChainState() error {
 		}
 		log.Debug("Done loading block index")
 
+		// Set the lastNode in the blockindex as the bestheader.
+		b.bestHeader.SetTip(lastNode)
+
 		// Set the best chain view to the stored best state.
 		tip := b.index.LookupNode(&state.hash)
 		if tip == nil {
@@ -1393,7 +1396,6 @@ func (b *BlockChain) initChainState() error {
 				"chain tip %s in block index", state.hash))
 		}
 		b.bestChain.SetTip(tip)
-		b.bestHeader.SetTip(tip)
 
 		// Load the raw block bytes for the best block.
 		blockBytes, err := dbTx.FetchBlock(&state.hash)


### PR DESCRIPTION
The bestHeader chainview would not be set up correctly which led to a node that has not finished ibd-ing to download headers on each startup.

Flushing the index per header and initializing the bestheader correctly alleviates this bug.