### PR TITLE
wire, indexers, blockchain: allocation cleanups

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1059,25 +1059,13 @@ func UtxoCacheInitialized(dbTx database.Tx) bool {
 // SerializeUtreexoRoots serializes the numLeaves and the roots into a byte slice.
 func SerializeUtreexoRoots(numLeaves uint64, roots []utreexo.Hash) ([]byte, error) {
 	// 8 byte NumLeaves + (32 byte roots * len(roots))
-	w := bytes.NewBuffer(make([]byte, 0, 8+(len(roots)*chainhash.HashSize)))
-
-	// Write the NumLeaves first.
-	var buf [8]byte
-	byteOrder.PutUint64(buf[:], numLeaves)
-	_, err := w.Write(buf[:])
-	if err != nil {
-		return nil, err
+	size := 8 + len(roots)*chainhash.HashSize
+	buf := make([]byte, size)
+	byteOrder.PutUint64(buf[:8], numLeaves)
+	for i, root := range roots {
+		copy(buf[8+i*chainhash.HashSize:], root[:])
 	}
-
-	// Then write the roots.
-	for _, root := range roots {
-		_, err = w.Write(root[:])
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return w.Bytes(), nil
+	return buf, nil
 }
 
 // DeserializeUtreexoRoots deserializes the provided byte slice into numLeaves and roots.

--- a/blockchain/indexers/flatfile.go
+++ b/blockchain/indexers/flatfile.go
@@ -238,31 +238,27 @@ func (ff *FlatFileState) StoreData(height int32, data []byte) error {
 			"Expected height of %d but got %d", ff.currentHeight+1, height)
 	}
 
-	// Pre-allocate the needed buffer.
-	buf := make([]byte, len(data)+8)
+	// An 8-byte stack array serves both fixed-size writes, so StoreData
+	// keeps no reusable scratch on the struct.
+	var buf [8]byte
 
-	// Slice the buffer to 8 bytes and encode the offset to it.
-	buf = buf[:8]
+	// Encode the offset and write it to the offset file.
 	ff.offsets = append(ff.offsets, ff.currentOffset)
-	binary.BigEndian.PutUint64(buf, uint64(ff.currentOffset))
-
-	// Do the actual currentOffset write to the offset file.
-	_, err := ff.offsetFile.WriteAt(buf, int64(height)*8)
-	if err != nil {
+	binary.BigEndian.PutUint64(buf[:], uint64(ff.currentOffset))
+	if _, err := ff.offsetFile.WriteAt(buf[:], int64(height)*8); err != nil {
 		return err
 	}
 
-	// Re-slice the buffer to the total length.
-	buf = buf[:len(data)+8]
-
-	// Add the magic bytes, size, and the data to the buffer to be written.
+	// Write the magic and size header, then the data itself, to the data
+	// file at adjacent offsets. FetchData reads them back as the same two
+	// pieces, and writing the data straight through avoids copying it into
+	// a combined buffer.
 	copy(buf[:4], magicBytes[:])
 	binary.BigEndian.PutUint32(buf[4:8], uint32(len(data)))
-	copy(buf[8:], data)
-
-	// Write the magic+size+data to the dataFile.
-	_, err = ff.dataFile.WriteAt(buf, ff.currentOffset)
-	if err != nil {
+	if _, err := ff.dataFile.WriteAt(buf[:], ff.currentOffset); err != nil {
+		return err
+	}
+	if _, err := ff.dataFile.WriteAt(data, ff.currentOffset+8); err != nil {
 		return err
 	}
 

--- a/blockchain/indexers/flatfile.go
+++ b/blockchain/indexers/flatfile.go
@@ -279,7 +279,14 @@ func (ff *FlatFileState) StoreData(height int32, data []byte) error {
 func (ff *FlatFileState) OverWrite(height, offset int32, data []byte) error {
 	ff.mtx.Lock()
 	defer ff.mtx.Unlock()
+	return ff.overwriteLocked(height, offset, data)
+}
 
+// overwriteLocked overwrites the given data at the height and offset. The
+// caller must hold ff.mtx. It is separate from OverWrite so a caller writing
+// many records in a row can hold the lock once across the batch instead of
+// reacquiring it for every record.
+func (ff *FlatFileState) overwriteLocked(height, offset int32, data []byte) error {
 	// If the height requsted is greater than the best height, return an error.
 	if height > ff.currentHeight || height <= 0 {
 		return fmt.Errorf("Best height is %v, can't overwrite at height %v",

--- a/blockchain/indexers/flatutreexoproofindex.go
+++ b/blockchain/indexers/flatutreexoproofindex.go
@@ -1116,13 +1116,18 @@ func writeTTLs(curHeight int32, createdIndexes []int32, lds []wire.LeafData,
 	}
 	buf := [ttlSize]byte{}
 
+	// Take the lock once for all writes instead of per-write.
+	ttlIdx.mtx.Lock()
+	defer ttlIdx.mtx.Unlock()
+
 	for i, ld := range lds {
 		byteOrder.PutUint32(buf[:uint32Size], uint32(curHeight))
 		byteOrder.PutUint32(buf[uint32Size:ttlSize], uint32(i))
 
 		cIndex := createdIndexes[i]
 		offset := cIndex * ttlSize
-		err := ttlIdx.OverWrite(ld.Height, offset, buf[:])
+
+		err := ttlIdx.overwriteLocked(ld.Height, offset, buf[:])
 		if err != nil {
 			return err
 		}
@@ -1151,39 +1156,35 @@ func (idx *FlatUtreexoProofIndex) addEmptyTTLs(height, numAdds int32) error {
 
 // storeProof serializes and stores the utreexo data in the proof state.
 func (idx *FlatUtreexoProofIndex) storeProof(height int32, ud *wire.UData) error {
-	proofBuf := bytes.NewBuffer(
-		make([]byte, 0, wire.BatchProofSerializeAccProofSize(&ud.AccProof)))
-	err := wire.ProofHashesSerialize(proofBuf, ud.AccProof.Proof)
-	if err != nil {
+	// One buffer serves all three writes. Each StoreData copies the bytes
+	// before the next serialization reuses the buffer, so no scratch is
+	// shared across calls or instances.
+	var buf bytes.Buffer
+
+	buf.Grow(wire.BatchProofSerializeAccProofSize(&ud.AccProof))
+	if err := wire.ProofHashesSerialize(&buf, ud.AccProof.Proof); err != nil {
 		return err
 	}
-
-	err = idx.proofState.StoreData(height, proofBuf.Bytes())
-	if err != nil {
+	if err := idx.proofState.StoreData(height, buf.Bytes()); err != nil {
 		return fmt.Errorf("store proof err. %v", err)
 	}
 
-	targetsBuf := bytes.NewBuffer(
-		make([]byte, 0, wire.BatchProofSerializeTargetSize(&ud.AccProof)))
-	err = wire.ProofTargetsSerialize(targetsBuf, ud.AccProof.Targets)
-	if err != nil {
+	buf.Reset()
+	buf.Grow(wire.BatchProofSerializeTargetSize(&ud.AccProof))
+	if err := wire.ProofTargetsSerialize(&buf, ud.AccProof.Targets); err != nil {
 		return err
 	}
-
-	err = idx.targetState.StoreData(height, targetsBuf.Bytes())
-	if err != nil {
+	if err := idx.targetState.StoreData(height, buf.Bytes()); err != nil {
 		return fmt.Errorf("store targets err. %v", err)
 	}
 
-	leafBuf := bytes.NewBuffer(make([]byte, 0, ud.SerializeUtxoDataSize()))
-	err = wire.SerializeUtxoData(leafBuf, ud.LeafDatas)
-	if err != nil {
+	buf.Reset()
+	buf.Grow(ud.SerializeUtxoDataSize())
+	if err := wire.SerializeUtxoData(&buf, ud.LeafDatas); err != nil {
 		return err
 	}
-
-	err = idx.leafDataState.StoreData(height, leafBuf.Bytes())
-	if err != nil {
-		return fmt.Errorf("store targets err. %v", err)
+	if err := idx.leafDataState.StoreData(height, buf.Bytes()); err != nil {
+		return fmt.Errorf("store leaf data err. %v", err)
 	}
 
 	return nil

--- a/wire/leaf.go
+++ b/wire/leaf.go
@@ -149,22 +149,84 @@ func (l *LeafData) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-var sha512DigestPool = sync.Pool{
+// leafHasherPool holds reusable LeafHashers so LeafHash can hash without
+// allocating a digest per call. Callers that hash many leaves on a single
+// goroutine should use NewLeafHasher directly to avoid the pool entirely.
+var leafHasherPool = sync.Pool{
 	New: func() interface{} {
-		return sha512.New512_256()
+		return NewLeafHasher()
 	},
 }
 
 // LeafHash concats and hashes all the data in LeafData.
 func (l *LeafData) LeafHash() [32]byte {
-	digest := sha512DigestPool.Get().(hash.Hash)
-	digest.Reset()
-	defer sha512DigestPool.Put(digest)
+	lh := leafHasherPool.Get().(*LeafHasher)
+	defer leafHasherPool.Put(lh)
+	return lh.HashLeaf(l)
+}
 
-	digest.Write(chainhash.UTREEXO_TAG_V1_APPEND[:])
-	l.Serialize(digest)
+// LeafHasher is a pre-allocated hasher for computing LeafHash without
+// sync.Pool contention. Create one per goroutine via NewLeafHasher.
+type LeafHasher struct {
+	digest hash.Hash
+	buf    [8]byte // scratch for uint32/uint64 encoding
+}
 
-	return *(*[32]byte)(digest.Sum(nil))
+// NewLeafHasher creates a LeafHasher with its own SHA-512/256 state.
+func NewLeafHasher() *LeafHasher {
+	return &LeafHasher{digest: sha512.New512_256()}
+}
+
+// HashLeaf computes the leaf hash without touching any sync.Pool.
+func (lh *LeafHasher) HashLeaf(l *LeafData) [32]byte {
+	d := lh.digest
+	d.Reset()
+
+	d.Write(chainhash.UTREEXO_TAG_V1_APPEND[:])
+
+	// Inline serialization to avoid sync.Pool in Serialize/WriteOutPoint/WriteVarInt.
+	// BlockHash (32 bytes)
+	d.Write(l.BlockHash[:])
+	// OutPoint: Hash (32 bytes) + Index (4 bytes LE)
+	d.Write(l.OutPoint.Hash[:])
+	littleEndian.PutUint32(lh.buf[:4], l.OutPoint.Index)
+	d.Write(lh.buf[:4])
+	// Header code: Height<<1 | IsCoinBase (4 bytes LE)
+	hcb := l.Height << 1
+	if l.IsCoinBase {
+		hcb |= 1
+	}
+	littleEndian.PutUint32(lh.buf[:4], uint32(hcb))
+	d.Write(lh.buf[:4])
+	// Amount (8 bytes LE)
+	littleEndian.PutUint64(lh.buf[:8], uint64(l.Amount))
+	d.Write(lh.buf[:8])
+	// PkScript: varint length + bytes
+	lh.writeVarInt(d, uint64(len(l.PkScript)))
+	d.Write(l.PkScript)
+
+	return *(*[32]byte)(d.Sum(nil))
+}
+
+// writeVarInt writes a Bitcoin-style variable-length integer directly to w.
+func (lh *LeafHasher) writeVarInt(w io.Writer, val uint64) {
+	if val < 0xfd {
+		lh.buf[0] = uint8(val)
+		w.Write(lh.buf[:1])
+	} else if val <= 0xffff {
+		lh.buf[0] = 0xfd
+		littleEndian.PutUint16(lh.buf[1:3], uint16(val))
+		w.Write(lh.buf[:3])
+	} else if val <= 0xffffffff {
+		lh.buf[0] = 0xfe
+		littleEndian.PutUint32(lh.buf[1:5], uint32(val))
+		w.Write(lh.buf[:5])
+	} else {
+		lh.buf[0] = 0xff
+		w.Write(lh.buf[:1])
+		littleEndian.PutUint64(lh.buf[:8], val)
+		w.Write(lh.buf[:8])
+	}
 }
 
 // String turns a LeafData into a string for logging.

--- a/wire/leaf_test.go
+++ b/wire/leaf_test.go
@@ -631,6 +631,15 @@ func TestLeafHash(t *testing.T) {
 				hex.EncodeToString(expect[:]),
 				hex.EncodeToString(got[:]))
 		}
+
+		// Verify LeafHasher produces the same result.
+		lh := NewLeafHasher()
+		gotHasher := lh.HashLeaf(&test.ld)
+		if gotHasher != expect {
+			t.Fatalf("LeafHasher: expect %s but got %s",
+				hex.EncodeToString(expect[:]),
+				hex.EncodeToString(gotHasher[:]))
+		}
 	}
 }
 


### PR DESCRIPTION
The minor changes here are pulled out of #413 as these are just standalone performance changes
that reduce the memory allocation.