### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/btcutil/base58/genalphabet.go
+++ b/btcutil/base58/genalphabet.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/btcutil/net.go
+++ b/btcutil/net.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !appengine
-// +build !appengine
 
 package btcutil
 

--- a/btcutil/net_noop.go
+++ b/btcutil/net_noop.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build appengine
-// +build appengine
 
 package btcutil
 

--- a/integration/bip0009_test.go
+++ b/integration/bip0009_test.go
@@ -4,7 +4,6 @@
 
 // This file is ignored during the regular tests due to the following build tag.
 //go:build rpctest
-// +build rpctest
 
 package integration
 

--- a/integration/csv_fork_test.go
+++ b/integration/csv_fork_test.go
@@ -4,7 +4,6 @@
 
 // This file is ignored during the regular tests due to the following build tag.
 //go:build rpctest
-// +build rpctest
 
 package integration
 

--- a/integration/prune_test.go
+++ b/integration/prune_test.go
@@ -4,7 +4,6 @@
 
 // This file is ignored during the regular tests due to the following build tag.
 //go:build rpctest
-// +build rpctest
 
 package integration
 

--- a/integration/rpcserver_test.go
+++ b/integration/rpcserver_test.go
@@ -4,7 +4,6 @@
 
 // This file is ignored during the regular tests due to the following build tag.
 //go:build rpctest
-// +build rpctest
 
 package integration
 

--- a/integration/rpctest/rpc_harness_test.go
+++ b/integration/rpctest/rpc_harness_test.go
@@ -4,7 +4,6 @@
 
 // This file is ignored during the regular tests due to the following build tag.
 //go:build rpctest
-// +build rpctest
 
 package rpctest
 

--- a/limits/limits_unix.go
+++ b/limits/limits_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows && !plan9
-// +build !windows,!plan9
 
 package limits
 

--- a/signalsigterm.go
+++ b/signalsigterm.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package main
 


### PR DESCRIPTION
Go 1.17 introduced a new `//go:build` syntax that replaces the legacy
`// +build` form. This change cleans up the old tag.

More info: https://github.com/golang/go/issues/41184