### PR TITLE
indexers, wire: add deathpos to the ttl message

### DIFF
--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -1220,7 +1220,7 @@ func TestUtreexoRootsAndSummaryState(t *testing.T) {
 }
 
 // checkTTLsAfterUndo undoes 20 blocks and checks that the ttls match up against the expected values.
-func checkTTLsAfterUndo(t *testing.T, expected [][]uint64, indexes []Indexer, chain *blockchain.BlockChain) {
+func checkTTLsAfterUndo(t *testing.T, expected [][]wire.TTLInfo, indexes []Indexer, chain *blockchain.BlockChain) {
 	hashes := make([]chainhash.Hash, 0, len(expected))
 
 	bestSnapshot := chain.BestSnapshot()
@@ -1304,7 +1304,7 @@ func TestTTLs(t *testing.T) {
 	maxHeight := int32(420)
 
 	expectedStumps := make([]utreexo.Stump, 0, maxHeight)
-	expectAfterUndoTTLs := make([][]uint64, 0, maxHeight)
+	expectAfterUndoTTLs := make([][]wire.TTLInfo, 0, maxHeight)
 
 	nextBlock := btcutil.NewBlock(params.GenesisBlock)
 	for i := int32(1); i <= maxHeight; i++ {

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -513,7 +513,7 @@ func (us *UtreexoState) initConsistentUtreexoState(chain *blockchain.BlockChain,
 				return err
 			}
 
-			err = writeTTLs(block.Height(), createIndexes, ud.LeafDatas, ttlIdx)
+			err = writeTTLs(block.Height(), createIndexes, ud.AccProof.Targets, ud.LeafDatas, ttlIdx)
 			if err != nil {
 				return err
 			}

--- a/wire/msgutreexottls_test.go
+++ b/wire/msgutreexottls_test.go
@@ -17,13 +17,24 @@ func TestUtreexoTTLsSerialize(t *testing.T) {
 		{
 			data: UtreexoTTL{
 				BlockHeight: 1,
-				TTLs:        []uint64{0},
+				TTLs: []TTLInfo{
+					{0, 8},
+				},
 			},
 		},
 		{
 			data: UtreexoTTL{
 				BlockHeight: 4785,
-				TTLs:        []uint64{0, 1, 4, 5, 0, 0, 1, 522, 1},
+				TTLs: []TTLInfo{
+					{0, 8},
+					{1, 56},
+					{4, 141},
+					{5, 0},
+					{0, 0},
+					{1, 1841},
+					{522, 878418},
+					{1, 876},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
In the flatutreexoproofindex, we save the deathpos with the ttl value. When the ttl message
is requested, the death pos of the leaf is now included.