### PR TITLE
Add `make install` recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ build-utreexod: build-bdk ## Build utreexod with all features
 build-utreexod-without-bdk: ## Build utreexod without BDK wallet
 	go build -o . ./...
 
+install: build-bdk ## Install binaries to GOPATH
+	go install --tags=bdkwallet ./...
+
 test: build-bdk ## Run all test
 	cargo test
 	sh ./goclean.sh

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ To build without the BDK wallet:
 go build -o . ./...
 ```
 
+To build and install binaries to `$GOPATH/bin` with BDK wallet:
+```bash
+make install
+```
+
 ## Getting Started
 
 To run a utreexo node:


### PR DESCRIPTION
Adds a `make install` recipe that will build (with BDK) and install the binaries to `$GOPATH`.