### PR TITLE
indexers: write ttls for flatutreexoproofindex

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -278,7 +278,7 @@ func (idx *FlatUtreexoProofIndex) Init(chain *blockchain.BlockChain,
 	idx.chain = chain
 
 	// Init Utreexo State.
-	uState, err := InitUtreexoState(idx.config, chain, tipHash, tipHeight)
+	uState, err := InitUtreexoState(idx.config, chain, &idx.ttlState, tipHash, tipHeight)
 	if err != nil {
 		return err
 	}

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -188,7 +188,7 @@ func (idx *UtreexoProofIndex) Init(chain *blockchain.BlockChain,
 	idx.chain = chain
 
 	// Init Utreexo State.
-	uState, err := InitUtreexoState(idx.config, chain, tipHash, tipHeight)
+	uState, err := InitUtreexoState(idx.config, chain, nil, tipHash, tipHeight)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The ttls for each block are required for blocksummaries. We now keep track of them
in the pollard state and write them to the flat files as the leaves are spent.