### PR TITLE
wire: add targets to msgutreexproof

### DIFF
--- a/wire/msggetutreexoproof.go
+++ b/wire/msggetutreexoproof.go
@@ -123,7 +123,9 @@ func (msg *MsgGetUtreexoProof) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgGetUtreexoProof) MaxPayloadLength(pver uint32) uint32 {
-	return MaxBlockPayload
+	// hashsize + target bool + proofBitMap len + math.MaxUint8 in bitmaps +
+	// leafindex bitmap len + MaxPossibleInputsPerBlock in bitmaps.
+	return chainhash.HashSize + 1 + MaxVarIntPayload + 32 + MaxVarIntPayload + 3049
 }
 
 // IsLeafDataRequested returns if the leafdata at the given index is requested or not.

--- a/wire/msgutreexoproof.go
+++ b/wire/msgutreexoproof.go
@@ -6,10 +6,21 @@ package wire
 
 import (
 	"io"
+	"math"
 
 	"github.com/utreexo/utreexo"
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
 )
+
+// MaxUtreexoProofSize is blockhash + len proofhashes + proofhashes + len targets + targets + len leafdatas +  pkscript size + Leafdata overhead of 12 bytes.
+const MaxUtreexoProofSize = chainhash.HashSize +
+	MaxVarIntPayload +
+	math.MaxUint8*chainhash.HashSize +
+	MaxVarIntPayload +
+	MaxVarIntPayload*MaxPossibleInputsPerBlock +
+	MaxVarIntPayload +
+	MaxBlockPayload +
+	MaxPossibleInputsPerBlock*12
 
 // MsgUtreexoProof is a utreexo proof for a given block that includes the rest of the data not
 // communicated by the utreexo header. It may or may not include all the data needed to prove
@@ -140,5 +151,5 @@ func (msg *MsgUtreexoProof) Command() string {
 // MaxPayloadLength returns the maximum length the payload can be for the
 // receiver.  This is part of the Message interface implementation.
 func (msg *MsgUtreexoProof) MaxPayloadLength(pver uint32) uint32 {
-	return MaxBlockPayload
+	return MaxUtreexoProofSize
 }

--- a/wire/msgutreexoproof_test.go
+++ b/wire/msgutreexoproof_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/utreexo/utreexo"
+	"github.com/utreexo/utreexod/chaincfg/chainhash"
+)
+
+func TestUtreexoProofSerialize(t *testing.T) {
+	tests := []struct {
+		data MsgUtreexoProof
+	}{
+		{
+			data: MsgUtreexoProof{
+				BlockHash: chainhash.HashH([]byte{1}),
+				ProofHashes: []utreexo.Hash{
+					{0xff, 0x0, 0x4},
+					{0xff, 0x1, 0xd, 0xdf},
+				},
+				Targets: []uint64{1254548, 481754},
+				LeafDatas: []LeafData{
+					{
+						Height:     784611,
+						IsCoinBase: true,
+						Amount:     631465945,
+						PkScript:   []byte{},
+					},
+					{
+						Height:     784631,
+						IsCoinBase: false,
+						Amount:     637465960,
+						PkScript:   []byte{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		var buf bytes.Buffer
+		err := test.data.BtcEncode(&buf, 0, LatestEncoding)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		b := buf.Bytes()
+
+		// Check data.
+		r := bytes.NewBuffer(b)
+		got := MsgUtreexoProof{}
+		err = got.BtcDecode(r, 0, LatestEncoding)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		require.Equal(t, test.data, got)
+	}
+}


### PR DESCRIPTION
The targets allow the nodes to request for full proof information when
asking for the utreexo proof.