### PR TITLE
blockchain: publish connected state before index flush

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -776,14 +776,6 @@ func (b *BlockChain) connectBlock(node *blockNode, block *btcutil.Block,
 		return err
 	}
 
-	// Flush the indexes if they need to be flushed.
-	if b.indexManager != nil {
-		err := b.indexManager.Flush(&state.Hash, FlushIfNeeded, true)
-		if err != nil {
-			return err
-		}
-	}
-
 	// Prune fully spent entries and mark all entries in the view unmodified
 	// now that the modifications have been committed to the database.
 	if view != nil {
@@ -802,12 +794,26 @@ func (b *BlockChain) connectBlock(node *blockNode, block *btcutil.Block,
 	b.stateSnapshot = state
 	b.stateLock.Unlock()
 
+	// Flush while holding the chain lock so the indexes still correspond to
+	// state.Hash. Save any error until after notifying subscribers because
+	// the block is already committed and published.
+	// TODO: Determine which index flush errors can be retried safely and
+	// which require stopping block processing.
+	var flushErr error
+	if b.indexManager != nil {
+		flushErr = b.indexManager.Flush(&state.Hash, FlushIfNeeded, true)
+	}
+
 	// Notify the caller that the block was connected to the main chain.
 	// The caller would typically want to react with actions such as
 	// updating wallets.
 	b.chainLock.Unlock()
 	b.sendNotification(NTBlockConnected, block)
 	b.chainLock.Lock()
+
+	if flushErr != nil {
+		return flushErr
+	}
 
 	// Don't try to flush the utxo set if we're a utreexo node.
 	if b.utreexoView == nil {

--- a/blockchain/indexers/indexers_test.go
+++ b/blockchain/indexers/indexers_test.go
@@ -3,6 +3,7 @@ package indexers
 import (
 	"bytes"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -1385,6 +1386,99 @@ func TestTTLs(t *testing.T) {
 
 	checkTTLRoots(t, maxHeight, expectedStumps, indexes)
 	checkTTLsAfterUndo(t, expectAfterUndoTTLs, indexes, chain)
+}
+
+// TestIndexFlushFailurePreservesConnectedState checks that a committed block
+// stays connected and is notified even when flushing its indexes fails.
+func TestIndexFlushFailurePreservesConnectedState(t *testing.T) {
+	// Boilerplate setup: create a chain with a utreexo proof index.
+	setup := func(t *testing.T) (*blockchain.BlockChain, *UtreexoProofIndex, *btcutil.Block) {
+		t.Helper()
+		params := chaincfg.RegressionNetParams
+
+		dbPath := t.TempDir()
+		db, err := database.Create(testDbType, dbPath, blockDataNet)
+		require.NoError(t, err)
+		t.Cleanup(func() { db.Close() })
+
+		// A one byte cache budget makes each block require an index flush.
+		idx, err := NewUtreexoProofIndex(db, false, 1, &params, dbPath, db.Flush)
+		require.NoError(t, err)
+		chain, err := blockchain.New(&blockchain.Config{
+			DB:               db,
+			ChainParams:      &params,
+			TimeSource:       blockchain.NewMedianTime(),
+			SigCache:         txscript.NewSigCache(1000),
+			UtxoCacheMaxSize: 10 * 1024 * 1024,
+			IndexManager:     NewManager(db, []Indexer{idx}),
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { idx.CloseUtreexoState() })
+
+		prev := btcutil.NewBlock(params.GenesisBlock)
+		prev.SetHeight(0)
+		block, _ := blockchain.NewBlock(chain, prev, nil)
+		return chain, idx, block
+	}
+
+	tests := []struct {
+		name  string
+		setup func(*testing.T) (*blockchain.BlockChain, *UtreexoProofIndex, *btcutil.Block)
+		err   error
+	}{
+		{name: "flush error", setup: setup, err: errors.New("index flush failure")},
+		{name: "database corruption", setup: setup, err: database.Error{
+			ErrorCode: database.ErrCorruption, Description: "index corruption",
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			chain, idx, block := test.setup(t)
+
+			// Test setup: check connected state and inject a flush failure.
+			var notifications []blockchain.NotificationType
+			chain.Subscribe(func(notification *blockchain.Notification) {
+				notifications = append(notifications, notification.Type)
+			})
+			checkState := func() {
+				t.Helper()
+
+				// The snapshot and main chain must already reflect the committed block.
+				state := chain.BestSnapshot()
+				require.Equal(t, *block.Hash(), state.Hash)
+				require.Equal(t, block.Height(), state.Height)
+				require.True(t, chain.MainChainHasBlock(block.Hash()))
+
+				// The indexer tip in the database must match the published snapshot.
+				var tipHash *chainhash.Hash
+				var tipHeight int32
+				err := idx.db.View(func(dbTx database.Tx) error {
+					var err error
+					tipHash, tipHeight, err = dbFetchIndexerTip(dbTx, idx.Key())
+					return err
+				})
+				require.NoError(t, err)
+				require.Equal(t, state.Hash, *tipHash)
+				require.Equal(t, state.Height, tipHeight)
+			}
+			idx.config.FlushMainDB = func() error {
+				checkState()
+				require.Empty(t, notifications)
+				return test.err
+			}
+
+			// Test: the flush error reaches the caller after the committed
+			// block's state and notification are published.
+			_, _, err := chain.ProcessBlock(block, blockchain.BFNone)
+			require.Equal(t, test.err, err)
+			checkState()
+
+			// Subscribers must receive NTBlockConnected before the flush error is returned.
+			require.Equal(t, []blockchain.NotificationType{
+				blockchain.NTBlockConnected,
+			}, notifications)
+		})
+	}
 }
 
 func TestBridgeNodeSSTableFlush(t *testing.T) {


### PR DESCRIPTION
An index flush can fail after the best-chain transaction commits. Publish the chain tip and snapshot and deliver NTBlockConnected before flushing indexes so the committed block remains visible on failure.

Return the original flush error to the caller. Test state publication, notification delivery, and error propagation for index flush failures and database corruption.