### PR TITLE
docs: completely rewrite outdated wallet, installation, and update documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,76 +1,45 @@
 # Installation
 
-The first step is to install btcd.  See one of the following sections for
-details on how to install on the supported operating systems.
+This guide covers how to build and install `utreexod` from source.
 
 ## Requirements
 
-[Go](http://golang.org) 1.11 or newer.
+- [Go](http://golang.org) 1.25 or newer.
+- [Rust](http://rust-lang.org) 1.81.0 or newer (Required if you want to compile the built-in [BDK wallet](https://bitcoindevkit.org) support).
 
-## GPG Verification Key
+## Building from Source (All Operating Systems)
 
-All official release tags are signed by Conformal so users can ensure the code
-has not been tampered with and is coming from the btcsuite developers.  To
-verify the signature perform the following:
-
-* Download the Conformal public key:
-  https://raw.githubusercontent.com/btcsuite/btcd/master/release/GIT-GPG-KEY-conformal.txt
-
-* Import the public key into your GPG keyring:
-
-  ```bash
-  gpg --import GIT-GPG-KEY-conformal.txt
-  ```
-
-* Verify the release tag with the following command where `TAG_NAME` is a
-  placeholder for the specific tag:
-
-  ```bash
-  git tag -v TAG_NAME
-  ```
-
-## Windows Installation
-
-* Install the MSI available at: [btcd windows installer](https://github.com/btcsuite/btcd/releases)
-* Launch btcd from the Start Menu
-
-## Linux/BSD/MacOSX/POSIX Installation
-
-* Install Go according to the [installation instructions](http://golang.org/doc/install)
-* Ensure Go was installed properly and is a supported version:
+1. Install Go according to the [official installation instructions](http://golang.org/doc/install).
+2. Install Rust using [rustup](https://rustup.rs/) (if you plan to use the BDK wallet).
+3. Clone the repository and navigate into it:
 
 ```bash
-go version
-go env GOROOT GOPATH
+git clone https://github.com/utreexo/utreexod
+cd utreexod
 ```
 
-NOTE: The `GOROOT` and `GOPATH` above must not be the same path.  It is
-recommended that `GOPATH` is set to a directory in your home directory such as
-`~/goprojects` to avoid write permission issues.  It is also recommended to add
-`$GOPATH/bin` to your `PATH` at this point.
+4. Build the project. You have two options depending on whether you want wallet support:
 
-* Run the following commands to obtain btcd, all dependencies, and install it:
+**To build WITH the BDK wallet (requires Rust):**
+```bash
+make all
+```
+To install the binaries directly to your `$GOPATH/bin`:
+```bash
+make install
+```
+
+**To build WITHOUT the BDK wallet (Go only):**
 
 ```bash
-git clone https://github.com/btcsuite/btcd $GOPATH/src/github.com/btcsuite/btcd
-cd $GOPATH/src/github.com/btcsuite/btcd
-GO111MODULE=on go install -v . ./cmd/...
+go build -o . ./...
 ```
-
-* btcd (and utilities) will now be installed in ```$GOPATH/bin```.  If you did
-  not already add the bin directory to your system path during Go installation,
-  we recommend you do so now.
-
-## Gentoo Linux Installation
-
-* [Install Layman](https://gitlab.com/bitcoin/gentoo) and enable the Bitcoin overlay.
-* Copy or symlink `/var/lib/layman/bitcoin/Documentation/package.keywords/btcd-live` to `/etc/portage/package.keywords/`
-* Install btcd: `$ emerge net-p2p/btcd`
 
 ## Startup
 
-Typically btcd will run and start downloading the block chain with no extra
-configuration necessary, however, there is an optional method to use a
-`bootstrap.dat` file that may speed up the initial block chain download process.
+Because `utreexod` uses a hardcoded UTXO state, the node will bootstrap almost instantly and skip the traditional initial block download. 
 
-* [Using bootstrap.dat](https://github.com/btcsuite/btcd/blob/master/docs/configuration.md#using-bootstrapdat)
+Simply run:
+```bash
+./utreexod
+```

--- a/docs/update.md
+++ b/docs/update.md
@@ -1,8 +1,20 @@
-# Update
+# Updating utreexod
 
-* Run the following commands to update btcd, all dependencies, and install it:
+To update `utreexod` and its utilities to the latest version, navigate to the directory where you cloned the repository and pull the latest changes:
 
 ```bash
-cd $GOPATH/src/github.com/btcsuite/btcd
-git pull && GO111MODULE=on go install -v . ./cmd/...
+cd utreexod
+git pull
+```
+
+Then, rebuild the binaries using the same method you used for installation:
+
+**If you are using the BDK wallet:**
+```bash
+make all
+```
+
+**If you are building without the wallet:**
+```bash
+go build -o . ./...
 ```

--- a/docs/wallet.md
+++ b/docs/wallet.md
@@ -1,5 +1,53 @@
-# Wallet
+# Wallet Integration
 
-btcd was intentionally developed without an integrated wallet for security
-reasons.  Please see [btcwallet](https://github.com/btcsuite/btcwallet) for more
-information.
+Unlike the original `btcd` project, `utreexod` comes with a built-in wallet powered by the [Bitcoin Dev Kit (BDK)](https://bitcoindevkit.org). 
+
+> [!WARNING]
+> **Experimental / Proof of Concept Only:**
+> The built-in wallet is an experimental Proof of Concept (PoC). **Do NOT use this wallet for significant amounts of Bitcoin.** On mainnet, it should only ever be used with **negligible amounts**. For testing and development, please use testnet, signet, or regtest.
+
+## Enabling and Disabling the Wallet
+
+If you compile `utreexod` with Rust installed (`make all`), the BDK wallet is automatically included and enabled by default when you start the node. 
+
+If you want to run `utreexod` purely as a node without the wallet, you can disable it by passing the `--nobdkwallet` flag:
+```bash
+./utreexod --nobdkwallet
+```
+*Note: The wallet cannot be disabled if the node was previously started with the wallet enabled in that data directory.*
+
+## Available Commands
+
+You can interact with the built-in wallet using the `utreexoctl` command-line tool. The following wallet-specific commands are available:
+
+### Wallet Management
+* `getmnemonicwords`: Displays the 24-word recovery phrase for your wallet. **Keep this safe and secret!**
+* `balance`: Returns the current total balance of the wallet.
+
+### Address Management
+* `freshaddress`: Generates a brand new receive address.
+* `unusedaddress`: Returns an address that has not received funds yet.
+* `peekaddress <index>`: Returns the address at a specific derivation index (e.g., `peekaddress 100`).
+
+### Transaction Management
+* `listbdktransactions`: Lists all transactions relevant to the wallet.
+* `listbdkutxos`: Lists all unspent transaction outputs (UTXOs) controlled by the wallet.
+* `rebroadcastunconfirmedbdktxs`: Rebroadcasts any unconfirmed transactions in the wallet.
+* `createtransactionfrombdkwallet <feerate> <recipients_json>`: Creates, signs, and broadcasts a transaction.
+
+**Transaction Examples:**
+
+*General syntax:*
+```bash
+./utreexoctl createtransactionfrombdkwallet "feerate_in_sat_per_vbyte" '[{"amount":n,"address":"value"},...]'
+```
+
+*Example 1: Sending 10,000 sats to a single address at 1 sat/vbyte:*
+```bash
+./utreexoctl createtransactionfrombdkwallet 1 '[{"amount":10000,"address":"tb1pdt9hl8ymdetdmvgk54aft8jaq4xle998m8e6adwxs4vh7vwpl9jsyadlhq"}]'
+```
+
+*Example 2: Sending to multiple addresses at 12 sats/vbyte:*
+```bash
+./utreexoctl createtransactionfrombdkwallet 12 '[{"amount":10000,"address":"tb1pdt9hl8ymdetdmvgk54aft8jaq4xle998m8e6adwxs4vh7vwpl9jsyadlhq"},{"amount":20000,"address":"tb1puuv30z568uc58c40duwl5ytyu5898fyehlyqtm0al2xk70z8tw0qcxfn6w"}]'
+```


### PR DESCRIPTION
Fixes #417 

Several documentation files contained factually incorrect information carried over from the original `btcd` project. This PR brings the documentation up to speed with how `utreexod` currently functions:

- **`wallet.md`**: Completely rewritten to document the built-in BDK wallet integration, including `--nobdkwallet` behavior and all available `utreexoctl` wallet commands.
- **`installation.md`**: Removed dead Windows MSI / Gentoo instructions. Added the Rust 1.81.0 requirement and updated build instructions to use `make all` vs `go build`.
- **`update.md`**: Corrected the update process to reflect the new repository and `make all` workflow.