### PR TITLE
readproofstats, indexers: add readproofstats cmd

### DIFF
--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -131,7 +131,7 @@ type FlatUtreexoProofIndex struct {
 	blockTTLState []utreexo.Pollard
 
 	// pStats are the proof size statistics that are kept for research purposes.
-	pStats proofStats
+	pStats ProofStats
 
 	// The time of when the utreexo state was last flushed.
 	lastFlushTime time.Time

--- a/blockchain/indexers/utreexoproofstats.go
+++ b/blockchain/indexers/utreexoproofstats.go
@@ -13,11 +13,11 @@ import (
 	"github.com/utreexo/utreexod/wire"
 )
 
-// proofStatsSize has 10 elements that are each 8 bytes big.
-const proofStatsSize int = 8 * 10
+// ProofStatsSize has 10 elements that are each 8 bytes big.
+const ProofStatsSize int = 8 * 10
 
-// proofStats are the relevant proof statistics to check how big each proofs are.
-type proofStats struct {
+// ProofStats are the relevant proof statistics to check how big each proofs are.
+type ProofStats struct {
 	// The height of the chain for the below stats.
 	BlockHeight uint64
 
@@ -42,12 +42,12 @@ type proofStats struct {
 }
 
 // UpdateTotalDelCount updates the deletion count in the proof stats.
-func (ps *proofStats) UpdateTotalDelCount(delCount uint64) {
+func (ps *ProofStats) UpdateTotalDelCount(delCount uint64) {
 	ps.TotalDels += delCount
 }
 
 // UpdateUDStats updates the all the udata statistics.
-func (ps *proofStats) UpdateUDStats(excludeAccProof bool, ud *wire.UData) {
+func (ps *ProofStats) UpdateUDStats(excludeAccProof bool, ud *wire.UData) {
 	// Update target size.
 	ps.TgSize += uint64(wire.BatchProofSerializeTargetSize(&ud.AccProof))
 	ps.TgCount += uint64(len(ud.AccProof.Targets))
@@ -69,7 +69,7 @@ func (ps *proofStats) UpdateUDStats(excludeAccProof bool, ud *wire.UData) {
 }
 
 // LogProofStats outputs a log of the proof statistics.
-func (ps *proofStats) LogProofStats() {
+func (ps *ProofStats) LogProofStats() {
 	log.Infof("height %d: totalDels %d, ldSize %d, ldCount %d, tgSize %d, tgCount %d, proofSize %d, proofCount %d",
 		ps.BlockHeight, ps.TotalDels, ps.LdSize, ps.LdCount, ps.TgSize, ps.TgCount,
 		ps.ProofSize, ps.ProofCount)
@@ -80,7 +80,7 @@ func (ps *proofStats) LogProofStats() {
 }
 
 // Serialize serializes the proof statistics into the writer.
-func (ps *proofStats) Serialize(w io.Writer) error {
+func (ps *ProofStats) Serialize(w io.Writer) error {
 	// 19 * 8
 	var buf [8]byte
 
@@ -148,7 +148,7 @@ func (ps *proofStats) Serialize(w io.Writer) error {
 }
 
 // Deserialize deserializes the proof statistics from the reader.
-func (ps *proofStats) Deserialize(r io.Reader) error {
+func (ps *ProofStats) Deserialize(r io.Reader) error {
 	var buf [8]byte
 	var res uint64
 
@@ -218,8 +218,8 @@ func (ps *proofStats) Deserialize(r io.Reader) error {
 
 // WritePStats writes the proof statistics into the passed in flatfile.  It always
 // writes the stats in the beginning of the file.
-func (ps *proofStats) WritePStats(pStatFF *FlatFileState) error {
-	w := bytes.NewBuffer(make([]byte, 0, proofStatsSize))
+func (ps *ProofStats) WritePStats(pStatFF *FlatFileState) error {
+	w := bytes.NewBuffer(make([]byte, 0, ProofStatsSize))
 
 	err := ps.Serialize(w)
 	if err != nil {
@@ -237,10 +237,10 @@ func (ps *proofStats) WritePStats(pStatFF *FlatFileState) error {
 // InitPStats reads the proof statistics from the passed in flatfile and attempts to
 // initializes the proof statistics.  If the size read is smaller than the proofStatsSize,
 // then nothing is initialized and the function returns.
-func (ps *proofStats) InitPStats(pStatFF *FlatFileState) error {
-	buf := make([]byte, proofStatsSize)
+func (ps *ProofStats) InitPStats(pStatFF *FlatFileState) error {
+	buf := make([]byte, ProofStatsSize)
 	n, err := pStatFF.dataFile.ReadAt(buf, 0)
-	if n < proofStatsSize {
+	if n < ProofStatsSize {
 		return nil
 	}
 	if err != nil {

--- a/blockchain/indexers/utreexoproofstats_test.go
+++ b/blockchain/indexers/utreexoproofstats_test.go
@@ -29,19 +29,19 @@ func TestProofStatSerialize(t *testing.T) {
 	seed := rand.NewSource(time)
 	rand := rand.New(seed)
 
-	proofStatsVal, ok := quick.Value(reflect.TypeOf(proofStats{}), rand)
+	proofStatsVal, ok := quick.Value(reflect.TypeOf(ProofStats{}), rand)
 	if !ok {
 		t.Fatalf("Couldn't create random proofStats")
 	}
 
-	pStats := proofStatsVal.Interface().(proofStats)
+	pStats := proofStatsVal.Interface().(ProofStats)
 
 	err = pStats.WritePStats(&ff)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	newPStats := proofStats{}
+	newPStats := ProofStats{}
 	err = newPStats.InitPStats(&ff)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/readproofstats/readproofstats.go
+++ b/cmd/readproofstats/readproofstats.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/utreexo/utreexod/blockchain/indexers"
+)
+
+// formatBytesToGB formats the bytes into a human readable GB format.
+func formatBytesToGB(bytes uint64) string {
+	const gb = 1024 * 1024 * 1024 // 1 GB in bytes
+	return fmt.Sprintf("%.2f GB", float64(bytes)/float64(gb))
+}
+
+var usage string = "Usage: readproofstats <file_path>. With the --flatutreexoproofindex enabled, " +
+	"the utreexoproofstats.dat file can be found under DATA_DIR/mainnet/utreexoproofstats_flat/. " +
+	"For other networks, replace mainnet with the desired network (signet, testnet)."
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatal(usage)
+	}
+
+	filePath := os.Args[1]
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		log.Fatalf("Failed to open file: %v\n%v", err, usage)
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		log.Fatalf("Failed to read file: %v\n%v", err, usage)
+	}
+
+	if len(content) != indexers.ProofStatsSize {
+		log.Fatalf("Expected the file to be of size %v but got %v\n%v",
+			indexers.ProofStatsSize, len(content), usage)
+	}
+
+	r := bytes.NewBuffer(content)
+
+	ps := indexers.ProofStats{}
+	err = ps.Deserialize(r)
+	if err != nil {
+		log.Fatalf("Failed to deserialize stats: %v\n%v", err, usage)
+	}
+
+	fmt.Printf("height %d: total dels %d, leafdata size %d (%s), leaf data count %d, target size %d (%s), target count %d, proof size %d (%s), proof count %d\n",
+		ps.BlockHeight, ps.TotalDels,
+		ps.LdSize, formatBytesToGB(ps.LdSize), ps.LdCount,
+		ps.TgSize, formatBytesToGB(ps.TgSize), ps.TgCount,
+		ps.ProofSize, formatBytesToGB(ps.ProofSize), ps.ProofCount)
+
+	fmt.Printf("height %d: average-blockoverhead %f, blockoverhead-sum %f, blockcount %d\n",
+		ps.BlockHeight, ps.BlockProofOverheadSum/float64(ps.BlockProofCount),
+		ps.BlockProofOverheadSum, ps.BlockProofCount)
+}


### PR DESCRIPTION
The raw .dat file can now be read with the readproofstats utility.