### PR TITLE
wire, main, indexers, netsync: remove proofhashes from msgutreexoblocksummaries

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -1179,14 +1179,9 @@ func (idx *FlatUtreexoProofIndex) updateBlockSummaryState(numAdds uint16, blockH
 }
 
 // FetchUtreexoSummaries fetches all the summaries and attaches a proof for those summaries if requsted with the includeProof boolean.
-func (idx *FlatUtreexoProofIndex) FetchUtreexoSummaries(blockHashes []*chainhash.Hash, includeProof bool) (*wire.MsgUtreexoSummaries, error) {
+func (idx *FlatUtreexoProofIndex) FetchUtreexoSummaries(blockHashes []*chainhash.Hash) (*wire.MsgUtreexoSummaries, error) {
 	msg := wire.MsgUtreexoSummaries{
 		Summaries: make([]*wire.UtreexoBlockSummary, 0, len(blockHashes)),
-	}
-
-	var leafHashes []utreexo.Hash
-	if includeProof {
-		leafHashes = make([]utreexo.Hash, 0, len(blockHashes))
 	}
 
 	for _, blockHash := range blockHashes {
@@ -1195,24 +1190,6 @@ func (idx *FlatUtreexoProofIndex) FetchUtreexoSummaries(blockHashes []*chainhash
 			return nil, err
 		}
 		msg.Summaries = append(msg.Summaries, summary)
-
-		if includeProof {
-			buf := bytes.NewBuffer(make([]byte, 0, summary.SerializeSize()))
-			err = summary.Serialize(buf)
-			if err != nil {
-				return nil, err
-			}
-			leafHashes = append(leafHashes, sha256.Sum256(buf.Bytes()))
-		}
-	}
-
-	if includeProof {
-		proof, err := idx.blockSummaryState.Prove(leafHashes)
-		if err != nil {
-			return nil, err
-		}
-
-		msg.ProofHashes = proof.Proof
 	}
 
 	return &msg, nil

--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -990,13 +990,13 @@ func compareBlockSummaries(indexes []Indexer, blockHashes []*chainhash.Hash) err
 	for _, indexer := range indexes {
 		switch idxType := indexer.(type) {
 		case *FlatUtreexoProofIndex:
-			flatMsg, err = idxType.FetchUtreexoSummaries(blockHashes, true)
+			flatMsg, err = idxType.FetchUtreexoSummaries(blockHashes)
 			if err != nil {
 				return err
 			}
 
 		case *UtreexoProofIndex:
-			msg, err = idxType.FetchUtreexoSummaries(blockHashes, true)
+			msg, err = idxType.FetchUtreexoSummaries(blockHashes)
 			if err != nil {
 				return err
 			}
@@ -1008,10 +1008,6 @@ func compareBlockSummaries(indexes []Indexer, blockHashes []*chainhash.Hash) err
 		if err != nil {
 			return err
 		}
-	}
-
-	if !reflect.DeepEqual(flatMsg.ProofHashes, msg.ProofHashes) {
-		return fmt.Errorf("expected %v, got %v", flatMsg.ProofHashes, msg.ProofHashes)
 	}
 
 	return nil
@@ -1053,7 +1049,7 @@ func compareBlockSummaryState(indexes []Indexer, blockHash *chainhash.Hash) erro
 				return err
 			}
 
-			flatSummaries, err = idxType.FetchUtreexoSummaries([]*chainhash.Hash{blockHash}, true)
+			flatSummaries, err = idxType.FetchUtreexoSummaries([]*chainhash.Hash{blockHash})
 			if err != nil {
 				return err
 			}
@@ -1073,7 +1069,7 @@ func compareBlockSummaryState(indexes []Indexer, blockHash *chainhash.Hash) erro
 				return err
 			}
 
-			summaries, err = idxType.FetchUtreexoSummaries([]*chainhash.Hash{blockHash}, true)
+			summaries, err = idxType.FetchUtreexoSummaries([]*chainhash.Hash{blockHash})
 			if err != nil {
 				return err
 			}

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1056,7 +1056,7 @@ func (sm *SyncManager) fetchUtreexoSummaries(peer *peerpkg.Peer) {
 
 	log.Debugf("fetching blocksummaries from %v - %v", startHeight, startHeight+(1<<exponent))
 
-	ghmsg := wire.NewMsgGetUtreexoSummaries(*startHash, exponent, true)
+	ghmsg := wire.NewMsgGetUtreexoSummaries(*startHash, exponent)
 	reqPeer.QueueMessage(ghmsg, nil)
 }
 
@@ -1378,19 +1378,6 @@ func (sm *SyncManager) handleUtreexoSummariesMsg(hmsg *utreexoSummariesMsg) {
 			return
 		}
 		delHashes = append(delHashes, sha256.Sum256(buf.Bytes()))
-	}
-	proof := utreexo.Proof{
-		Targets: targets,
-		Proof:   msg.ProofHashes,
-	}
-
-	// Verify the block summary.
-	_, err := utreexo.Verify(sm.chainParams.BlockSummary.Stump, delHashes, proof)
-	if err != nil {
-		log.Warnf("Got utreexo block summary from %s failed validation %v -- "+
-			"disconnecting", peer.Addr(), err)
-		peer.Disconnect()
-		return
 	}
 
 	// If we're in headers first, check if we have the final utreexo block summary. If not,
@@ -1796,7 +1783,7 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 			if _, exists := sm.requestedBlocks[iv.Hash]; !exists {
 				amUtreexoNode := sm.chain.IsUtreexoViewActive()
 				if amUtreexoNode {
-					ghmsg := wire.NewMsgGetUtreexoSummaries(iv.Hash, 1, false)
+					ghmsg := wire.NewMsgGetUtreexoSummaries(iv.Hash, 1)
 					peer.QueueMessage(ghmsg, nil)
 					continue
 				}

--- a/server.go
+++ b/server.go
@@ -941,7 +941,7 @@ func (sp *serverPeer) OnGetUtreexoSummaries(_ *peer.Peer, msg *wire.MsgGetUtreex
 
 	var usmsg *wire.MsgUtreexoSummaries
 	if sp.server.utreexoProofIndex != nil {
-		usmsg, err = sp.server.utreexoProofIndex.FetchUtreexoSummaries(blockHashes, msg.IncludeProof)
+		usmsg, err = sp.server.utreexoProofIndex.FetchUtreexoSummaries(blockHashes)
 		if err != nil {
 			chanLog.Debugf("Unable to fetch summaries for start hash %v and max receive exponent of %v: %v",
 				msg.StartHash, msg.MaxReceiveExponent, err)
@@ -949,7 +949,7 @@ func (sp *serverPeer) OnGetUtreexoSummaries(_ *peer.Peer, msg *wire.MsgGetUtreex
 		}
 	}
 	if sp.server.flatUtreexoProofIndex != nil {
-		usmsg, err = sp.server.flatUtreexoProofIndex.FetchUtreexoSummaries(blockHashes, msg.IncludeProof)
+		usmsg, err = sp.server.flatUtreexoProofIndex.FetchUtreexoSummaries(blockHashes)
 		if err != nil {
 			chanLog.Debugf("Unable to fetch summaries for start hash %v and max receive exponent of %v: %v",
 				msg.StartHash, msg.MaxReceiveExponent, err)

--- a/wire/msggetutreexosummaries.go
+++ b/wire/msggetutreexosummaries.go
@@ -20,7 +20,6 @@ const AccumulatorRows = 63
 type MsgGetUtreexoSummaries struct {
 	StartHash          chainhash.Hash
 	MaxReceiveExponent uint8
-	IncludeProof       bool
 }
 
 // BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
@@ -33,9 +32,6 @@ func (msg *MsgGetUtreexoSummaries) BtcDecode(r io.Reader, pver uint32, enc Messa
 
 	msg.MaxReceiveExponent = msg.StartHash[31]
 	msg.StartHash[31] = 0
-
-	msg.IncludeProof = msg.StartHash[30] == 1
-	msg.StartHash[30] = 0
 
 	if msg.MaxReceiveExponent > MaxUtreexoExponent {
 		str := fmt.Sprintf("exponent too high in message [max %v, got %v]",
@@ -56,9 +52,6 @@ func (msg *MsgGetUtreexoSummaries) BtcEncode(w io.Writer, pver uint32, enc Messa
 	}
 
 	msg.StartHash[31] = msg.MaxReceiveExponent
-	if msg.IncludeProof {
-		msg.StartHash[30] = 1
-	}
 
 	_, err := w.Write(msg.StartHash[:])
 	if err != nil {
@@ -82,8 +75,8 @@ func (msg *MsgGetUtreexoSummaries) MaxPayloadLength(pver uint32) uint32 {
 
 // NewMsgGetUtreexoSummaries returns a new bitcoin getutreexosummaries message that conforms to
 // the Message interface.  See MsgGetUtreexoSummaries for details.
-func NewMsgGetUtreexoSummaries(blockHash chainhash.Hash, maxReceiveExponent uint8, includeProof bool) *MsgGetUtreexoSummaries {
-	return &MsgGetUtreexoSummaries{StartHash: blockHash, MaxReceiveExponent: maxReceiveExponent, IncludeProof: includeProof}
+func NewMsgGetUtreexoSummaries(blockHash chainhash.Hash, maxReceiveExponent uint8) *MsgGetUtreexoSummaries {
+	return &MsgGetUtreexoSummaries{StartHash: blockHash, MaxReceiveExponent: maxReceiveExponent}
 }
 
 // GetUtreexoSummaryHeights returns the heights of the blocks that we can serve based on the startBlock

--- a/wire/msggetutreexosummaries_test.go
+++ b/wire/msggetutreexosummaries_test.go
@@ -10,63 +10,54 @@ import (
 
 func TestMsgGetUtreexoSummariesEncode(t *testing.T) {
 	testCases := []struct {
-		hash         chainhash.Hash
-		maxExponent  uint8
-		includeProof bool
-		shouldErr    bool
+		hash        chainhash.Hash
+		maxExponent uint8
+		shouldErr   bool
 	}{
 		{
-			hash:         genesisHash,
-			maxExponent:  1,
-			includeProof: true,
-			shouldErr:    false,
+			hash:        genesisHash,
+			maxExponent: 1,
+			shouldErr:   false,
 		},
 		{
-			hash:         genesisHash,
-			maxExponent:  1,
-			includeProof: false,
-			shouldErr:    false,
+			hash:        genesisHash,
+			maxExponent: 1,
+			shouldErr:   false,
 		},
 		{
-			hash:         genesisHash,
-			maxExponent:  0,
-			includeProof: false,
-			shouldErr:    false,
+			hash:        genesisHash,
+			maxExponent: 0,
+			shouldErr:   false,
 		},
 		{
-			hash:         genesisHash,
-			maxExponent:  0,
-			includeProof: true,
-			shouldErr:    false,
+			hash:        genesisHash,
+			maxExponent: 0,
+			shouldErr:   false,
 		},
 		{
-			hash:         genesisHash,
-			maxExponent:  8,
-			includeProof: true,
-			shouldErr:    false,
+			hash:        genesisHash,
+			maxExponent: 8,
+			shouldErr:   false,
 		},
 		{
-			hash:         genesisHash,
-			maxExponent:  8,
-			includeProof: false,
-			shouldErr:    false,
+			hash:        genesisHash,
+			maxExponent: 8,
+			shouldErr:   false,
 		},
 		{
-			hash:         genesisHash,
-			maxExponent:  9,
-			includeProof: true,
-			shouldErr:    true,
+			hash:        genesisHash,
+			maxExponent: 9,
+			shouldErr:   true,
 		},
 		{
-			hash:         genesisHash,
-			maxExponent:  255,
-			includeProof: true,
-			shouldErr:    true,
+			hash:        genesisHash,
+			maxExponent: 255,
+			shouldErr:   true,
 		},
 	}
 
 	for _, testCase := range testCases {
-		beforeMsg := NewMsgGetUtreexoSummaries(testCase.hash, testCase.maxExponent, testCase.includeProof)
+		beforeMsg := NewMsgGetUtreexoSummaries(testCase.hash, testCase.maxExponent)
 
 		// Encode.
 		var buf bytes.Buffer
@@ -99,11 +90,6 @@ func TestMsgGetUtreexoSummariesEncode(t *testing.T) {
 		if afterMsg.MaxReceiveExponent != testCase.maxExponent {
 			t.Fatalf("expected %v but got %v",
 				testCase.maxExponent, afterMsg.MaxReceiveExponent)
-		}
-
-		if afterMsg.IncludeProof != testCase.includeProof {
-			t.Fatalf("expected %v but got %v",
-				testCase.includeProof, afterMsg.IncludeProof)
 		}
 	}
 }


### PR DESCRIPTION
The summaries will no longer be used for ibd optimizations so they don't need to be committed.