### PR TITLE
main: fix bug in getutreexoproofs rpc

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3383,7 +3383,7 @@ func handleGetUtreexoProof(s *rpcServer, cmd interface{}, closeChan <-chan struc
 		return nil, err
 	}
 
-	serialized := bytes.NewBuffer(make([]byte, udata.SerializeSize()))
+	serialized := bytes.NewBuffer(make([]byte, 0, udata.SerializeSize()))
 	err = udata.Serialize(serialized)
 	if err != nil {
 		return nil, &btcjson.RPCError{


### PR DESCRIPTION
Since we were allocating 0s, the utreexo proof had lots of 0s prepended. This commit resolves that bug.