### PR TITLE
chaincfg: add new checkpoint so that we're checkpointed til the end of ttl state

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -950,6 +950,7 @@ func CustomSignetParams(challenge []byte, dnsSeeds []DNSSeed) Params {
 			{170_000, newHashFromStr("00000041c812a89f084f633e4cf47e819a2f6b1c0a15162355a930410522c99d")},
 			{193_792, newHashFromStr("000000408463e4809d3a493baf8f17f25a919f883824f5b42247402cfeec1b73")},
 			{231_620, newHashFromStr("0000012f65a81923ad36ee7d6a0d0ab2c7880e1390fbb4a87b2ebab5ee956d2e")},
+			{270_566, newHashFromStr("00000004d85480599a5997038d256ea2a31a8e9dca48b1e4c0298063cb016fd6")},
 		}
 	}
 


### PR DESCRIPTION
Since the ttls are up until block 270566 for signet, we also add a checkpoint up until that block.