### PR TITLE
netsync : compare header hash at assume utreexo height instead of chain tip

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -7,6 +7,7 @@ package netsync
 import (
 	"bytes"
 	"crypto/sha256"
+	"fmt"
 	"math/rand"
 	"net"
 	"os"
@@ -1236,13 +1237,11 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 
 	bestHash, bestHeight := sm.chain.BestHeader()
 	if sm.headersBuildMode && bestHeight >= sm.chain.AssumeUtreexoHeight() {
-		assumeUtreexoHash := sm.chain.AssumeUtreexoHash()
-		if !bestHash.IsEqual(&assumeUtreexoHash) {
-			log.Warnf("The node had hash %v hardcoded in but the valid proof-of-work "+
-				"chain has the hash %v at height %v. The user should not trust this "+
-				"software as genuine and there may be attempts to steal funds. The user "+
-				"should delete the datadir", sm.chain.AssumeUtreexoHash().String(),
-				bestHash.String(), bestHeight)
+		if err := sm.checkAssumeUtreexoHash(); err != nil {
+			log.Warnf("The hardcoded assume utreexo hash did not match the valid "+
+				"proof-of-work chain. The user should not trust this software as "+
+				"genuine and there may be attempts to steal funds. The user should "+
+				"delete the data dir: %v", err)
 			os.Exit(1)
 		}
 
@@ -1287,6 +1286,26 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		hmsg.peer.PushGetHeadersMsg(locator, &stopHash)
 		return
 	}
+}
+
+// checkAssumeUtreexoHash returns an error if the header hash at the assume
+// utreexo height does not match the hardcoded value in the chain params
+// or if the hash cannot be fetched.
+func (sm *SyncManager) checkAssumeUtreexoHash() error {
+	assumeHeight := sm.chain.AssumeUtreexoHeight()
+	assumeUtreexoHash := sm.chain.AssumeUtreexoHash()
+	headerHash, err := sm.chain.HeaderHashByHeight(assumeHeight)
+
+	if err != nil {
+		return fmt.Errorf("could not find header at assume utreexo height %d"+
+			"in the downloaded best proof-of-work chain: %v", assumeHeight, err)
+	}
+	if !headerHash.IsEqual(&assumeUtreexoHash) {
+		return fmt.Errorf("hardcoded assume utreexo hash %s does not match "+
+			"the valid proof-of-work chain hash %s at height %d",
+			assumeUtreexoHash, headerHash, assumeHeight)
+	}
+	return nil
 }
 
 // handleUtreexoProofMsg queues the utreexo proof and if we already have the block,

--- a/netsync/manager_test.go
+++ b/netsync/manager_test.go
@@ -87,11 +87,12 @@ func chainSetup(t *testing.T, params *chaincfg.Params) (
 
 	// Create the main chain instance.
 	chain, err := blockchain.New(&blockchain.Config{
-		DB:          db,
-		Checkpoints: paramsCopy.Checkpoints,
-		ChainParams: &paramsCopy,
-		TimeSource:  blockchain.NewMedianTime(),
-		SigCache:    txscript.NewSigCache(1000),
+		DB:                 db,
+		Checkpoints:        paramsCopy.Checkpoints,
+		ChainParams:        &paramsCopy,
+		TimeSource:         blockchain.NewMedianTime(),
+		SigCache:           txscript.NewSigCache(1000),
+		AssumeUtreexoPoint: paramsCopy.AssumeUtreexoPoint,
 	})
 	if err != nil {
 		teardown()
@@ -1297,4 +1298,64 @@ func TestBlockConnectedCleansMempool(t *testing.T) {
 	// The mempool tx must have been evicted, even though we were not current.
 	require.False(t, txPool.HaveTransaction(mempoolTx.Hash()),
 		"mempool should have removed the double-spending tx on block connect")
+}
+
+func TestCheckUtreexoHash(t *testing.T) {
+
+	tests := []struct {
+		name              string
+		numBlocks         int
+		assumepointHeight int32
+		hashFunc          func([]*btcutil.Block) *chainhash.Hash
+		wantErr           bool
+	}{
+		{
+			name:              "success: hash at assumepointHeight matches",
+			numBlocks:         5,
+			assumepointHeight: 2,
+			hashFunc:          func(b []*btcutil.Block) *chainhash.Hash { return b[1].Hash() },
+			wantErr:           false,
+		},
+		{
+			name:              "mismatch: hash at assumepointHeight differs",
+			numBlocks:         5,
+			assumepointHeight: 2,
+			hashFunc:          func(b []*btcutil.Block) *chainhash.Hash { return &chainhash.Hash{} },
+			wantErr:           true,
+		},
+		{
+			name:              "fetch error: assumeHeight not in bestHeader",
+			numBlocks:         1,
+			assumepointHeight: 10,
+			hashFunc:          func(b []*btcutil.Block) *chainhash.Hash { return &chainhash.Hash{} },
+			wantErr:           true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			//setup
+			params := chaincfg.RegressionNetParams
+			params.Checkpoints = nil
+			blocks := generateTestBlocks(t, &params, tc.numBlocks)
+			params.AssumeUtreexoPoint = chaincfg.AssumeUtreexo{
+				BlockHash:   tc.hashFunc(blocks),
+				BlockHeight: tc.assumepointHeight,
+			}
+			sm, tearDown := makeMockSyncManager(t, &params)
+			defer tearDown()
+			for _, block := range blocks {
+				_, err := sm.chain.ProcessBlockHeader(&block.MsgBlock().Header, blockchain.BFNone)
+				require.NoError(t, err)
+			}
+			//assert
+			err := sm.checkAssumeUtreexoHash()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
BestHeader() returns the tip hash of header chain, which is can be at a height pass the assume utreexo point when headers are downloaded in a single batch.
this causes a false mismatch and os.Exit(1).

BestHeader() = chain tip = 954,553
00000000000000000001c86c3e8ddbffa6a572724f66fe9df46ba84f51fe70ef

hard coded = 943,013
00000000000000000001c595730bd4a5fb0e2b35af70882962ce7ae602f48aff
