### PR TITLE
netsync, wire, chaincfg: don't ask for targets

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -950,6 +950,7 @@ func CustomSignetParams(challenge []byte, dnsSeeds []DNSSeed) Params {
 			{170_000, newHashFromStr("00000041c812a89f084f633e4cf47e819a2f6b1c0a15162355a930410522c99d")},
 			{193_792, newHashFromStr("000000408463e4809d3a493baf8f17f25a919f883824f5b42247402cfeec1b73")},
 			{231_620, newHashFromStr("0000012f65a81923ad36ee7d6a0d0ab2c7880e1390fbb4a87b2ebab5ee956d2e")},
+			{270_566, newHashFromStr("00000004d85480599a5997038d256ea2a31a8e9dca48b1e4c0298063cb016fd6")},
 		}
 	}
 

--- a/wire/msggetutreexoproof.go
+++ b/wire/msggetutreexoproof.go
@@ -7,7 +7,9 @@ package wire
 import (
 	"io"
 	"math"
+	"slices"
 
+	"github.com/utreexo/utreexo"
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
 )
 
@@ -151,6 +153,31 @@ func (msg *MsgGetUtreexoProof) IsLeafDataRequested(idx int) bool {
 // IsProofRequested returns if the proof hash at the given index is requested or not.
 func (msg *MsgGetUtreexoProof) IsProofRequested(idx int) bool {
 	return isBitSet(msg.ProofIndexBitMap, idx)
+}
+
+// GetProofBitMap returns a bitmap requesting all proofs for the given targets and numleaves.
+func GetProofBitMap(targets []uint64, numleaves uint64) []byte {
+	targetsCopy := make([]uint64, len(targets))
+	copy(targetsCopy, targets)
+	slices.Sort(targetsCopy)
+
+	proofPositions, _ := utreexo.ProofPositions(targetsCopy, numleaves, utreexo.TreeRows(numleaves))
+
+	bitMap := make([]bool, len(proofPositions))
+	for i := range bitMap {
+		bitMap[i] = true
+	}
+
+	return createBitmap(bitMap)
+}
+
+// GetLeafBitMap returns a bitmap requesting all leaf datas for the given targets.
+func GetLeafBitMap(targets []uint64) []byte {
+	bitMap := make([]bool, len(targets))
+	for i := range bitMap {
+		bitMap[i] = true
+	}
+	return createBitmap(bitMap)
 }
 
 // Returns true if the bit at the given index is set.


### PR DESCRIPTION
Since we're able to generate the targets from the ttls, we don't ask for them
if we're still downloading ttls.