### PR TITLE
indexers: change ttls to uint16

### DIFF
--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -1234,7 +1234,7 @@ func TestTTLs(t *testing.T) {
 	// Number of blocks we'll generate for the test.
 	maxHeight := int32(300)
 
-	expectAfterUndoTTLs := make([][]uint32, 0, maxHeight)
+	expectAfterUndoTTLs := make([][]uint16, 0, maxHeight)
 	nextBlock := btcutil.NewBlock(params.GenesisBlock)
 	for i := int32(1); i <= maxHeight; i++ {
 		newBlock, newSpendableOuts, err := blockchain.AddBlock(chain, nextBlock, nextSpends)
@@ -1271,7 +1271,7 @@ func TestTTLs(t *testing.T) {
 		}
 	}
 
-	ttls := make([][]uint32, 0, maxHeight)
+	ttls := make([][]uint16, 0, maxHeight)
 	for _, indexer := range indexes {
 		switch idxType := indexer.(type) {
 		case *FlatUtreexoProofIndex:


### PR DESCRIPTION
If they go over the maxuint16 value, we simply don't mark their actual ttls. This is on the basis that most utxos have a low ttl and a cache value that includes the ones that go over the maxuint16 value just might as well cache everything.