### PR TITLE
Fix typos in code comments and string literals

### DIFF
--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -768,7 +768,7 @@ func (idx *UtreexoProofIndex) PruneBlock(_ database.Tx, _ *chainhash.Hash, lastK
 	return idx.Flush(&bestHash, blockchain.FlushRequired, true)
 }
 
-// FetchUtreexoSummaries fetches all the summaries and attaches a proof for those summaries if requsted with the includeProof boolean.
+// FetchUtreexoSummaries fetches all the summaries and attaches a proof for those summaries if requested with the includeProof boolean.
 func (idx *UtreexoProofIndex) FetchUtreexoSummaries(blockHashes []*chainhash.Hash, includeProof bool) (*wire.MsgUtreexoSummaries, error) {
 	msg := wire.MsgUtreexoSummaries{
 		Summaries: make([]*wire.UtreexoBlockSummary, 0, len(blockHashes)),

--- a/database/ffldb/driver.go
+++ b/database/ffldb/driver.go
@@ -78,7 +78,7 @@ func init() {
 		UseLogger: useLogger,
 	}
 	if err := database.RegisterDriver(driver); err != nil {
-		panic(fmt.Sprintf("Failed to regiser database driver '%s': %v",
+		panic(fmt.Sprintf("Failed to register database driver '%s': %v",
 			dbType, err))
 	}
 }

--- a/database/ffldb/interface_test.go
+++ b/database/ffldb/interface_test.go
@@ -641,7 +641,7 @@ func rollbackOnPanic(t *testing.T, tx database.Tx) {
 func testMetadataManualTxInterface(tc *testContext) bool {
 	// populateValues tests that populating values works as expected.
 	//
-	// When the writable flag is false, a read-only tranasction is created,
+	// When the writable flag is false, a read-only transaction is created,
 	// standard bucket tests for read-only transactions are performed, and
 	// the Commit function is checked to ensure it fails as expected.
 	//

--- a/database/ffldb/whitebox_test.go
+++ b/database/ffldb/whitebox_test.go
@@ -221,7 +221,7 @@ func TestCornerCases(t *testing.T) {
 	ldb := idb.(*db).cache.ldb
 	ldb.Close()
 
-	// Ensure initilization errors in the underlying database work as
+	// Ensure initialization errors in the underlying database work as
 	// expected.
 	testName = "initDB: reinitialization"
 	wantErrCode = database.ErrDbNotOpen


### PR DESCRIPTION
This pull request fixes several typos found in the codebase:

1. Fixed spelling of "initialization" in database/ffldb/whitebox_test.go
2. Standardized capitalization of "register" in database/ffldb/driver.go
3. Fixed capitalization of "transaction" in database/ffldb/interface_test.go
4. Standardized formatting in blockchain/indexers/utreexoproofindex.go

These changes are purely cosmetic and do not affect functionality.