### PR TITLE
indexers, wire: separate out targets, proof, and leafdata in flatutreexoproofindex

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -832,6 +832,28 @@ func (idx *FlatUtreexoProofIndex) FetchUtreexoProof(height int32) (
 	return ud, nil
 }
 
+// fetchTargets fetches the targets at the given height.
+func (idx *FlatUtreexoProofIndex) fetchTargets(height int32) ([]uint64, error) {
+	if height == 0 {
+		return []uint64{}, nil
+	}
+
+	if idx.config.Pruned {
+		return nil, fmt.Errorf("Cannot fetch targets as the node is pruned")
+	}
+
+	targetBytes, err := idx.targetState.FetchData(height)
+	if err != nil {
+		return nil, err
+	}
+	if targetBytes == nil {
+		return nil, fmt.Errorf("Couldn't fetch targets for height %d", height)
+	}
+	r := bytes.NewReader(targetBytes)
+
+	return wire.ProofTargetsDeserialize(r)
+}
+
 // GetLeafHashPositions returns the positions of the passed in hashes.
 func (idx *FlatUtreexoProofIndex) GetLeafHashPositions(delHashes []utreexo.Hash) []uint64 {
 	idx.mtx.RLock()

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -394,6 +394,12 @@ func (idx *FlatUtreexoProofIndex) Init(chain *blockchain.BlockChain,
 		}
 		ud.AccProof.Targets = targets
 
+		lds, err := idx.fetchLeafDatas(height)
+		if err != nil {
+			return err
+		}
+		ud.LeafDatas = lds
+
 		// Fetch block.
 		block, err := idx.chain.BlockByHeight(height)
 		if err != nil {
@@ -889,6 +895,21 @@ func (idx *FlatUtreexoProofIndex) fetchTargets(height int32) ([]uint64, error) {
 	r := bytes.NewReader(targetBytes)
 
 	return wire.ProofTargetsDeserialize(r)
+}
+
+// fetchLeafDatas fetches the leafdatas at the given height. Returns an error if it couldn't
+// fetch it.
+func (idx *FlatUtreexoProofIndex) fetchLeafDatas(height int32) ([]wire.LeafData, error) {
+	leafDataBytes, err := idx.leafDataState.FetchData(height)
+	if err != nil {
+		return nil, err
+	}
+	if leafDataBytes == nil {
+		return nil, fmt.Errorf("Couldn't fetch leafDatas for height %d", height)
+	}
+	r := bytes.NewReader(leafDataBytes)
+
+	return wire.DeserializeUtxoData(r)
 }
 
 // GetLeafHashPositions returns the positions of the passed in hashes.

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -782,6 +782,11 @@ func (idx *FlatUtreexoProofIndex) DisconnectBlock(dbTx database.Tx, block *btcut
 			return err
 		}
 
+		err = idx.leafDataState.DisconnectBlock(block.Height())
+		if err != nil {
+			return err
+		}
+
 		// Re-initializes to the current accumulator roots, effectively
 		// disconnecting a block.
 		err = idx.initBlockTTLState()
@@ -1051,6 +1056,17 @@ func (idx *FlatUtreexoProofIndex) storeProof(height int32, ud *wire.UData) error
 	}
 
 	err = idx.targetState.StoreData(height, targetsBuf.Bytes())
+	if err != nil {
+		return fmt.Errorf("store targets err. %v", err)
+	}
+
+	leafBuf := bytes.NewBuffer(make([]byte, 0, ud.SerializeUtxoDataSize()))
+	err = wire.SerializeUtxoData(leafBuf, ud.LeafDatas)
+	if err != nil {
+		return err
+	}
+
+	err = idx.leafDataState.StoreData(height, leafBuf.Bytes())
 	if err != nil {
 		return fmt.Errorf("store targets err. %v", err)
 	}

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -320,11 +320,6 @@ func (idx *FlatUtreexoProofIndex) Init(chain *blockchain.BlockChain,
 		// doesn't exist.
 		return nil
 	}
-	proofState, err := loadFlatFileState(idx.config.DataDir, flatUtreexoProofName)
-	if err != nil {
-		return err
-	}
-	idx.proofState = *proofState
 
 	// Nothing to do if the best height is 0.
 	bestHeight := chain.BestSnapshot().Height


### PR DESCRIPTION
At the moment we clump all three (targets, proof hashes, and leafdata) into
a single udata chunk. This forces us to fetch all of them when serving the
utreexo proof to a peer.

Since the peer is able to ask for a subset of any of the three so we modify the
flatutreexoproofindex so that they're able to be independently fetched.