### PR TITLE
netsync: remove txs on block connect

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -526,6 +526,10 @@ func (mp *TxPool) removeTransaction(tx *btcutil.Tx, removeRedeemers bool) {
 			mp.cfg.AddrIndex.RemoveUnconfirmedTx(txHash)
 		}
 
+		// Uncache the utreexo proof and remove the leaf data for this
+		// transaction if present.
+		mp.removeUtreexoData(txHash)
+
 		// Mark the referenced outpoints as unspent by the pool.
 		for _, txIn := range txDesc.Tx.MsgTx().TxIn {
 			delete(mp.outpoints, txIn.PreviousOutPoint)
@@ -538,8 +542,8 @@ func (mp *TxPool) removeTransaction(tx *btcutil.Tx, removeRedeemers bool) {
 // RemoveTransaction removes the passed transaction from the mempool. When the
 // removeRedeemers flag is set, any transactions that redeem outputs from the
 // removed transaction will also be removed recursively from the mempool, as
-// they would otherwise become orphans. When the uncacheUtreexo flag is set,
-// it'll uncache the utreexo proof for the given tx if it's cached.
+// they would otherwise become orphans. Any cached utreexo leaf data for the
+// transaction is always cleaned up.
 //
 // This function is safe for concurrent access.
 func (mp *TxPool) RemoveTransaction(tx *btcutil.Tx, removeRedeemers bool) {
@@ -622,6 +626,26 @@ func (mp *TxPool) addUtreexoData(tx *btcutil.Tx, udata *wire.UData) error {
 	mp.poolLeaves[*tx.Hash()] = udata.LeafDatas
 
 	return nil
+}
+
+// removeUtreexoData removes the cached leaves and uncaches the proof from the
+// accumulator for the given transaction.
+//
+// This function MUST be called with the mempool lock held (for writes).
+func (mp *TxPool) removeUtreexoData(txHash *chainhash.Hash) {
+	leaves, found := mp.poolLeaves[*txHash]
+	if !found {
+		return
+	}
+	delete(mp.poolLeaves, *txHash)
+
+	if mp.cfg.PruneFromAccumulator != nil {
+		err := mp.cfg.PruneFromAccumulator(leaves)
+		if err != nil {
+			log.Debugf("error while pruning proof for tx %v "+
+				"from the accumulator: %v", txHash, err)
+		}
+	}
 }
 
 // checkPoolDoubleSpend checks whether or not the passed transaction is

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1921,3 +1921,49 @@ func TestRBFUtreexoDataFailure(t *testing.T) {
 	testPoolMembership(ctx, childTx, false, true)
 	testPoolMembership(ctx, replacementTx, false, false)
 }
+
+// TestRemoveTransactionCleansUtreexoData verifies that removing a transaction
+// from the mempool also removes its cached utreexo leaf data.
+func TestRemoveTransactionCleansUtreexoData(t *testing.T) {
+	t.Parallel()
+
+	harness, outputs, err := newPoolHarness(&chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatalf("unable to create test pool: %v", err)
+	}
+
+	ctx := &testContext{t, harness}
+
+	// Add a transaction to the mempool.
+	tx := ctx.addSignedTx(outputs, 1, 0, false, false)
+
+	// Simulate utreexo proof data by writing directly to poolLeaves.
+	// In production this is done by addUtreexoData during ProcessTransaction
+	// on utreexo nodes.
+	fakeLeaves := []wire.LeafData{
+		{
+			OutPoint:   wire.OutPoint{Hash: *tx.Hash(), Index: 0},
+			Height:     1,
+			IsCoinBase: false,
+			Amount:     100,
+			PkScript:   []byte{txscript.OP_TRUE},
+		},
+	}
+	harness.txPool.poolLeaves[*tx.Hash()] = fakeLeaves
+
+	// Sanity: leaf data is present.
+	_, err = harness.txPool.FetchLeafDatas(tx.Hash())
+	if err != nil {
+		t.Fatalf("expected leaf data to be present before removal: %v", err)
+	}
+
+	// Remove the transaction.
+	harness.txPool.RemoveTransaction(tx, false)
+	testPoolMembership(ctx, tx, false, false)
+
+	// The leaf data must have been cleaned up.
+	_, err = harness.txPool.FetchLeafDatas(tx.Hash())
+	if err == nil {
+		t.Fatal("expected leaf data to be removed after RemoveTransaction")
+	}
+}

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/require"
 	"github.com/utreexo/utreexod/blockchain"
 	"github.com/utreexo/utreexod/btcutil"
 	"github.com/utreexo/utreexod/chaincfg"
@@ -1966,4 +1967,53 @@ func TestRemoveTransactionCleansUtreexoData(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected leaf data to be removed after RemoveTransaction")
 	}
+}
+
+// TestRemoveTransactionPrunesUtreexoAccumulator verifies that when a
+// PruneFromAccumulator callback is configured, removing a transaction from the
+// mempool invokes it with the cached leaves so the proof is uncached from the
+// accumulator.
+func TestRemoveTransactionPrunesUtreexoAccumulator(t *testing.T) {
+	t.Parallel()
+
+	harness, outputs, err := newPoolHarness(&chaincfg.MainNetParams)
+	require.NoError(t, err, "unable to create test pool")
+
+	// Install a recording PruneFromAccumulator that captures the leaves it
+	// is invoked with.
+	var pruned [][]wire.LeafData
+	harness.txPool.cfg.PruneFromAccumulator = func(leaves []wire.LeafData) error {
+		pruned = append(pruned, leaves)
+		return nil
+	}
+
+	ctx := &testContext{t, harness}
+
+	tx := ctx.addSignedTx(outputs, 1, 0, false, false)
+	testPoolMembership(ctx, tx, false, true)
+
+	fakeLeaves := []wire.LeafData{
+		{
+			OutPoint:   wire.OutPoint{Hash: *tx.Hash(), Index: 0},
+			Height:     1,
+			IsCoinBase: false,
+			Amount:     100,
+			PkScript:   []byte{txscript.OP_TRUE},
+		},
+	}
+	harness.txPool.poolLeaves[*tx.Hash()] = fakeLeaves
+
+	harness.txPool.RemoveTransaction(tx, false)
+	testPoolMembership(ctx, tx, false, false)
+
+	require.Len(t, pruned, 1, "expected PruneFromAccumulator to be called once")
+	require.Equal(t, fakeLeaves, pruned[0],
+		"PruneFromAccumulator received unexpected leaves")
+
+	// Removing a transaction with no cached leaves must NOT invoke the
+	// callback again.
+	otherTx := ctx.addSignedTx(outputs, 1, 0, false, false)
+	harness.txPool.RemoveTransaction(otherTx, false)
+	require.Len(t, pruned, 1,
+		"PruneFromAccumulator should not fire when no leaves are cached")
 }

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1971,12 +1971,6 @@ func (sm *SyncManager) handleBlockchainNotification(notification *blockchain.Not
 
 	// A block has been connected to the main block chain.
 	case blockchain.NTBlockConnected:
-		// Don't relay if we are not current. Other peers that are
-		// current should already know about it.
-		if !sm.current() {
-			return
-		}
-
 		block, ok := notification.Data.(*btcutil.Block)
 		if !ok {
 			log.Warnf("Chain connected notification is not a block.")

--- a/netsync/manager_test.go
+++ b/netsync/manager_test.go
@@ -1175,3 +1175,126 @@ func TestStartSyncChainCurrent(t *testing.T) {
 	require.False(t, sm.headersFirstMode,
 		"headersFirstMode should not be activated when chain is already current")
 }
+
+// TestBlockConnectedCleansMempool verifies that the NTBlockConnected
+// notification always removes double-spending transactions from the mempool,
+// even when the node is not current (e.g. during IBD).
+//
+// This is a regression test for a bug where the entire NTBlockConnected handler
+// was gated behind sm.current(), causing mempool cleanup to be skipped during
+// initial sync.  When a reorg later disconnected such a block, the stale
+// mempool entries would conflict with re-added block transactions, triggering
+// an RBF code path that crashed with a nil pointer dereference.
+func TestBlockConnectedCleansMempool(t *testing.T) {
+	t.Parallel()
+
+	params := chaincfg.RegressionNetParams
+	params.Checkpoints = nil
+
+	chain, tearDown, err := chainSetup(t, &params)
+	require.NoError(t, err)
+	defer tearDown()
+
+	txPool := mempool.New(&mempool.Config{
+		Policy: mempool.Policy{
+			DisableRelayPriority: true,
+			FreeTxRelayLimit:     15.0,
+			MaxOrphanTxs:         5,
+			MaxOrphanTxSize:      1000,
+			MaxSigOpCostPerTx:    blockchain.MaxBlockSigOpsCost / 4,
+			MinRelayTxFee:        1000,
+			MaxTxVersion:         2,
+			AcceptNonStd:         true,
+		},
+		ChainParams:   &params,
+		FetchUtxoView: chain.FetchUtxoView,
+		BestHeight:    func() int32 { return chain.BestSnapshot().Height },
+		MedianTimePast: func() time.Time {
+			return chain.BestSnapshot().MedianTime
+		},
+		CalcSequenceLock: func(tx *btcutil.Tx, view *blockchain.UtxoViewpoint) (*blockchain.SequenceLock, error) {
+			return chain.CalcSequenceLock(tx, view, true)
+		},
+		IsDeploymentActive:  chain.IsDeploymentActive,
+		IsUtreexoViewActive: func() bool { return false },
+		SigCache:            txscript.NewSigCache(1000),
+	})
+
+	sm, err := New(&Config{
+		PeerNotifier: noopPeerNotifier{},
+		Chain:        chain,
+		TxMemPool:    txPool,
+		ChainParams:  &params,
+	})
+	require.NoError(t, err)
+
+	// Mine enough blocks to mature the first coinbase.
+	blocks := generateTestBlocks(t, &params, int(params.CoinbaseMaturity)+1)
+	for _, blk := range blocks {
+		_, _, err := chain.ProcessBlock(blk, blockchain.BFNone)
+		require.NoError(t, err)
+	}
+
+	// Grab the mature coinbase outpoint.
+	cbOutpoint := wire.OutPoint{
+		Hash:  *blocks[0].Transactions()[0].Hash(),
+		Index: 0,
+	}
+
+	// Create a tx spending the coinbase and add it to the mempool.
+	mempoolSpend := wire.NewMsgTx(1)
+	mempoolSpend.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: cbOutpoint,
+		Sequence:         wire.MaxTxInSequenceNum,
+	})
+	mempoolSpend.AddTxOut(&wire.TxOut{
+		Value:    100_000_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+	mempoolTx := btcutil.NewTx(mempoolSpend)
+	_, err = txPool.ProcessTransaction(mempoolTx, nil, false, false, 0)
+	require.NoError(t, err)
+	require.True(t, txPool.HaveTransaction(mempoolTx.Hash()))
+
+	// Make the node NOT current by adding a peer at a much higher height.
+	newSyncCandidate(t, sm, 900_000)
+	require.False(t, sm.current())
+
+	// Build and connect a block containing a DIFFERENT tx that spends the
+	// same coinbase (a double-spend).  ProcessBlock fires NTBlockConnected
+	// synchronously, which calls handleBlockchainNotification.
+	blockSpend := wire.NewMsgTx(1)
+	blockSpend.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: cbOutpoint,
+		Sequence:         wire.MaxTxInSequenceNum,
+	})
+	blockSpend.AddTxOut(&wire.TxOut{
+		Value:    90_000_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+
+	snap := chain.BestSnapshot()
+	cb := createTestCoinbase(snap.Height+1, &params)
+	blockTxns := []*wire.MsgTx{cb, blockSpend}
+	merkleRoot := blockchain.CalcMerkleRoot(
+		[]*btcutil.Tx{btcutil.NewTx(cb), btcutil.NewTx(blockSpend)},
+		false,
+	)
+	header := wire.BlockHeader{
+		Version:    1,
+		PrevBlock:  snap.Hash,
+		MerkleRoot: merkleRoot,
+		Timestamp:  blocks[len(blocks)-1].MsgBlock().Header.Timestamp.Add(time.Minute),
+		Bits:       params.PowLimitBits,
+	}
+	require.True(t, solveTestBlock(&header, &params))
+	_, _, err = chain.ProcessBlock(
+		btcutil.NewBlock(&wire.MsgBlock{Header: header, Transactions: blockTxns}),
+		blockchain.BFNone,
+	)
+	require.NoError(t, err)
+
+	// The mempool tx must have been evicted, even though we were not current.
+	require.False(t, txPool.HaveTransaction(mempoolTx.Hash()),
+		"mempool should have removed the double-spending tx on block connect")
+}


### PR DESCRIPTION
Remove the sm.current() guard that caused the entire NTBlockConnected
handler to be skipped during IBD. This meant RemoveTransaction,
RemoveDoubleSpends, RemoveOrphan, and ProcessOrphans were never called
while the node was catching up, leaving stale double-spending entries
in the mempool.

When a reorg later disconnected a block whose transactions conflicted
with those stale entries, the RBF validation in validateReplacement
would crash with a nil pointer dereference on mp.pool[hash].

This matches the upstream btcd behavior where NTBlockConnected has no
current-check.