### PR TITLE
indexers: fix flatfile recovery and durability

### DIFF
--- a/blockchain/indexers/flatfile.go
+++ b/blockchain/indexers/flatfile.go
@@ -86,6 +86,14 @@ func (ff *FlatFileState) recover() error {
 			if err == nil && uint32(read) == size {
 				_, err := ff.FetchData(ff.currentHeight)
 				if err == nil {
+					// The next write must start immediately after the last
+					// readable record.  In particular, do not retain the offset
+					// from a corrupt entry that was removed below.
+					ff.currentOffset = offset + 8 + int64(size)
+					if err := ff.dataFile.Truncate(ff.currentOffset); err != nil {
+						return err
+					}
+
 					// If we're able to read the data bytes, then return here.
 					return nil
 				}
@@ -115,14 +123,14 @@ func (ff *FlatFileState) recover() error {
 			return err
 		}
 
-		// Set the currentOffset as the last offset.
-		ff.currentOffset = ff.offsets[len(ff.offsets)-1]
-
 		// Pop the offset in memory.
 		ff.offsets = ff.offsets[:len(ff.offsets)-1]
 	}
 
-	return nil
+	// No record survived. Reset the append cursor as well as the file so a
+	// subsequent store cannot leave a hole at the beginning of the index.
+	ff.currentOffset = 0
+	return ff.dataFile.Truncate(0)
 }
 
 // Init initializes the FlatFileState.  If resuming, it loads the offsets onto memory.
@@ -242,13 +250,6 @@ func (ff *FlatFileState) StoreData(height int32, data []byte) error {
 	// keeps no reusable scratch on the struct.
 	var buf [8]byte
 
-	// Encode the offset and write it to the offset file.
-	ff.offsets = append(ff.offsets, ff.currentOffset)
-	binary.BigEndian.PutUint64(buf[:], uint64(ff.currentOffset))
-	if _, err := ff.offsetFile.WriteAt(buf[:], int64(height)*8); err != nil {
-		return err
-	}
-
 	// Write the magic and size header, then the data itself, to the data
 	// file at adjacent offsets. FetchData reads them back as the same two
 	// pieces, and writing the data straight through avoids copying it into
@@ -261,6 +262,16 @@ func (ff *FlatFileState) StoreData(height int32, data []byte) error {
 	if _, err := ff.dataFile.WriteAt(data, ff.currentOffset+8); err != nil {
 		return err
 	}
+
+	// Publish the offset only after the complete framed record has been
+	// written. This avoids publishing a record after a failed data write.
+	// Write ordering alone does not guarantee persistence ordering; callers
+	// must also sync the files at their durability boundary.
+	binary.BigEndian.PutUint64(buf[:], uint64(ff.currentOffset))
+	if _, err := ff.offsetFile.WriteAt(buf[:], int64(height)*8); err != nil {
+		return err
+	}
+	ff.offsets = append(ff.offsets, ff.currentOffset)
 
 	// Increment the current offset.  +8 to account for the magic bytes and size.
 	ff.currentOffset += int64(len(data)) + 8
@@ -291,9 +302,32 @@ func (ff *FlatFileState) overwriteLocked(height, offset int32, data []byte) erro
 
 	// Grab the offset for where the data is in the dataFile.
 	fOffset := ff.offsets[height]
+	// Only the first stored record can start at byte zero. Reject a zero
+	// offset for later heights so a corrupt lookup cannot overwrite it.
+	if fOffset < 0 || (height > 1 && fOffset == 0) {
+		return fmt.Errorf("cannot overwrite height %d: invalid record offset %d", height, fOffset)
+	}
+	// Validate the destination's framing before using its declared payload
+	// size to bound the write.
+	header := make([]byte, 8)
+	_, err := ff.dataFile.ReadAt(header, fOffset)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(header[:4], magicBytes[:]) {
+		return fmt.Errorf("cannot overwrite height %d: read wrong magic of %x",
+			height, header[:4])
+	}
+	// Keep the entire write inside the payload; an unchecked TTL offset could
+	// otherwise overwrite this record's header or the following record.
+	recordSize := int64(binary.BigEndian.Uint32(header[4:]))
+	if offset < 0 || int64(offset)+int64(len(data)) > recordSize {
+		return fmt.Errorf("overwrite outside height %d record: offset %d, size %d, record size %d",
+			height, offset, len(data), recordSize)
+	}
 	writeOffset := fOffset + 8 + int64(offset)
 
-	_, err := ff.dataFile.WriteAt(data, writeOffset)
+	_, err = ff.dataFile.WriteAt(data, writeOffset)
 	return err
 }
 

--- a/blockchain/indexers/flatfile.go
+++ b/blockchain/indexers/flatfile.go
@@ -443,6 +443,17 @@ func (ff *FlatFileState) BestHeight() int32 {
 	return ff.currentHeight
 }
 
+// Sync flushes record data before its offset table. Callers must coordinate
+// external database commits separately; this is not a multi-file transaction.
+func (ff *FlatFileState) Sync() error {
+	ff.mtx.Lock()
+	defer ff.mtx.Unlock()
+	if err := ff.dataFile.Sync(); err != nil {
+		return err
+	}
+	return ff.offsetFile.Sync()
+}
+
 // deleteFileFile removes the flat file state directory and all the contents
 // in it.
 func deleteFlatFile(path string) error {

--- a/blockchain/indexers/flatfile_test.go
+++ b/blockchain/indexers/flatfile_test.go
@@ -959,3 +959,130 @@ func TestOverWrite(t *testing.T) {
 		}
 	}
 }
+
+// TestRecoverResetsCurrentOffset truncates the second record's header and
+// reopens the index. Recovery must position the next write at the end of the
+// surviving first record, which must remain intact after storing a replacement.
+func TestRecoverResetsCurrentOffset(t *testing.T) {
+	dir := t.TempDir()
+	ff := NewFlatFileState()
+	if err := ff.Init(dir, "recover-offset"); err != nil {
+		t.Fatal(err)
+	}
+
+	first := []byte("first record remains intact")
+	second := []byte("second record is truncated")
+	if err := ff.StoreData(1, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := ff.StoreData(2, second); err != nil {
+		t.Fatal(err)
+	}
+	firstEnd := int64(8 + len(first))
+	if err := ff.dataFile.Truncate(firstEnd + 4); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened := NewFlatFileState()
+	if err := reopened.Init(dir, "recover-offset"); err != nil {
+		t.Fatal(err)
+	}
+	if reopened.currentHeight != 1 {
+		t.Fatalf("recovered height: got %d, want 1", reopened.currentHeight)
+	}
+	if reopened.currentOffset != firstEnd {
+		t.Fatalf("recovered offset: got %d, want %d", reopened.currentOffset, firstEnd)
+	}
+
+	replacement := []byte("replacement second record")
+	if err := reopened.StoreData(2, replacement); err != nil {
+		t.Fatal(err)
+	}
+	got, err := reopened.FetchData(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, first, got)
+}
+
+// TestOverWriteRejectsRecordBoundary attempts a write that starts inside the
+// first record's payload but extends into the next record's header. The write
+// must fail and leave the next record readable and unchanged.
+func TestOverWriteRejectsRecordBoundary(t *testing.T) {
+	dir := t.TempDir()
+	ff := NewFlatFileState()
+	if err := ff.Init(dir, "overwrite-boundary"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ff.StoreData(1, make([]byte, 8)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ff.StoreData(2, []byte("next record")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ff.OverWrite(1, 4, make([]byte, 8))
+	if err == nil {
+		t.Fatal("expected overwrite crossing the record boundary to fail")
+	}
+	got, fetchErr := ff.FetchData(2)
+	if fetchErr != nil {
+		t.Fatal(fetchErr)
+	}
+	require.Equal(t, []byte("next record"), got)
+}
+
+// TestRecoverEmptyThenAppend truncates the only record so recovery removes it.
+// The next store must start at byte zero and be readable through its new offset.
+func TestRecoverEmptyThenAppend(t *testing.T) {
+	dir := t.TempDir()
+	ff := NewFlatFileState()
+	require.NoError(t, ff.Init(dir, "empty"))
+	require.NoError(t, ff.StoreData(1, []byte("incomplete")))
+	require.NoError(t, ff.dataFile.Truncate(4))
+	require.NoError(t, ff.dataFile.Close())
+	require.NoError(t, ff.offsetFile.Close())
+
+	ff = NewFlatFileState()
+	require.NoError(t, ff.Init(dir, "empty"))
+	t.Cleanup(func() { ff.dataFile.Close(); ff.offsetFile.Close() })
+	require.Equal(t, int32(0), ff.BestHeight())
+	require.Equal(t, int64(0), ff.currentOffset)
+	require.NoError(t, ff.StoreData(1, []byte("replacement")))
+	require.Equal(t, int64(0), ff.offsets[1])
+	got, err := ff.FetchData(1)
+	require.NoError(t, err)
+	require.Equal(t, []byte("replacement"), got)
+}
+
+// TestOverWriteRejectsZeroOffset redirects the second record's offset to the
+// first record. Even though the destination has valid framing and enough room,
+// the write must fail without changing the first record's payload.
+func TestOverWriteRejectsZeroOffset(t *testing.T) {
+	ff := NewFlatFileState()
+	require.NoError(t, ff.Init(t.TempDir(), "zero-offset"))
+	t.Cleanup(func() { ff.dataFile.Close(); ff.offsetFile.Close() })
+	require.NoError(t, ff.StoreData(1, []byte("original")))
+	require.NoError(t, ff.StoreData(2, make([]byte, 8)))
+	ff.offsets[2] = 0
+	require.Error(t, ff.OverWrite(2, 0, []byte("corrupt!")))
+	got, err := ff.FetchData(1)
+	require.NoError(t, err)
+	require.Equal(t, []byte("original"), got)
+}
+
+// TestStoreFailureDoesNotPublishOffset closes the data file to force a store
+// failure. Neither the offset table nor the in-memory height and offsets may
+// advance to reference the unwritten record.
+func TestStoreFailureDoesNotPublishOffset(t *testing.T) {
+	ff := NewFlatFileState()
+	require.NoError(t, ff.Init(t.TempDir(), "failed-store"))
+	t.Cleanup(func() { ff.offsetFile.Close() })
+	require.NoError(t, ff.dataFile.Close())
+	require.Error(t, ff.StoreData(1, []byte("unwritten")))
+	require.Equal(t, int32(0), ff.BestHeight())
+	require.Len(t, ff.offsets, 1)
+	info, err := ff.offsetFile.Stat()
+	require.NoError(t, err)
+	require.Equal(t, int64(8), info.Size())
+}

--- a/blockchain/indexers/utreexobackend.go
+++ b/blockchain/indexers/utreexobackend.go
@@ -200,6 +200,23 @@ func (idx *FlatUtreexoProofIndex) Flush(bestHash *chainhash.Hash, mode blockchai
 	}
 
 	if onConnect {
+		// Sync flat records before this explicit main database flush. This does
+		// not cover independent database flushes or make the files transactional.
+		states := []*FlatFileState{
+			&idx.undoState,
+			&idx.proofStatsState,
+			&idx.rootsState,
+		}
+		if !idx.config.Pruned {
+			states = append(states, &idx.targetState, &idx.proofState,
+				&idx.leafDataState, &idx.ttlState)
+		}
+		for _, state := range states {
+			if err := state.Sync(); err != nil {
+				return err
+			}
+		}
+
 		// Flush the main database first. This is because the block and other data may still
 		// be in the database cache. If we flush the utreexo state before, there's no way to
 		// undo the utreexo state to the last block where the main database flushed. Flushing

--- a/blockchain/indexers/utreexobackend_test.go
+++ b/blockchain/indexers/utreexobackend_test.go
@@ -5,13 +5,94 @@
 package indexers
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/utreexo/utreexo"
+	"github.com/utreexo/utreexod/blockchain"
 	"github.com/utreexo/utreexod/chaincfg"
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
 )
+
+// TestFlatFlushBeforeMainDB checks that Flush reaches the main database when
+// flat-file syncing succeeds, but stops before it when a flat-file sync fails.
+// Both archive and pruned indexes must work; pruned indexes have fewer files.
+func TestFlatFlushBeforeMainDB(t *testing.T) {
+	modes := []struct {
+		name   string
+		pruned bool
+	}{
+		{name: "archive", pruned: false},
+		{name: "pruned", pruned: true},
+	}
+	cases := []struct {
+		name          string
+		closeRootFile bool
+	}{
+		{name: "flat_files_sync_successfully", closeRootFile: false},
+		{name: "flat_file_sync_fails", closeRootFile: true},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			for _, test := range cases {
+				t.Run(test.name, func(t *testing.T) {
+					// Record whether Flush reaches the main database. Return a
+					// recognizable error to stop there: this test does not set up
+					// the forest that Flush would otherwise persist next.
+					stopAtMainDB := errors.New("stop after reaching the main database")
+					mainDBFlushCalled := false
+					flushMainDB := func() error {
+						mainDBFlushCalled = true
+						return stopAtMainDB
+					}
+
+					// Each case gets its own index and files.
+					idx, err := NewFlatUtreexoProofIndex(mode.pruned,
+						&chaincfg.MainNetParams, 0, t.TempDir(), flushMainDB)
+					require.NoError(t, err)
+					files := []*FlatFileState{
+						&idx.undoState,
+						&idx.rootsState,
+						&idx.proofStatsState,
+					}
+					if !mode.pruned {
+						files = append(files, &idx.targetState, &idx.proofState,
+							&idx.leafDataState, &idx.ttlState)
+					}
+					t.Cleanup(func() {
+						for _, file := range files {
+							file.dataFile.Close()
+							file.offsetFile.Close()
+						}
+					})
+
+					// Syncing a closed file must fail. This simulates a storage
+					// error before the main database can be flushed.
+					if test.closeRootFile {
+						require.NoError(t, idx.rootsState.dataFile.Close())
+					}
+
+					// Force a flush as if we had just connected a block.
+					err = idx.Flush(chaincfg.MainNetParams.GenesisHash,
+						blockchain.FlushRequired, true)
+
+					if test.closeRootFile {
+						require.Error(t, err)
+						require.NotErrorIs(t, err, stopAtMainDB)
+						require.False(t, mainDBFlushCalled,
+							"a flat-file sync failure must stop the main database flush")
+					} else {
+						require.True(t, mainDBFlushCalled,
+							"successful flat-file syncing must allow the main database flush")
+						require.ErrorIs(t, err, stopAtMainDB)
+					}
+				})
+			}
+		})
+	}
+}
 
 func TestReadConsistencyHash(t *testing.T) {
 	dbPath := t.TempDir()


### PR DESCRIPTION
• This came out of recovering a corrupted flat proof index on my bridge node. There were zero offsets at one height, and TTL writes through those offsets ended up overwriting historical record headers.

  This fixes a few things that made that possible:
  - Reset the write offset correctly after recovery, including when no records survive.
  - Write the data before publishing its offset.
  - Check the record header, offset, and bounds before overwriting TTLs.
  - Sync the flat files before the explicit main DB flush. Skip archive-only files on pruned nodes.

  Added regression tests for these cases. `go test ./blockchain/... -count=1` passes.

  This isn't a complete crash-consistency fix yet. The flat files and main DB still aren't committed atomically, and independent DB flushes and disconnects need more work.