### PR TITLE
wire: add msgttls

### DIFF
--- a/wire/message.go
+++ b/wire/message.go
@@ -43,6 +43,7 @@ const (
 	CmdGetUtreexoSummaries = "gusummaries"
 	CmdHeaders             = "headers"
 	CmdUtreexoSummaries    = "usummaries"
+	CmdUtreexoTTLs         = "uttls"
 	CmdPing                = "ping"
 	CmdPong                = "pong"
 	CmdAlert               = "alert"
@@ -158,6 +159,9 @@ func makeEmptyMessage(command string) (Message, error) {
 
 	case CmdUtreexoSummaries:
 		msg = &MsgUtreexoSummaries{}
+
+	case CmdUtreexoTTLs:
+		msg = &MsgUtreexoTTLs{}
 
 	case CmdUtreexoProof:
 		msg = &MsgUtreexoProof{}

--- a/wire/msgutreexottls.go
+++ b/wire/msgutreexottls.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2025 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/utreexo/utreexo"
+	"github.com/utreexo/utreexod/chaincfg/chainhash"
+)
+
+// MaxUtreexoTTLExponent is the maximum exponent you can ask for in a bitcoin getutreexosummaries
+// message.
+const MaxUtreexoTTLExponent = 10
+
+// MaxUtreexoTTLsPerMsg is the maximum amount of utreexo ttls there can be in a given MsgUtreexoTTLs.
+const MaxUtreexoTTLsPerMsg = 1 << MaxUtreexoTTLExponent
+
+// MaxUtreexoTTLsSize is the maximum size that the MsgUtreexoTTLs can be.
+const MaxUtreexoTTLsSize = (MaxUtreexoTTLsPerMsg * MaxUtreexoTTLSize) + (2 * MaxVarIntPayload) +
+	(chainhash.HashSize * math.MaxUint8)
+
+// MsgUtreexoTTLs implements the Message interface and represents a bitcoin
+// utreexottls message. It has the utreexo ttls which is used as a
+// response to a getutreexottls message. There can only be a maximum of a
+// 1024 utreexo ttls in one message.
+type MsgUtreexoTTLs struct {
+	// TTLs are the ttls per block.
+	TTLs []UtreexoTTL
+
+	// ProofHashes prove that the ttls in this message are committed in the binary.
+	ProofHashes []utreexo.Hash
+}
+
+// BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgUtreexoTTLs) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) error {
+	count, err := ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+
+	if count > MaxUtreexoTTLsPerMsg {
+		str := fmt.Sprintf("too many utreexo ttls for message "+
+			"[count %v, max %v]", count, MaxUtreexoTTLsPerMsg)
+		return messageError("MsgUtreexoTTLs.BtcDecode", str)
+	}
+
+	msg.TTLs = make([]UtreexoTTL, count)
+	for i := range msg.TTLs {
+		err = msg.TTLs[i].Deserialize(r)
+		if err != nil {
+			return err
+		}
+	}
+
+	count, err = ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+
+	msg.ProofHashes = make([]utreexo.Hash, count)
+	for i := range msg.ProofHashes {
+		_, err := io.ReadFull(r, msg.ProofHashes[i][:])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgUtreexoTTLs) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) error {
+	count := len(msg.TTLs)
+
+	if count > MaxUtreexoTTLsPerMsg {
+		str := fmt.Sprintf("too many utreexo ttls for message "+
+			"[count %v, max %v]", count, MaxUtreexoTTLsPerMsg)
+		return messageError("MsgUtreexoTTLs.BtcEncode", str)
+	}
+
+	err := WriteVarInt(w, 0, uint64(len(msg.TTLs)))
+	if err != nil {
+		return err
+	}
+
+	for _, ttl := range msg.TTLs {
+		err := ttl.Serialize(w)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = WriteVarInt(w, 0, uint64(len(msg.ProofHashes)))
+	if err != nil {
+		return err
+	}
+
+	for _, proofHash := range msg.ProofHashes {
+		_, err := w.Write(proofHash[:])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Command returns the protocol command string for the message.  This is part
+// of the Message interface implementation.
+func (msg *MsgUtreexoTTLs) Command() string {
+	return CmdUtreexoTTLs
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver. This is part of the Message interface implementation.
+func (msg *MsgUtreexoTTLs) MaxPayloadLength(_ uint32) uint32 {
+	return MaxUtreexoTTLsSize
+}

--- a/wire/msgutreexottls_test.go
+++ b/wire/msgutreexottls_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestUtreexoTTLsSerialize(t *testing.T) {
+	tests := []struct {
+		data UtreexoTTL
+	}{
+		{
+			data: UtreexoTTL{
+				BlockHeight: 1,
+				TTLs:        []uint16{0},
+			},
+		},
+		{
+			data: UtreexoTTL{
+				BlockHeight: 4785,
+				TTLs:        []uint16{0, 1, 4, 5, 0, 0, 1, 522, 1},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		var buf bytes.Buffer
+		err := test.data.Serialize(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		b := buf.Bytes()
+
+		// Check size.
+		expectedSize := len(b)
+		gotSize := test.data.SerializeSize()
+		if gotSize != expectedSize {
+			t.Fatalf("expected %v, got %v", expectedSize, gotSize)
+		}
+
+		// Check data.
+		r := bytes.NewBuffer(b)
+		got := UtreexoTTL{}
+		err = got.Deserialize(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, test.data) {
+			t.Fatalf("expected %v, got %v", test.data, got)
+		}
+	}
+}

--- a/wire/utreexottls.go
+++ b/wire/utreexottls.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import "io"
+
+// MaxUtreexoTTLSize is height 4 bytes, + varint len of ttls + uint16 size * max outputs per block.
+const MaxUtreexoTTLSize = 4 + MaxVarIntPayload + (99_984 * 2)
+
+// UtreexoTTL provides information about the time-to-live values of each added leaf to the
+// accumulator on a given block height. It's used for ibd optimization for utreexo nodes.
+type UtreexoTTL struct {
+	BlockHeight uint32
+	TTLs        []uint16
+}
+
+// SerializeSize returns how many bytes would be required to serialize the utreexo ttl.
+func (ut *UtreexoTTL) SerializeSize() int {
+	return 4 + VarIntSerializeSize(uint64(len(ut.TTLs))) + (2 * len(ut.TTLs))
+}
+
+// Deserialize constructs a utreexo ttl from the given reader.
+func (ut *UtreexoTTL) Deserialize(r io.Reader) error {
+	bs := newSerializer()
+	defer bs.free()
+
+	var err error
+	ut.BlockHeight, err = bs.Uint32(r, littleEndian)
+	if err != nil {
+		return err
+	}
+
+	count, err := ReadVarInt(r, 0)
+	if err != nil {
+		return err
+	}
+
+	ut.TTLs = make([]uint16, count)
+	for i := range ut.TTLs {
+		ut.TTLs[i], err = bs.Uint16(r, littleEndian)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Serialize serializes the utreexo ttl to the writer.
+func (ut *UtreexoTTL) Serialize(w io.Writer) error {
+	bs := newSerializer()
+	defer bs.free()
+
+	err := bs.PutUint32(w, littleEndian, ut.BlockHeight)
+	if err != nil {
+		return err
+	}
+
+	err = WriteVarInt(w, 0, uint64(len(ut.TTLs)))
+	if err != nil {
+		return err
+	}
+
+	for _, ttl := range ut.TTLs {
+		err = bs.PutUint16(w, littleEndian, ttl)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
The msgttls provide ttls for each of the blocks, allowing for caching optimizations by the nodes during ibd.