### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -497,10 +497,7 @@ func (b *BlockChain) calcSequenceLock(node *blockNode, tx *btcutil.Tx, utxoView 
 			// which this input was included within so we can
 			// compute the past median time for the block prior to
 			// the one which included this referenced output.
-			prevInputHeight := inputHeight - 1
-			if prevInputHeight < 0 {
-				prevInputHeight = 0
-			}
+			prevInputHeight := max(inputHeight-1, 0)
 			blockNode := node.Ancestor(prevInputHeight)
 			medianTime := blockNode.CalcPastMedianTime()
 

--- a/blockchain/chainview.go
+++ b/blockchain/chainview.go
@@ -388,10 +388,7 @@ func (c *chainView) blockLocator(node *blockNode) BlockLocator {
 
 		// Calculate height of previous node to include ensuring the
 		// final node is the genesis block.
-		height := node.height - step
-		if height < 0 {
-			height = 0
-		}
+		height := max(node.height-step, 0)
 
 		// When the node is in the current chain view, all of its
 		// ancestors must be too, so use a much faster O(1) lookup in

--- a/blockchain/fullblocks_test.go
+++ b/blockchain/fullblocks_test.go
@@ -282,10 +282,7 @@ func TestFullBlocks(t *testing.T) {
 	// provided test instance and ensures that it failed to decode with a
 	// message error.
 	testRejectedNonCanonicalBlock := func(item fullblocktests.RejectedNonCanonicalBlock) {
-		headerLen := len(item.RawBlock)
-		if headerLen > 80 {
-			headerLen = 80
-		}
+		headerLen := min(len(item.RawBlock), 80)
 		blockHash := chainhash.DoubleHashH(item.RawBlock[0:headerLen])
 		blockHeight := item.Height
 		t.Logf("Testing block %s (hash %s, height %d)", item.Name,

--- a/blockchain/indexers/addrindex.go
+++ b/blockchain/indexers/addrindex.go
@@ -304,10 +304,7 @@ func dbFetchAddrIndexEntries(bucket internalBucket, addrKey [addrKeySize]byte,
 
 	// Limit the number to load based on the number of available entries,
 	// the number to skip, and the number requested.
-	numToLoad := numEntries - numToSkip
-	if numToLoad > numRequested {
-		numToLoad = numRequested
-	}
+	numToLoad := min(numEntries-numToSkip, numRequested)
 
 	// Start the offset after all skipped entries and load the calculated
 	// number.

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -318,12 +318,8 @@ func (idx *FlatUtreexoProofIndex) Init(chain *blockchain.BlockChain,
 	// Make undo blocks for blocks up to 288 block from the tip. 288 since
 	// that's the basis used for NODE_NETWORK_LIMITED. Reorgs that go past
 	// that are gonna be problematic anyways.
-	undoCount := int32(288)
-
 	// The bestHeight is less than 288, then just undo all the blocks we have.
-	if undoCount > bestHeight {
-		undoCount = bestHeight
-	}
+	undoCount := min(int32(288), bestHeight)
 
 	// Disconnect blocks.
 	for i := int32(0); i < undoCount; i++ {

--- a/blockchain/indexers/utreexoproofindex.go
+++ b/blockchain/indexers/utreexoproofindex.go
@@ -247,12 +247,8 @@ func (idx *UtreexoProofIndex) Init(chain *blockchain.BlockChain,
 	// Make undo blocks for blocks up to 288 block from the tip. 288 since
 	// that's the basis used for NODE_NETWORK_LIMITED. Reorgs that go past
 	// that are gonna be problematic anyways.
-	undoCount := int32(288)
-
 	// The bestHeight is less than 288, then just undo all the blocks we have.
-	if undoCount > bestHeight {
-		undoCount = bestHeight
-	}
+	undoCount := min(int32(288), bestHeight)
 
 	for i := int32(0); i < undoCount; i++ {
 		height := bestHeight - i


### PR DESCRIPTION

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.