### PR TITLE
log: disable automatic log rotation pruning

### DIFF
--- a/log.go
+++ b/log.go
@@ -131,7 +131,7 @@ func initLogRotator(logFile string) {
 		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
 		os.Exit(1)
 	}
-	r, err := rotator.New(logFile, 10*1024, false, 3)
+	r, err := rotator.New(logFile, 10*1024, false, 0)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
It's annoying that logs are deleted when these are pretty valuable.