### PR TITLE
main: bump utreexo library to 0.17.2

### DIFF
--- a/blockchain/indexers/utreexobackend_test.go
+++ b/blockchain/indexers/utreexobackend_test.go
@@ -18,12 +18,16 @@ func TestReadConsistencyHash(t *testing.T) {
 	forest, err := utreexo.OpenForest(dbPath)
 	require.NoError(t, err)
 
-	// Flush with a known hash.
+	// Close with a known hash so it is persisted via the WAL.
 	hash := chaincfg.MainNetParams.GenesisHash
-	err = forest.Flush([32]byte(*hash))
-	require.NoError(t, err)
+	require.NoError(t, forest.Close([32]byte(*hash)))
 
-	// Read it back and cast to chainhash.Hash.
+	// Reopen and read the hash back, mirroring how production callers
+	// recover the consistency hash after a restart.
+	forest, err = utreexo.OpenForest(dbPath)
+	require.NoError(t, err)
+	defer forest.Close([32]byte(*hash))
+
 	gotBytes, err := forest.ReadConsistencyHash()
 	require.NoError(t, err)
 	gotHash := chainhash.Hash(gotBytes)

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23
 	github.com/stretchr/testify v1.11.1
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/utreexo/utreexo v0.17.0
+	github.com/utreexo/utreexo v0.17.2
 	golang.org/x/crypto v0.25.0
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 	pgregory.net/rapid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -324,6 +324,10 @@ github.com/utreexo/utreexo v0.15.0 h1:UdYz2wYpacc1ih0Fv1u/BNks1Cab7QVo+KgO1f7hPj
 github.com/utreexo/utreexo v0.15.0/go.mod h1:7BbTQYp48IyyfSmPG+QoWxldLfyO0+5zOqKw1lF27WE=
 github.com/utreexo/utreexo v0.17.0 h1:eq2qfLred/pwkX56yQyCPBTCbPdWKPwPvIkbJqHYG6M=
 github.com/utreexo/utreexo v0.17.0/go.mod h1:7BbTQYp48IyyfSmPG+QoWxldLfyO0+5zOqKw1lF27WE=
+github.com/utreexo/utreexo v0.17.1 h1:EQaYG8e1rh4VUxZ1MsvZpzvxSiJ8oOlrgCHKinfu+qE=
+github.com/utreexo/utreexo v0.17.1/go.mod h1:7BbTQYp48IyyfSmPG+QoWxldLfyO0+5zOqKw1lF27WE=
+github.com/utreexo/utreexo v0.17.2 h1:ON+2tq8K7cbE6/94p090az7U8srl96Um6ptw8vmw2P8=
+github.com/utreexo/utreexo v0.17.2/go.mod h1:7BbTQYp48IyyfSmPG+QoWxldLfyO0+5zOqKw1lF27WE=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/version.go
+++ b/version.go
@@ -18,7 +18,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 5
-	appPatch uint = 1
+	appPatch uint = 2
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
This version fixes a memory leak that affected utreexo bridge nodes.