### PR TITLE
indexers: fix index catchup bug

### DIFF
--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -1479,3 +1479,71 @@ func TestBridgeNodeSSTableFlush(t *testing.T) {
 		}
 	}
 }
+
+// cfIndexClosingInterrupt wraps a CfIndex so that its first ConnectBlock
+// closes the supplied interrupt channel. The catchup loop's interrupt
+// branch then fires on an iteration where the loop's blockhash is not
+// the utreexo indexer's tip.
+type cfIndexClosingInterrupt struct {
+	*CfIndex
+	interrupt chan struct{}
+}
+
+func (c *cfIndexClosingInterrupt) ConnectBlock(dbTx database.Tx, block *btcutil.Block, stxos []blockchain.SpentTxOut) error {
+	close(c.interrupt)
+	return c.CfIndex.ConnectBlock(dbTx, block, stxos)
+}
+
+// TestCatchupPreservesUtreexoConsistencyHash checks that the manager's
+// catchup loop does not overwrite the on-disk utreexo consistency hash
+// when utreexo is already at the chain tip and a different indexer is
+// catching up. If it did, initConsistentUtreexoState would try to re-apply
+// already-applied blocks on the next start and corrupt the forest.
+func TestCatchupPreservesUtreexoConsistencyHash(t *testing.T) {
+	defer os.RemoveAll(testDbRoot)
+	chain, indexes, params, mgr, tearDown := indexersTestChain(
+		"TestCatchupPreservesUtreexoConsistencyHash")
+	defer tearDown()
+
+	// Mine one block so that the utreexo index is now at block 1.
+	// The catchup loop will start at genesis for the lagging cfindex
+	// below, so the blockhash the cfindex passes to Flush won't match
+	// the utreexo indexer's tip.
+	_, _, err := blockchain.AddBlock(chain, btcutil.NewBlock(params.GenesisBlock), nil)
+	require.NoError(t, err)
+	tipHash := chain.BestSnapshot().Hash
+
+	// state.Close writes the chain tip as the consistency hash and
+	// releases file handles so the next Init can re-open the forest.
+	forEachUtreexoState := func(fn func(*UtreexoState)) {
+		for _, indexer := range indexes {
+			switch i := indexer.(type) {
+			case *UtreexoProofIndex:
+				fn(i.utreexoState)
+			case *FlatUtreexoProofIndex:
+				fn(i.utreexoState)
+			}
+		}
+	}
+	forEachUtreexoState(func(us *UtreexoState) {
+		require.NoError(t, us.state.Close(tipHash))
+	})
+
+	// Append a lagging cfindex so that Manager.Init runs its catchup
+	// loop, which feeds blocks to indexers whose tip is behind the
+	// chain. On the first iteration (genesis), the cfindex closes the
+	// interrupt channel from inside its ConnectBlock, so the loop's
+	// interrupt branch fires and calls Flush with the genesis blockhash,
+	// which is not the utreexo indexer's tip.
+	interrupt := make(chan struct{})
+	mgr.enabledIndexes = append(mgr.enabledIndexes,
+		&cfIndexClosingInterrupt{CfIndex: NewCfIndex(mgr.db, params), interrupt: interrupt},
+	)
+	require.Equal(t, errInterruptRequested, mgr.Init(chain, interrupt))
+
+	forEachUtreexoState(func(us *UtreexoState) {
+		got, err := us.state.ReadConsistencyHash()
+		require.NoError(t, err)
+		require.Equal(t, tipHash[:], got[:])
+	})
+}

--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -661,10 +661,27 @@ func (m *Manager) PruneBlocks(dbTx database.Tx, lastKeptHeight int32,
 }
 
 // Flush flushes the enabled indexes. For the indexers that do not need to be flushed, it's a no-op.
+//
+// Indexers whose tip is not at bestHash are skipped. The catchup loop calls
+// this with the loop's per-iteration block hash, which doesn't match an
+// indexer whose tip is elsewhere (e.g. the utreexo indexer at the chain tip
+// while the cfilter indexer is catching up). Flushing then would persist a
+// consistency hash that doesn't match the indexer's actual state.
 func (m *Manager) Flush(bestHash *chainhash.Hash, mode blockchain.FlushMode, onConnect bool) error {
 	for _, index := range m.enabledIndexes {
-		err := index.Flush(bestHash, mode, onConnect)
+		var tipHash *chainhash.Hash
+		err := m.db.View(func(dbTx database.Tx) error {
+			h, _, err := dbFetchIndexerTip(dbTx, index.Key())
+			tipHash = h
+			return err
+		})
 		if err != nil {
+			return err
+		}
+		if !tipHash.IsEqual(bestHash) {
+			continue
+		}
+		if err := index.Flush(bestHash, mode, onConnect); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The catchup loop fed every indexer's Flush the loop's per-iteration block
hash, so an indexer whose tip was elsewhere (e.g. the utreexo indexer at
the chain tip while the cfilter indexer was catching up) would persist a
stale consistency hash and corrupt the forest on the next start.