### PR TITLE
blockchain: validate utreexo TTL count

### DIFF
--- a/blockchain/utreexoviewpoint.go
+++ b/blockchain/utreexoviewpoint.go
@@ -57,6 +57,12 @@ func (uview *UtreexoViewpoint) ProcessUData(block *btcutil.Block,
 
 	ttls := block.UtreexoTTLs()
 	if ttls != nil {
+		// Check the count before spent additions change the aggregator.
+		if len(ttls.TTLs) != len(adds) {
+			return fmt.Errorf("block has %d accumulator additions but %d ttls",
+				len(adds), len(ttls.TTLs))
+		}
+
 		// Generate the addHashes. Add empty hashes if the utxo has already been
 		// spent.
 		addHashes := make([]utreexo.Hash, len(adds))

--- a/blockchain/utreexoviewpoint_test.go
+++ b/blockchain/utreexoviewpoint_test.go
@@ -10,8 +10,59 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/utreexo/utreexo"
+	"github.com/utreexo/utreexod/btcutil"
+	"github.com/utreexo/utreexod/txscript"
 	"github.com/utreexo/utreexod/wire"
 )
+
+func TestProcessUDataTTLCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ttls    []wire.TTLInfo
+		wantErr bool
+	}{
+		{name: "empty", wantErr: true},
+		{name: "too few", ttls: []wire.TTLInfo{{DeathHeight: 2}}, wantErr: true},
+		{name: "too many", ttls: []wire.TTLInfo{{DeathHeight: 2}, {}, {}}, wantErr: true},
+		{name: "matching count", ttls: []wire.TTLInfo{{DeathHeight: 2}, {}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Setup: a coinbase with two accumulator additions.
+			block := btcutil.NewBlock(&wire.MsgBlock{
+				Transactions: []*wire.MsgTx{{
+					TxIn: []*wire.TxIn{{PreviousOutPoint: wire.OutPoint{Index: wire.MaxPrevOutIndex}}},
+					TxOut: []*wire.TxOut{
+						{Value: 1, PkScript: []byte{txscript.OP_TRUE}},
+						{Value: 2, PkScript: []byte{txscript.OP_TRUE}},
+					},
+				}},
+			})
+			block.SetHeight(1)
+			block.SetUtreexoTTLs(&wire.UtreexoTTL{BlockHeight: 1, TTLs: test.ttls})
+			view := NewUtreexoViewpoint()
+			view.accumulator = *utreexo.InitWithStump(utreexo.Stump{
+				Roots: []utreexo.Hash{{1}}, NumLeaves: 1,
+			})
+			view.agg.InitFromBytes([64]byte{1})
+			before := view.CopyWithRoots()
+
+			// A mismatched count must be rejected before changing either
+			// the accumulator or the aggregator for the spent addition.
+			err := view.ProcessUData(block, nil, &wire.UData{})
+			if test.wantErr {
+				require.Error(t, err)
+				require.Equal(t, before.accumulator.GetStump(), view.accumulator.GetStump())
+				require.Equal(t, before.agg, view.agg)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, uint64(3), view.NumLeaves())
+		})
+	}
+}
 
 func TestChainTipProofSerialize(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
ProcessUData uses one TTL for each accumulator addition. Reject count mismatches before updating the accumulator or aggregator.

Cover empty, short, extra, and matching TTL data. Check that rejected counts preserve both states.

Validation: go test ./blockchain ./netsync