### PR TITLE
wire, indexers: change ttls back to uint64

### DIFF
--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -1230,7 +1230,7 @@ func TestTTLs(t *testing.T) {
 	// Number of blocks we'll generate for the test.
 	maxHeight := int32(300)
 
-	expectAfterUndoTTLs := make([][]uint16, 0, maxHeight)
+	expectAfterUndoTTLs := make([][]uint64, 0, maxHeight)
 	nextBlock := btcutil.NewBlock(params.GenesisBlock)
 	for i := int32(1); i <= maxHeight; i++ {
 		newBlock, newSpendableOuts, err := blockchain.AddBlock(chain, nextBlock, nextSpends)
@@ -1267,7 +1267,7 @@ func TestTTLs(t *testing.T) {
 		}
 	}
 
-	ttls := make([][]uint16, 0, maxHeight)
+	ttls := make([][]uint64, 0, maxHeight)
 	for _, indexer := range indexes {
 		switch idxType := indexer.(type) {
 		case *FlatUtreexoProofIndex:

--- a/wire/msgutreexottls_test.go
+++ b/wire/msgutreexottls_test.go
@@ -17,13 +17,13 @@ func TestUtreexoTTLsSerialize(t *testing.T) {
 		{
 			data: UtreexoTTL{
 				BlockHeight: 1,
-				TTLs:        []uint16{0},
+				TTLs:        []uint64{0},
 			},
 		},
 		{
 			data: UtreexoTTL{
 				BlockHeight: 4785,
-				TTLs:        []uint16{0, 1, 4, 5, 0, 0, 1, 522, 1},
+				TTLs:        []uint64{0, 1, 4, 5, 0, 0, 1, 522, 1},
 			},
 		},
 	}


### PR DESCRIPTION
We make this change as the protocol won't serve targets in the ttl messages as the ttls imply the targets in the future.