### PR TITLE
peer, netsync, main, wire: remove utreexoblock invs

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1158,18 +1158,6 @@ func (sm *SyncManager) fetchHeaderBlocks(peer *peerpkg.Peer) {
 			// witness data in the blocks.
 			if reqPeer.IsWitnessEnabled() {
 				iv.Type = wire.InvTypeWitnessBlock
-
-				// If we're syncing from a utreexo enabled peer, also
-				// ask for the proofs.
-				if reqPeer.IsUtreexoEnabled() {
-					iv.Type = wire.InvTypeWitnessUtreexoBlock
-				}
-			} else {
-				// If we're syncing from a utreexo enabled peer, also
-				// ask for the proofs.
-				if reqPeer.IsUtreexoEnabled() {
-					iv.Type = wire.InvTypeUtreexoBlock
-				}
 			}
 
 			gdmsg.AddInvVect(iv)
@@ -1418,10 +1406,6 @@ func (sm *SyncManager) handleNotFoundMsg(nfmsg *notFoundMsg) {
 		// verify the hash was actually announced by the peer
 		// before deleting from the global requested maps.
 		switch inv.Type {
-		case wire.InvTypeUtreexoBlock:
-			fallthrough
-		case wire.InvTypeWitnessUtreexoBlock:
-			fallthrough
 		case wire.InvTypeWitnessBlock:
 			fallthrough
 		case wire.InvTypeBlock:
@@ -1456,10 +1440,6 @@ func (sm *SyncManager) handleNotFoundMsg(nfmsg *notFoundMsg) {
 // are in the memory pool (either the main pool or orphan pool).
 func (sm *SyncManager) haveInventory(invVect *wire.InvVect) (bool, error) {
 	switch invVect.Type {
-	case wire.InvTypeUtreexoBlock:
-		fallthrough
-	case wire.InvTypeWitnessUtreexoBlock:
-		fallthrough
 	case wire.InvTypeWitnessBlock:
 		fallthrough
 	case wire.InvTypeBlock:
@@ -1589,8 +1569,6 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 		case wire.InvTypeBlock:
 		case wire.InvTypeTx:
 		case wire.InvTypeWitnessBlock:
-		case wire.InvTypeWitnessUtreexoBlock:
-		case wire.InvTypeUtreexoBlock:
 		case wire.InvTypeWitnessTx:
 		case wire.InvTypeUtreexoTx:
 		case wire.InvTypeWitnessUtreexoTx:
@@ -1668,7 +1646,7 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 			continue
 		}
 
-		if iv.Type == wire.InvTypeBlock || iv.Type == wire.InvTypeUtreexoBlock {
+		if iv.Type == wire.InvTypeBlock {
 			// The block is an orphan block that we already have.
 			// When the existing orphan was processed, it requested
 			// the missing parent blocks.  When this scenario
@@ -1720,10 +1698,6 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 		requestQueue = requestQueue[1:]
 
 		switch iv.Type {
-		case wire.InvTypeUtreexoBlock:
-			fallthrough
-		case wire.InvTypeWitnessUtreexoBlock:
-			fallthrough
 		case wire.InvTypeWitnessBlock:
 			fallthrough
 		case wire.InvTypeBlock:

--- a/peer/log.go
+++ b/peer/log.go
@@ -95,10 +95,6 @@ func invSummary(invList []*wire.InvVect) string {
 			return fmt.Sprintf("witness block %s", iv.Hash)
 		case wire.InvTypeBlock:
 			return fmt.Sprintf("block %s", iv.Hash)
-		case wire.InvTypeUtreexoBlock:
-			return fmt.Sprintf("utreexo block %s", iv.Hash)
-		case wire.InvTypeWitnessUtreexoBlock:
-			return fmt.Sprintf("witness utreexo block %s", iv.Hash)
 		case wire.InvTypeWitnessTx:
 			return fmt.Sprintf("witness tx %s", iv.Hash)
 		case wire.InvTypeUtreexoTx:

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1841,9 +1841,7 @@ out:
 					// out immediately, skipping the inv trickle
 					// queue.
 					if iv.Type == wire.InvTypeBlock ||
-						iv.Type == wire.InvTypeUtreexoBlock ||
-						iv.Type == wire.InvTypeWitnessBlock ||
-						iv.Type == wire.InvTypeWitnessUtreexoBlock {
+						iv.Type == wire.InvTypeWitnessBlock {
 
 						invMsg := wire.NewMsgInvSizeHint(1)
 						invMsg.AddInvVect(iv)

--- a/server.go
+++ b/server.go
@@ -834,10 +834,6 @@ func (sp *serverPeer) OnGetData(_ *peer.Peer, msg *wire.MsgGetData) {
 			err = sp.server.pushBlockMsg(sp, &iv.Hash, c, waitChan, wire.WitnessEncoding)
 		case wire.InvTypeBlock:
 			err = sp.server.pushBlockMsg(sp, &iv.Hash, c, waitChan, wire.BaseEncoding)
-		case wire.InvTypeUtreexoBlock:
-			err = sp.server.pushBlockMsg(sp, &iv.Hash, c, waitChan, wire.BaseEncoding)
-		case wire.InvTypeWitnessUtreexoBlock:
-			err = sp.server.pushBlockMsg(sp, &iv.Hash, c, waitChan, wire.WitnessEncoding)
 		case wire.InvTypeFilteredWitnessBlock:
 			err = sp.server.pushMerkleBlockMsg(sp, &iv.Hash, c, waitChan, wire.WitnessEncoding)
 		case wire.InvTypeFilteredBlock:
@@ -1699,10 +1695,6 @@ func (sp *serverPeer) OnNotFound(p *peer.Peer, msg *wire.MsgNotFound) {
 		case wire.InvTypeBlock:
 			numBlocks++
 		case wire.InvTypeWitnessBlock:
-			numBlocks++
-		case wire.InvTypeUtreexoBlock:
-			numBlocks++
-		case wire.InvTypeWitnessUtreexoBlock:
 			numBlocks++
 		case wire.InvTypeTx:
 			numTxns++

--- a/wire/invvect.go
+++ b/wire/invvect.go
@@ -41,8 +41,6 @@ const (
 	InvTypeWTXIDTx              InvType = 5
 	InvTypeUtreexoProofHash     InvType = 6
 	InvTypeWitnessBlock         InvType = InvTypeBlock | InvWitnessFlag
-	InvTypeUtreexoBlock         InvType = InvTypeBlock | InvUtreexoFlag
-	InvTypeWitnessUtreexoBlock  InvType = InvTypeBlock | InvWitnessFlag | InvUtreexoFlag
 	InvTypeWitnessTx            InvType = InvTypeTx | InvWitnessFlag
 	InvTypeUtreexoTx            InvType = InvTypeTx | InvUtreexoFlag
 	InvTypeWitnessUtreexoTx     InvType = InvTypeTx | InvWitnessFlag | InvUtreexoFlag
@@ -57,8 +55,6 @@ var ivStrings = map[InvType]string{
 	InvTypeFilteredBlock:        "MSG_FILTERED_BLOCK",
 	InvTypeUtreexoProofHash:     "MSG_UTREEXO_PROOF_HASH",
 	InvTypeWitnessBlock:         "MSG_WITNESS_BLOCK",
-	InvTypeUtreexoBlock:         "MSG_UTREEXO_BLOCK",
-	InvTypeWitnessUtreexoBlock:  "MSG_WITNESS_UTREEXO_BLOCK",
 	InvTypeWitnessTx:            "MSG_WITNESS_TX",
 	InvTypeUtreexoTx:            "MSG_UTREEXO_TX",
 	InvTypeWitnessUtreexoTx:     "MSG_WITNESS_UTREEXO_TX",

--- a/wire/invvect_test.go
+++ b/wire/invvect_test.go
@@ -22,7 +22,6 @@ func TestInvTypeStringer(t *testing.T) {
 		{InvTypeError, "ERROR"},
 		{InvTypeTx, "MSG_TX"},
 		{InvTypeBlock, "MSG_BLOCK"},
-		{InvTypeUtreexoBlock, "MSG_UTREEXO_BLOCK"},
 		{InvTypeUtreexoProofHash, "MSG_UTREEXO_PROOF_HASH"},
 		{0xffffffff, "Unknown InvType (4294967295)"},
 	}


### PR DESCRIPTION
These are outdated and was part of the old protocol. No need for them anymore