### PR TITLE
main, utreexoctl: preserve semantic version separators

### DIFF
--- a/cmd/utreexoctl/version.go
+++ b/cmd/utreexoctl/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // semanticAlphabet
-const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-."
 
 // These constants define the application version and follow the semantic
 // versioning 2.0.0 spec (http://semver.org/).

--- a/cmd/utreexoctl/version_test.go
+++ b/cmd/utreexoctl/version_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import "testing"
+
+// TestNormalizeVerString ensures valid semantic version separators are
+// preserved, and that characters outside the semantic alphabet are still
+// filtered out.
+func TestNormalizeVerString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			// Dotted pre-release identifier.
+			name: "dotted pre-release identifier",
+			in:   "beta.rc1",
+			want: "beta.rc1",
+		},
+		{
+			// Dotted build metadata, which appBuild may be set to
+			// via -ldflags at build time.
+			name: "dotted build metadata",
+			in:   "exp.sha.5114f85",
+			want: "exp.sha.5114f85",
+		},
+		{
+			// Guards against the filter being dropped entirely:
+			// an identity function satisfies the cases above.
+			name: "character outside the alphabet",
+			in:   "beta!rc1",
+			want: "betarc1",
+		},
+	}
+
+	for _, test := range tests {
+		got := normalizeVerString(test.in)
+		if got != test.want {
+			t.Fatalf("%s: unexpected normalized version: got %q, "+
+				"want %q", test.name, got, test.want)
+		}
+	}
+}

--- a/version.go
+++ b/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // semanticAlphabet
-const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-."
 
 // These constants define the application version and follow the semantic
 // versioning 2.0.0 spec (http://semver.org/).

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 The utreexo developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import "testing"
+
+// TestNormalizeVerString ensures valid semantic version separators are
+// preserved, and that characters outside the semantic alphabet are still
+// filtered out.
+func TestNormalizeVerString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			// Dotted pre-release identifier.
+			name: "dotted pre-release identifier",
+			in:   "beta.rc1",
+			want: "beta.rc1",
+		},
+		{
+			// Dotted build metadata, which appBuild may be set to
+			// via -ldflags at build time.
+			name: "dotted build metadata",
+			in:   "exp.sha.5114f85",
+			want: "exp.sha.5114f85",
+		},
+		{
+			// Guards against the filter being dropped entirely:
+			// an identity function satisfies the cases above.
+			name: "character outside the alphabet",
+			in:   "beta!rc1",
+			want: "betarc1",
+		},
+	}
+
+	for _, test := range tests {
+		got := normalizeVerString(test.in)
+		if got != test.want {
+			t.Fatalf("%s: unexpected normalized version: got %q, "+
+				"want %q", test.name, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
`semanticAlphabet` leaves out the period, so `normalizeVerString` strips periods out of the version string.

SemVer uses the period to separate pre-release identifiers and build metadata, so `beta.rc1` comes back as `betarc1`.

That is reachable, not just theoretical. `appBuild` is settable at build time with `-ldflags`, and dot-separated build metadata like `exp.sha.5114f85` is the example the spec itself uses. A binary stamped that way reports `+expsha5114f85` today, so the metadata no longer round-trips.

`version.go` and `cmd/utreexoctl/version.go` each carry their own copy of the constant, so there is one commit per package, each with the fix and a test for that package.

The test covers the two separator cases plus an input holding a character that is not in the alphabet (`beta!rc1` gives `betarc1`), so it fails if the filtering is dropped and not only if the period is.

btcd fixed the same bug in its copy in [65db493](https://github.com/btcsuite/btcd/commit/65db49397a59fb10fd5a954df19bda33ce4e5e5d).

`go build ./...`, `go test`, `gofmt` and `go vet` are clean at both commits.

Developed with assistance from AI.
