### PR TITLE
netsync: change getdatasize length to MaxUtreexoTTLPerMsg

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1198,6 +1198,11 @@ func (sm *SyncManager) fetchHeaderBlocks(peer *peerpkg.Peer) {
 			sm.fetchUtreexoTTLs(reqPeer)
 			return
 		}
+
+		// If we're downloading ttl messages before asking for blocks,
+		// then the maximum amount of blocks we are able to download is
+		// the max utreexo ttls per message.
+		length = wire.MaxUtreexoTTLsPerMsg
 	}
 
 	// Build up a getdata request for the list of blocks the headers


### PR DESCRIPTION
During fetchHeaderBlocks, we'd allocate 50,000 (max invs per getdata) inventory vectors in the getdata message which contributed significantly to the memory allocated during ibd as we were overallocating when downloading ttls first.

Since we can only download blocks up to the ttls that we have, we'll only be getting 16 (MaxUtreexoTTLPerMsg) invs at a time while allocating 50,000 invs.

Changing this here reduces the memory allocation and thus speeds up the entire program.