### PR TITLE
blockchain, utreexobackends, main, indexers: update to utreexo lib v0.5.0

### DIFF
--- a/blockchain/chainio_test.go
+++ b/blockchain/chainio_test.go
@@ -842,7 +842,7 @@ func TestUtreexoViewSerialize(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = test.uView.accumulator.CachedLeaves.ForEach(func(k utreexo.Hash, v uint64) error {
+		err = test.uView.accumulator.CachedLeaves.ForEach(func(k utreexo.Hash, v utreexo.LeafInfo) error {
 			gotV, found := gotUtreexoView.accumulator.CachedLeaves.Get(k)
 			if !found {
 				return fmt.Errorf("expected %v for key of %d but it wasn't found",

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -66,7 +66,7 @@ type UtreexoConfig struct {
 // information.  It contains the entire, non-pruned accumulator.
 type UtreexoState struct {
 	config         *UtreexoConfig
-	state          utreexo.Utreexo
+	state          *utreexo.MapPollard
 	utreexoStateDB *pebble.DB
 
 	isFlushNeeded       func() bool

--- a/blockchain/internal/utreexobackends/cachedleavesmap.go
+++ b/blockchain/internal/utreexobackends/cachedleavesmap.go
@@ -9,13 +9,16 @@ import (
 )
 
 const (
+	// Output from unsafe.Sizeof(CachedPosition{})
+	cachedPositionSize = 24
+
 	// Bucket size for the cached leaves map.
-	cachedLeavesMapBucketSize = 16 + sizehelper.Uint64Size*chainhash.HashSize + sizehelper.Uint64Size*sizehelper.Uint64Size
+	cachedLeavesMapBucketSize = 16 + sizehelper.Uint64Size*chainhash.HashSize + sizehelper.Uint64Size*cachedPositionSize
 )
 
 // CachedPosition has the leaf and a flag for the status in the cache.
 type CachedPosition struct {
-	Position uint64
+	LeafInfo utreexo.LeafInfo
 	Flags    CachedFlag
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,9 +18,9 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0
 	github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/utreexo/utreexo v0.4.0
+	github.com/utreexo/utreexo v0.5.0
 	golang.org/x/crypto v0.7.0
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 )

--- a/go.sum
+++ b/go.sum
@@ -291,6 +291,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/utreexo/utreexo v0.2.1 h1:xycdaHK+HhDZO5MY6Clq7YeXEDguzar1GrAYqIJ1gvs=
@@ -307,6 +309,8 @@ github.com/utreexo/utreexo v0.3.3 h1:Gutt6YEUq0DiTJNbveIVuVNW6pp3aYgobwKviJfbRUs
 github.com/utreexo/utreexo v0.3.3/go.mod h1:xIu3cTtT0jNdntc1qJhVyQV/RX03Sk9gFD3UAzALvuU=
 github.com/utreexo/utreexo v0.4.0 h1:mZS8EVb11lPYNHYp9UfhCJVtOvu1B44NAD8OaCmJrvI=
 github.com/utreexo/utreexo v0.4.0/go.mod h1:xIu3cTtT0jNdntc1qJhVyQV/RX03Sk9gFD3UAzALvuU=
+github.com/utreexo/utreexo v0.5.0 h1:ity0iFkHZvTa4n1ZuIkCBjZS3AA6tIk0oomp7kTo028=
+github.com/utreexo/utreexo v0.5.0/go.mod h1:KmtWvRFEvgmpFXvamn24Kr0ecsmuSCqgVdYHKQvnnJ0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Utreexo library on v0.5.0 introduces `LeafInfo` on the CachedLeaves.
The `LeafInfo` stores the created height and the index, which allows
quick lookup of where the deleted leaf was originally created. This allows
for generating the TTL values for the block summaries on each of the deleted
leaves.