### PR TITLE
wire, blockchain, netsync: change numAdds to uint64

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -239,7 +239,7 @@ func (idx *FlatUtreexoProofIndex) initBlockSummaryState() error {
 		if err != nil {
 			return err
 		}
-		numAdds := uint16(stump.NumLeaves - prevNumLeaves)
+		numAdds := stump.NumLeaves - prevNumLeaves
 		prevNumLeaves = stump.NumLeaves
 
 		proof, err := idx.FetchUtreexoProof(h)
@@ -533,7 +533,7 @@ func (idx *FlatUtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.
 		return err
 	}
 
-	return idx.updateBlockSummaryState(uint16(len(adds)), block.Hash(), ud.AccProof)
+	return idx.updateBlockSummaryState(uint64(len(adds)), block.Hash(), ud.AccProof)
 }
 
 // calcProofOverhead calculates the overhead of the current utreexo accumulator proof
@@ -1160,7 +1160,7 @@ func (idx *FlatUtreexoProofIndex) updateRootsState() error {
 }
 
 // updateBlockSummaryState updates the block summary accumulator state with the given inputs.
-func (idx *FlatUtreexoProofIndex) updateBlockSummaryState(numAdds uint16, blockHash *chainhash.Hash, proof utreexo.Proof) error {
+func (idx *FlatUtreexoProofIndex) updateBlockSummaryState(numAdds uint64, blockHash *chainhash.Hash, proof utreexo.Proof) error {
 	summary := wire.UtreexoBlockSummary{
 		BlockHash:    *blockHash,
 		NumAdds:      numAdds,
@@ -1217,7 +1217,7 @@ func (idx *FlatUtreexoProofIndex) fetchBlockSummary(blockHash *chainhash.Hash) (
 			return nil, err
 		}
 	}
-	numAdds := uint16(stump.NumLeaves - prevStump.NumLeaves)
+	numAdds := stump.NumLeaves - prevStump.NumLeaves
 
 	return &wire.UtreexoBlockSummary{
 		BlockHash:    *blockHash,

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -148,7 +148,7 @@ func (idx *UtreexoProofIndex) initBlockSummaryState(bestHeight int32) error {
 			return err
 		})
 
-		numAdds := uint16(numLeaves - prevNumLeaves)
+		numAdds := numLeaves - prevNumLeaves
 		prevNumLeaves = numLeaves
 
 		proof, err := idx.FetchUtreexoProof(blockHash)
@@ -421,7 +421,7 @@ func (idx *UtreexoProofIndex) ConnectBlock(dbTx database.Tx, block *btcutil.Bloc
 		return err
 	}
 
-	err = idx.updateBlockSummaryState(uint16(len(adds)), block.Hash(), ud.AccProof)
+	err = idx.updateBlockSummaryState(uint64(len(adds)), block.Hash(), ud.AccProof)
 	if err != nil {
 		return err
 	}
@@ -721,7 +721,7 @@ func (idx *UtreexoProofIndex) updateRootsState() error {
 }
 
 // updateBlockSummaryState updates the block summary accumulator state with the given inputs.
-func (idx *UtreexoProofIndex) updateBlockSummaryState(numAdds uint16, blockHash *chainhash.Hash, proof utreexo.Proof) error {
+func (idx *UtreexoProofIndex) updateBlockSummaryState(numAdds uint64, blockHash *chainhash.Hash, proof utreexo.Proof) error {
 	summary := wire.UtreexoBlockSummary{
 		BlockHash:    *blockHash,
 		NumAdds:      numAdds,
@@ -832,7 +832,7 @@ func (idx *UtreexoProofIndex) fetchBlockSummary(blockHash, prevHash *chainhash.H
 		}
 	}
 
-	numAdds := uint16(stump.NumLeaves - prevStump.NumLeaves)
+	numAdds := stump.NumLeaves - prevStump.NumLeaves
 
 	return &wire.UtreexoBlockSummary{
 		BlockHash:    *blockHash,

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1118,7 +1118,7 @@ func (sm *SyncManager) fetchHeaderBlocks(peer *peerpkg.Peer) {
 				sm.fetchUtreexoSummaries(reqPeer)
 				return
 			}
-			numLeaves := sm.numLeaves[h-1] + uint64(summary.NumAdds)
+			numLeaves := sm.numLeaves[h-1] + summary.NumAdds
 			sm.numLeaves[h] = numLeaves
 		}
 


### PR DESCRIPTION
We change numAdds to uint64 and use varint serialization as you can have a block with more than math.MaxUint16 utxos.