### PR TITLE
aggregator: add helper functions for aggregator

### DIFF
--- a/blockchain/internal/aggregator/aggregator.go
+++ b/blockchain/internal/aggregator/aggregator.go
@@ -1,0 +1,75 @@
+package aggregator
+
+import (
+	"encoding/binary"
+	"math/bits"
+)
+
+// Agg512 keeps a 512-bit aggregator as 8 little-endian uint64 limbs.
+// limbs[0] is the least-significant limb.
+type Agg512 struct {
+	limbs [8]uint64
+}
+
+// InitFromBytes initializes from a little-endian [64]byte.
+func (a *Agg512) InitFromBytes(b [64]byte) {
+	a.limbs[0] = binary.LittleEndian.Uint64(b[0:8])
+	a.limbs[1] = binary.LittleEndian.Uint64(b[8:16])
+	a.limbs[2] = binary.LittleEndian.Uint64(b[16:24])
+	a.limbs[3] = binary.LittleEndian.Uint64(b[24:32])
+	a.limbs[4] = binary.LittleEndian.Uint64(b[32:40])
+	a.limbs[5] = binary.LittleEndian.Uint64(b[40:48])
+	a.limbs[6] = binary.LittleEndian.Uint64(b[48:56])
+	a.limbs[7] = binary.LittleEndian.Uint64(b[56:64])
+}
+
+// Bytes writes out as little-endian [64]byte.
+func (a *Agg512) Bytes() [64]byte {
+	var out [64]byte
+	binary.LittleEndian.PutUint64(out[0:8], a.limbs[0])
+	binary.LittleEndian.PutUint64(out[8:16], a.limbs[1])
+	binary.LittleEndian.PutUint64(out[16:24], a.limbs[2])
+	binary.LittleEndian.PutUint64(out[24:32], a.limbs[3])
+	binary.LittleEndian.PutUint64(out[32:40], a.limbs[4])
+	binary.LittleEndian.PutUint64(out[40:48], a.limbs[5])
+	binary.LittleEndian.PutUint64(out[48:56], a.limbs[6])
+	binary.LittleEndian.PutUint64(out[56:64], a.limbs[7])
+
+	return out
+}
+
+// Add256 adds the numerical value of a [32]byte interpreted as little-endian.
+func (a *Agg512) Add256(h *[32]byte) {
+	w0 := binary.LittleEndian.Uint64(h[0:8])
+	w1 := binary.LittleEndian.Uint64(h[8:16])
+	w2 := binary.LittleEndian.Uint64(h[16:24])
+	w3 := binary.LittleEndian.Uint64(h[24:32])
+
+	var carry uint64
+	a.limbs[0], carry = bits.Add64(a.limbs[0], w0, carry)
+	a.limbs[1], carry = bits.Add64(a.limbs[1], w1, carry)
+	a.limbs[2], carry = bits.Add64(a.limbs[2], w2, carry)
+	a.limbs[3], carry = bits.Add64(a.limbs[3], w3, carry)
+	a.limbs[4], carry = bits.Add64(a.limbs[4], 0, carry)
+	a.limbs[5], carry = bits.Add64(a.limbs[5], 0, carry)
+	a.limbs[6], carry = bits.Add64(a.limbs[6], 0, carry)
+	a.limbs[7], carry = bits.Add64(a.limbs[7], 0, carry)
+}
+
+// Sub256 subtracts the numerical value of a [32]byte interpreted as little-endian.
+func (a *Agg512) Sub256(h *[32]byte) {
+	w0 := binary.LittleEndian.Uint64(h[0:8])
+	w1 := binary.LittleEndian.Uint64(h[8:16])
+	w2 := binary.LittleEndian.Uint64(h[16:24])
+	w3 := binary.LittleEndian.Uint64(h[24:32])
+
+	var borrow uint64
+	a.limbs[0], borrow = bits.Sub64(a.limbs[0], w0, borrow)
+	a.limbs[1], borrow = bits.Sub64(a.limbs[1], w1, borrow)
+	a.limbs[2], borrow = bits.Sub64(a.limbs[2], w2, borrow)
+	a.limbs[3], borrow = bits.Sub64(a.limbs[3], w3, borrow)
+	a.limbs[4], borrow = bits.Sub64(a.limbs[4], 0, borrow)
+	a.limbs[5], borrow = bits.Sub64(a.limbs[5], 0, borrow)
+	a.limbs[6], borrow = bits.Sub64(a.limbs[6], 0, borrow)
+	a.limbs[7], borrow = bits.Sub64(a.limbs[7], 0, borrow)
+}

--- a/blockchain/internal/aggregator/aggregator_test.go
+++ b/blockchain/internal/aggregator/aggregator_test.go
@@ -1,0 +1,175 @@
+package aggregator
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func littleEndianBytesToBigInt(b []byte) *big.Int {
+	be := make([]byte, len(b))
+	for i := range b {
+		be[len(b)-1-i] = b[i]
+	}
+	return new(big.Int).SetBytes(be)
+}
+
+func bigIntToLittleEndian64(x *big.Int) [64]byte {
+	var out [64]byte
+	be := x.Bytes()
+	if len(be) > len(out) {
+		panic("integer does not fit into 64 bytes")
+	}
+	for i := 0; i < len(be); i++ {
+		out[i] = be[len(be)-1-i]
+	}
+	return out
+}
+
+func TestAgg512Bytes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   [64]byte
+	}{
+		{name: "all-zero", in: [64]byte{}},
+		{name: "all-ff", in: func() (b [64]byte) {
+			for i := range b {
+				b[i] = 0xFF
+			}
+			return
+		}()},
+		{name: "lsb-only", in: func() (b [64]byte) { b[0] = 0x01; return }()},
+		{name: "msb-only", in: func() (b [64]byte) { b[63] = 0x80; return }()},
+		{name: "pattern", in: func() (b [64]byte) {
+			for i := range b {
+				b[i] = byte(i*7 + 3)
+			}
+			return
+		}()},
+	}
+
+	for _, tt := range tests {
+		var agg Agg512
+		agg.InitFromBytes(tt.in)
+
+		out := agg.Bytes()
+		require.Equal(t, tt.in, out)
+	}
+}
+
+func TestAgg512AddSub(t *testing.T) {
+	tests := []struct {
+		name string
+		acc  [64]byte
+		adds [][32]byte
+	}{
+		{
+			name: "carry-within-low",
+			acc: func() (b [64]byte) {
+				for i := 0; i < 32; i++ {
+					b[i] = 0xFF
+				}
+				return
+			}(),
+			adds: func() [][32]byte {
+				b := [][32]byte{
+					{0x1},
+				}
+				return b
+			}(),
+		},
+		{
+			name: "patterned",
+			acc: func() (b [64]byte) {
+				for i := range b {
+					b[i] = byte(i*13 + 5)
+				}
+				return
+			}(),
+			adds: func() [][32]byte {
+				adds := make([][32]byte, 1)
+				for i := range adds[0] {
+					adds[0][i] = byte(i*17 + 9)
+				}
+				return adds
+			}(),
+		},
+		{
+			name: "double-add-cross-half",
+			acc: func() (b [64]byte) {
+				b[32] = 0xAA
+				b[45] = 0x11
+				return
+			}(),
+			adds: func() [][32]byte {
+				adds := make([][32]byte, 2)
+				for i := range adds[0] {
+					adds[0][i] = 0xFF
+				}
+				adds[1][0] = 0x01
+				return adds
+			}(),
+		},
+		{
+			name: "full-wrap-around",
+			acc: func() (b [64]byte) {
+				for i := range b {
+					b[i] = 0xFF
+				}
+				return
+			}(),
+			adds: func() [][32]byte {
+				b := [][32]byte{
+					{0x1},
+				}
+				return b
+			}(),
+		},
+		{
+			name: "multi-add-patterns",
+			acc: func() (b [64]byte) {
+				for i := range b {
+					b[i] = byte(i*5 + 7)
+				}
+				return
+			}(),
+			adds: func() [][32]byte {
+				adds := make([][32]byte, 3)
+				for i := range adds {
+					for j := range adds[i] {
+						adds[i][j] = byte(i*29 + j*13 + 3)
+					}
+				}
+				return adds
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		var agg Agg512
+		agg.InitFromBytes(tt.acc)
+		expectedAdd := littleEndianBytesToBigInt(tt.acc[:])
+
+		for _, add := range tt.adds {
+			agg.Add256(&add)
+
+			addInt := littleEndianBytesToBigInt(add[:])
+			expectedAdd.Add(expectedAdd, addInt)
+
+			// Probably never needed since we won't ever go over 2**512
+			// but why not just test it.
+			var mod512 = new(big.Int).Lsh(big.NewInt(1), 512)
+			expectedAdd.Mod(expectedAdd, mod512)
+		}
+
+		require.Equal(t, bigIntToLittleEndian64(expectedAdd), agg.Bytes())
+		require.NotEqual(t, tt.acc, agg.Bytes())
+
+		for _, add := range tt.adds {
+			agg.Sub256(&add)
+		}
+
+		require.Equal(t, tt.acc, agg.Bytes())
+	}
+}


### PR DESCRIPTION
For swiftsync, you must have an aggregator to check that all the utxos marked as spent were indeed spent. We create a helper function to efficiently add and subtract from the aggregator.

We can use big.Int but converting [32]byte hashes to big.Int values allocate memory and slow down the ibd.