### PR TITLE
build: reinstall uniffi-bindgen-go when the installed version is stale 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
+UNIFFI_BINDGEN_GO_VERSION := 0.4.0+v0.28.3
+
 help: ## Display help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 install-rust: ## Install rust if not installed
 	if ! type cargo; then curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh ; fi
 
-install-uniffi-bindgen-go: install-rust ## Install uniffi-bindgen-go if not installed
-	if ! type uniffi-bindgen-go; then CARGO_NET_GIT_FETCH_WITH_CLI=true cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.4.0+v0.28.3 --locked; fi
+install-uniffi-bindgen-go: install-rust ## Install uniffi-bindgen-go at the pinned version if missing or stale
+	if ! uniffi-bindgen-go --version 2>/dev/null | grep -q "$(UNIFFI_BINDGEN_GO_VERSION)"; then CARGO_NET_GIT_FETCH_WITH_CLI=true cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v$(UNIFFI_BINDGEN_GO_VERSION) --locked --force; fi
 
 build-bdk: install-uniffi-bindgen-go ## Build BDK static library
 	uniffi-bindgen-go -o bdkwallet bdkwallet/bdkgo_crate/src/bdkgo.udl


### PR DESCRIPTION
The previous check only verified that the binary existed on PATH, so a
user with an older uniffi-bindgen-go from a prior project setup would
silently use it and generate bindings that don't match the current
bdkgo.h/bdkgo.go expected by the codebase. Pin the version as a Makefile
variable, compare against --version, and use --force on cargo install so
a stale binary is actually replaced.