### PR TITLE
blockchain: store blocks and utreexo proofs atomically

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -46,6 +46,20 @@ func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags)
 		return false, err
 	}
 
+	// Get the block node before validating the proof since side-chain proof
+	// validation needs the node's ancestry.
+	node := b.index.LookupNode(block.Hash())
+	isNewNode := node == nil
+	if isNewNode {
+		node = newBlockNode(&block.MsgBlock().Header, prevNode)
+	}
+
+	// Validate before storage because the proof store is write-once per hash.
+	err = b.checkUtreexoContext(node, block)
+	if err != nil {
+		return false, err
+	}
+
 	// Insert the block into the database if it's not already there.  Even
 	// though it is possible the block will ultimately fail to connect, it
 	// has already passed all proof-of-work and validity tests which means
@@ -56,24 +70,22 @@ func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags)
 	// such as making blocks that never become part of the main chain or
 	// blocks that fail to connect available for further analysis.
 	err = b.db.Update(func(dbTx database.Tx) error {
-		return dbStoreBlock(dbTx, block)
+		if err := dbStoreBlock(dbTx, block); err != nil {
+			return err
+		}
+		if b.utreexoView != nil {
+			return dbStoreUtreexoProof(dbTx, block)
+		}
+		return nil
 	})
 	if err != nil {
 		return false, err
 	}
 
-	// Check to see if we already have the blocknode in our index.
-	node := b.index.LookupNode(block.Hash())
-	if node == nil {
-		// Create a new block node for the block and add it to the node index. Even
-		// if the block ultimately gets connected to the main chain, it starts out
-		// on a side chain.
-		blockHeader := &block.MsgBlock().Header
-		newNode := newBlockNode(blockHeader, prevNode)
-		newNode.status = statusDataStored
-
-		b.index.AddNode(newNode)
-		node = newNode
+	if isNewNode {
+		// Add the block node only after its data is stored.
+		node.status = statusDataStored
+		b.index.AddNode(node)
 	} else {
 		// If we already have it, then just set the status as data stored.
 		b.index.SetStatusFlags(node, statusDataStored)

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1431,8 +1431,9 @@ func (b *BlockChain) verifyReorganizationValidity(detachNodes, attachNodes *list
 	return detachBlocks, attachBlocks, detachSpentTxOuts, nil
 }
 
-// storeUtreexoProof persists the proof attached to block.
-func (b *BlockChain) storeUtreexoProof(block *btcutil.Block) error {
+// dbStoreUtreexoProof uses the caller's transaction so the block and proof are
+// committed together.
+func dbStoreUtreexoProof(dbTx database.Tx, block *btcutil.Block) error {
 	ud := block.UtreexoData()
 	if ud == nil {
 		return AssertError(fmt.Sprintf("no utreexo proof for block %s",
@@ -1443,9 +1444,7 @@ func (b *BlockChain) storeUtreexoProof(block *btcutil.Block) error {
 	if err := ud.Serialize(&buf); err != nil {
 		return err
 	}
-	return b.db.Update(func(dbTx database.Tx) error {
-		return dbTx.StoreUtreexoProof(block.Hash(), buf.Bytes())
-	})
+	return dbTx.StoreUtreexoProof(block.Hash(), buf.Bytes())
 }
 
 // reconstructUtreexoViewForParent returns the accumulator state immediately
@@ -1525,6 +1524,40 @@ func (b *BlockChain) reconstructUtreexoViewForParent(node *blockNode,
 	}
 
 	return workView, nil
+}
+
+// checkUtreexoContext validates the block's utreexo data against its parent's
+// accumulator state.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) checkUtreexoContext(node *blockNode,
+	block *btcutil.Block) error {
+
+	if b.utreexoView == nil {
+		return nil
+	}
+
+	ttls := block.UtreexoTTLs()
+	if ttls != nil {
+		addCount := len(ExtractAccumulatorAdds(block))
+		if len(ttls.TTLs) != addCount {
+			return fmt.Errorf("block has %d accumulator additions but %d ttls",
+				addCount, len(ttls.TTLs))
+		}
+	}
+
+	// A side-chain proof must be checked against its parent's accumulator
+	// state, which is reconstructed from the fork point.
+	if node.parent != b.bestChain.Tip() {
+		return b.validateUtreexoProof(node, block)
+	}
+	if ttls != nil {
+		// TTL processing needs valid leaf data even though it skips proof
+		// verification.
+		_, err := ExtractAccumulatorDels(block, b.bestChain)
+		return err
+	}
+	return b.utreexoView.VerifyUData(block, b.bestChain, block.UtreexoData())
 }
 
 // validateUtreexoProof verifies and applies the proof attached to block against
@@ -1614,31 +1647,6 @@ func (b *BlockChain) connectBestChain(node *blockNode, block *btcutil.Block, fla
 
 		stxos := make([]SpentTxOut, 0, countSpentOutputs(block))
 		if b.utreexoView != nil {
-			if fastAdd {
-				// Only attempt to verify the udata if we don't have utreexo ttls.
-				// If we have ttls, it means that we're still on the swiftsync part
-				// of the ibd and we do not need to verify the proof as we don't
-				// perform deletions.
-				if block.UtreexoTTLs() == nil {
-					// Check that the block txOuts are valid by checking the utreexo proof and
-					// the leaf data.
-					err := b.utreexoView.VerifyUData(block, b.bestChain, block.UtreexoData())
-					if err != nil {
-						return false, fmt.Errorf("connectBestChain fail on block %s. "+
-							"Error: %v", block.Hash().String(), err)
-					}
-				}
-			}
-
-			// Persist the proof before updating the accumulator so a
-			// persistence failure leaves the in-memory state unchanged.  The
-			// proof has already passed the applicable validation above.
-			if block.UtreexoData() != nil {
-				if err := b.storeUtreexoProof(block); err != nil {
-					return false, err
-				}
-			}
-
 			// Update the accumulator.
 			err := b.utreexoView.ProcessUData(block, b.bestChain, block.UtreexoData())
 			if err != nil {
@@ -1695,19 +1703,6 @@ func (b *BlockChain) connectBestChain(node *blockNode, block *btcutil.Block, fla
 	if fastAdd {
 		log.Warnf("fastAdd set in the side chain case? %v\n",
 			block.Hash())
-	}
-
-	// Validate and store the proof before the work comparison so a
-	// reorganization can load it for every block it attaches.
-	if b.utreexoView != nil && block.UtreexoData() != nil {
-		err := b.validateUtreexoProof(node, block)
-		if err != nil {
-			return false, err
-		}
-		err = b.storeUtreexoProof(block)
-		if err != nil {
-			return false, err
-		}
 	}
 
 	// We're extending (or creating) a side chain, but the cumulative

--- a/blockchain/reorg_test.go
+++ b/blockchain/reorg_test.go
@@ -260,100 +260,21 @@ func assertStoredUtreexoProof(t *testing.T, chain *BlockChain,
 	require.NoError(t, err, "FetchUtreexoProof")
 }
 
-// assertNoStoredUtreexoProof ensures the block has no proof in the store.
-func assertNoStoredUtreexoProof(t *testing.T, chain *BlockChain,
-	block *btcutil.Block) {
-
-	t.Helper()
-
-	err := chain.db.View(func(dbTx database.Tx) error {
-		proof, err := dbTx.FetchUtreexoProof(block.Hash())
-		if err != nil {
-			return err
-		}
-		require.Nil(t, proof, "stored utreexo proof for %s",
-			block.Hash())
-		return nil
-	})
-	require.NoError(t, err, "FetchUtreexoProof")
-}
-
-// TestStoreUtreexoProof ensures attached proofs are stored and missing ones are
-// rejected.
-func TestStoreUtreexoProof(t *testing.T) {
-	chain, params, _, tearDown := countingUtreexoTestChain(t,
-		"store-proof")
-	defer tearDown()
-
-	genesis := btcutil.NewBlock(params.GenesisBlock)
-	genesis.SetHeight(0)
-	proofState := newTestUtreexoProofState()
-	attachedBlock, _ := proofState.newBlock(t, chain, genesis, nil)
-	err := chain.db.Update(func(dbTx database.Tx) error {
-		return dbStoreBlock(dbTx, attachedBlock)
-	})
-	require.NoError(t, err, "dbStoreBlock")
-
+// TestInvalidUtreexoProofIsNotStored ensures rejected proofs are not persisted.
+func TestInvalidUtreexoProofIsNotStored(t *testing.T) {
 	tests := []struct {
-		name    string
-		block   *btcutil.Block
-		wantErr bool
+		name      string
+		flags     BehaviorFlags
+		sideChain bool
 	}{
-		{
-			name:  "attached proof",
-			block: attachedBlock,
-		},
-		{
-			name:    "missing proof",
-			block:   btcutil.NewBlock(params.GenesisBlock),
-			wantErr: true,
-		},
+		{name: "main chain"},
+		{name: "main chain fast add", flags: BFFastAdd},
+		{name: "side chain", sideChain: true},
 	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			err := chain.storeUtreexoProof(test.block)
-			if test.wantErr {
-				require.Error(t, err)
-				require.IsType(t, AssertError(""), err,
-					"storeUtreexoProof error type")
-				assertNoStoredUtreexoProof(t, chain, test.block)
-				return
-			}
-			require.NoError(t, err, "storeUtreexoProof")
-			assertStoredUtreexoProof(t, chain, test.block)
-		})
-	}
-}
-
-// TestValidateUtreexoProof ensures validation has no storage or best-chain side
-// effects.
-func TestValidateUtreexoProof(t *testing.T) {
-	tests := []struct {
-		name    string
-		mutate  func(*btcutil.Block)
-		wantErr bool
-	}{
-		{
-			name: "valid proof",
-		},
-		{
-			name: "invalid proof",
-			mutate: func(block *btcutil.Block) {
-				ud := *block.UtreexoData()
-				ud.LeafDatas = append([]wire.LeafData(nil),
-					ud.LeafDatas...)
-				ud.LeafDatas[0].Amount++
-				block.SetUtreexoData(&ud)
-			},
-			wantErr: true,
-		},
-	}
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			chain, params, _, tearDown := countingUtreexoTestChain(t,
-				"validate-proof")
+				"invalid-proof")
 			defer tearDown()
 
 			genesis := btcutil.NewBlock(params.GenesisBlock)
@@ -361,99 +282,48 @@ func TestValidateUtreexoProof(t *testing.T) {
 			mainProofState := newTestUtreexoProofState()
 			branchProofState := newTestUtreexoProofState()
 
-			// Establish a shared fork point for both proof states.
-			forkBlock, forkAdds := mainProofState.newBlock(t, chain,
-				genesis, nil)
+			forkBlock, forkAdds := mainProofState.newBlock(t, chain, genesis, nil)
 			branchProofState.attachUData(t, forkBlock, nil)
 			processBlock(t, chain, forkBlock, true)
 
-			// Keep the candidate branch off the main chain.
-			mainTip := forkBlock
-			for i := 0; i < 2; i++ {
-				mainBlock, _ := mainProofState.newBlock(t, chain,
-					mainTip, nil)
+			if test.sideChain {
+				mainBlock, _ := mainProofState.newBlock(t, chain, forkBlock, nil)
 				processBlock(t, chain, mainBlock, true)
-				mainTip = mainBlock
 			}
 
-			// Build a candidate whose proof depends on its branch parent.
-			branchParent, branchAdds := branchProofState.newBlock(t,
-				chain, forkBlock, forkAdds[:1])
-			processBlock(t, chain, branchParent, false)
+			// Corrupt the proof by changing a committed leaf amount.
+			block, _ := branchProofState.newBlock(t, chain, forkBlock, forkAdds[:1])
+			ud := *block.UtreexoData()
+			ud.LeafDatas = append([]wire.LeafData(nil), ud.LeafDatas...)
+			ud.LeafDatas[0].Amount++
+			block.SetUtreexoData(&ud)
 
-			block, _ := branchProofState.newBlock(t, chain,
-				branchParent, branchAdds[:1])
-			if test.mutate != nil {
-				test.mutate(block)
-			}
-			parentNode := chain.index.LookupNode(branchParent.Hash())
-			require.NotNil(t, parentNode, "parent block %s not "+
-				"indexed", branchParent.Hash())
-			node := newBlockNode(&block.MsgBlock().Header, parentNode)
+			_, _, err := chain.ProcessBlock(block, test.flags)
+			require.Error(t, err, "ProcessBlock accepted an invalid utreexo proof")
 
-			// Direct validation must not store the proof or mutate the best-chain
-			// accumulator.
-			chain.chainLock.Lock()
-			rootsBefore := append([]utreexo.Hash(nil),
-				chain.utreexoView.accumulator.GetRoots()...)
-			leavesBefore := chain.utreexoView.NumLeaves()
-			err := chain.validateUtreexoProof(node, block)
-			rootsUnchanged := chain.utreexoView.compareRoots(rootsBefore)
-			leavesAfter := chain.utreexoView.NumLeaves()
-			chain.chainLock.Unlock()
-			if test.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-			assertNoStoredUtreexoProof(t, chain, block)
-			require.True(t, rootsUnchanged,
-				"validation mutated the best-chain accumulator")
-			require.Equal(t, leavesBefore, leavesAfter,
-				"validation mutated the best-chain accumulator")
-			if !test.wantErr {
-				require.NotNil(t, block.UtreexoUpdateData(),
-					"validated proof was not applied to the "+
-						"accumulator")
-			}
+			var hasBlock bool
+			var proof []byte
+			err = chain.db.View(func(dbTx database.Tx) error {
+				var err error
+				hasBlock, err = dbTx.HasBlock(block.Hash())
+				if err != nil {
+					return err
+				}
+				proof, err = dbTx.FetchUtreexoProof(block.Hash())
+				proof = bytes.Clone(proof)
+				return err
+			})
+			require.NoError(t, err)
+			require.False(t, hasBlock, "block stored with an invalid utreexo proof")
+			require.Nil(t, proof)
 		})
 	}
 }
 
-// TestInvalidUtreexoProofIsNotStored ensures rejected proofs are not persisted.
-func TestInvalidUtreexoProofIsNotStored(t *testing.T) {
-	chain, params, _, tearDown := countingUtreexoTestChain(t,
-		"invalid-proof")
-	defer tearDown()
-
-	genesis := btcutil.NewBlock(params.GenesisBlock)
-	genesis.SetHeight(0)
-	mainProofState := newTestUtreexoProofState()
-	branchProofState := newTestUtreexoProofState()
-
-	forkBlock, forkAdds := mainProofState.newBlock(t, chain, genesis, nil)
-	branchProofState.attachUData(t, forkBlock, nil)
-	processBlock(t, chain, forkBlock, true)
-
-	// Keep the invalid candidate on a side chain.
-	mainBlock, _ := mainProofState.newBlock(t, chain, forkBlock, nil)
-	processBlock(t, chain, mainBlock, true)
-
-	// Corrupt the proof by changing a committed leaf amount.
-	block, _ := branchProofState.newBlock(t, chain, forkBlock, forkAdds[:1])
-	ud := *block.UtreexoData()
-	ud.LeafDatas = append([]wire.LeafData(nil), ud.LeafDatas...)
-	ud.LeafDatas[0].Amount++
-	block.SetUtreexoData(&ud)
-
-	_, _, err := chain.ProcessBlock(block, BFNone)
-	require.Error(t, err, "ProcessBlock accepted an invalid utreexo proof")
-	assertNoStoredUtreexoProof(t, chain, block)
-}
-
 // TestStoreMainChainUtreexoProof ensures a main-chain proof is stored once.
 func TestStoreMainChainUtreexoProof(t *testing.T) {
-	chain, params, _, tearDown := countingUtreexoTestChain(t, "main-proof")
+	chain, params, countingDB, tearDown := countingUtreexoTestChain(t,
+		"main-proof")
 	defer tearDown()
 
 	genesis := btcutil.NewBlock(params.GenesisBlock)
@@ -462,6 +332,7 @@ func TestStoreMainChainUtreexoProof(t *testing.T) {
 	block, _ := proofState.newBlock(t, chain, genesis, nil)
 
 	processBlock(t, chain, block, true)
+	require.Equal(t, 1, countingDB.stores)
 	assertStoredUtreexoProof(t, chain, block)
 }
 

--- a/blockchain/utreexo_rollback_regression_test.go
+++ b/blockchain/utreexo_rollback_regression_test.go
@@ -5,6 +5,7 @@
 package blockchain
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/utreexo/utreexod/btcutil"
 	"github.com/utreexo/utreexod/chaincfg/chainhash"
 	"github.com/utreexo/utreexod/database"
+	"github.com/utreexo/utreexod/wire"
 )
 
 var errRegressionProofStore = errors.New("regression proof store failure")
@@ -44,10 +46,10 @@ func (tx *regressionProofStoreFailTx) StoreUtreexoProof(*chainhash.Hash,
 	return errRegressionProofStore
 }
 
-// TestUtreexoViewRollbackOnProofStoreFailure ensures a block is not left
-// applied to the in-memory accumulator when its proof cannot be persisted.
+// TestUtreexoViewRollbackOnProofStoreFailure ensures proof persistence failure
+// leaves the block and accumulator state unchanged so the block can be retried.
 func TestUtreexoViewRollbackOnProofStoreFailure(t *testing.T) {
-	chain, params, _, tearDown := countingUtreexoTestChain(t,
+	chain, params, countingDB, tearDown := countingUtreexoTestChain(t,
 		"proof-store-rollback")
 	defer tearDown()
 
@@ -61,15 +63,138 @@ func TestUtreexoViewRollbackOnProofStoreFailure(t *testing.T) {
 	leavesBefore := chain.utreexoView.NumLeaves()
 	tipBefore := chain.bestChain.Tip().hash
 
-	chain.db = &regressionProofStoreFailDB{DB: chain.db}
-	mainChain, orphan, err := chain.ProcessBlock(block, BFNone)
+	chain.db = &regressionProofStoreFailDB{DB: countingDB}
+	_, _, err := chain.ProcessBlock(block, BFNone)
 	require.ErrorIs(t, err, errRegressionProofStore)
-	require.False(t, mainChain, "failed block reported on main chain")
-	require.False(t, orphan, "failed block reported as orphan")
 	require.Equal(t, tipBefore, chain.bestChain.Tip().hash,
 		"best-chain tip changed after proof store failure")
 	require.True(t, chain.utreexoView.compareRoots(rootsBefore),
 		"proof store failure left the block applied to the accumulator")
 	require.Equal(t, leavesBefore, chain.utreexoView.NumLeaves(),
 		"proof store failure changed the accumulator leaf count")
+
+	var hasBlock bool
+	var proof []byte
+	err = chain.db.View(func(dbTx database.Tx) error {
+		var err error
+		hasBlock, err = dbTx.HasBlock(block.Hash())
+		if err != nil {
+			return err
+		}
+		proof, err = dbTx.FetchUtreexoProof(block.Hash())
+		proof = bytes.Clone(proof)
+		return err
+	})
+	require.NoError(t, err)
+	require.False(t, hasBlock, "block stored without its utreexo proof")
+	require.Nil(t, proof)
+
+	// Restore proof writes to verify the same block can be submitted again.
+	chain.db = countingDB
+	processBlock(t, chain, block, true)
+	var want bytes.Buffer
+	require.NoError(t, block.UtreexoData().Serialize(&want))
+	err = chain.db.View(func(dbTx database.Tx) error {
+		var err error
+		proof, err = dbTx.FetchUtreexoProof(block.Hash())
+		proof = bytes.Clone(proof)
+		return err
+	})
+	require.NoError(t, err)
+	require.Equal(t, want.Bytes(), proof)
+}
+
+// TestInvalidTTLUtreexoDataIsNotStored ensures malformed Utreexo data is
+// rejected before the block and proof are persisted or the accumulator changes.
+func TestInvalidTTLUtreexoDataIsNotStored(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*btcutil.Block)
+	}{
+		{
+			name: "empty leaf data",
+			mutate: func(block *btcutil.Block) {
+				udata := block.UtreexoData()
+				udata.LeafDatas = nil
+				block.SetUtreexoData(udata)
+			},
+		},
+		{
+			name: "short leaf data",
+			mutate: func(block *btcutil.Block) {
+				udata := block.UtreexoData()
+				udata.LeafDatas = udata.LeafDatas[:1]
+				block.SetUtreexoData(udata)
+			},
+		},
+		{
+			name: "short ttls",
+			mutate: func(block *btcutil.Block) {
+				ttls := block.UtreexoTTLs()
+				ttls.TTLs = ttls.TTLs[:len(ttls.TTLs)-1]
+			},
+		},
+	}
+	for _, mode := range []struct {
+		name  string
+		flags BehaviorFlags
+	}{
+		{name: "normal", flags: BFNone},
+		{name: "fast add", flags: BFFastAdd},
+	} {
+		for _, test := range tests {
+			t.Run(mode.name+"/"+test.name, func(t *testing.T) {
+				chain, params, _, tearDown := countingUtreexoTestChain(t,
+					"invalid-ttl-udata")
+				defer tearDown()
+
+				// Build a block that needs two leaf datas so a partial slice is invalid.
+				genesis := btcutil.NewBlock(params.GenesisBlock)
+				genesis.SetHeight(0)
+				proofState := newTestUtreexoProofState()
+				firstBlock, firstAdds := proofState.newBlock(t, chain, genesis, nil)
+				processBlock(t, chain, firstBlock, true)
+				secondBlock, secondAdds := proofState.newBlock(t, chain, firstBlock, nil)
+				processBlock(t, chain, secondBlock, true)
+
+				spends := []wire.LeafData{firstAdds[0], secondAdds[0]}
+				block, adds := proofState.newBlock(t, chain, secondBlock, spends)
+				block.SetUtreexoTTLs(&wire.UtreexoTTL{
+					BlockHeight: uint32(block.Height()),
+					TTLs:        make([]wire.TTLInfo, len(adds)),
+				})
+				test.mutate(block)
+
+				// Rejection must leave the chain and both stores unchanged.
+				tipBefore := chain.BestSnapshot()
+				rootsBefore := append([]utreexo.Hash(nil),
+					chain.utreexoView.accumulator.GetRoots()...)
+				leavesBefore := chain.utreexoView.NumLeaves()
+				aggBefore := chain.utreexoView.agg
+				_, _, err := chain.ProcessBlock(block, mode.flags)
+				require.Error(t, err)
+				require.Equal(t, tipBefore, chain.BestSnapshot())
+				require.Equal(t, tipBefore.Hash, chain.bestChain.Tip().hash)
+				require.True(t, chain.utreexoView.compareRoots(rootsBefore))
+				require.Equal(t, leavesBefore, chain.utreexoView.NumLeaves())
+				require.Equal(t, aggBefore, chain.utreexoView.agg)
+
+				var hasBlock bool
+				var proof []byte
+				err = chain.db.View(func(dbTx database.Tx) error {
+					var err error
+					hasBlock, err = dbTx.HasBlock(block.Hash())
+					if err != nil {
+						return err
+					}
+					proof, err = dbTx.FetchUtreexoProof(block.Hash())
+					proof = bytes.Clone(proof)
+					return err
+				})
+				require.NoError(t, err)
+				require.False(t, hasBlock)
+				require.Nil(t, proof)
+			})
+		}
+	}
 }

--- a/blockchain/utreexoviewpoint.go
+++ b/blockchain/utreexoviewpoint.go
@@ -306,6 +306,13 @@ func ExtractAccumulatorDels(block *btcutil.Block, bestChain *chainView) (
 
 	_, _, inskip, _ := DedupeBlock(block)
 
+	// Reconstruction indexes one leaf data for each outpoint needing a proof.
+	OPsToProve := BlockToDelOPs(block)
+	if len(OPsToProve) != len(ud.LeafDatas) {
+		return nil, fmt.Errorf("ExtractAccumulatorDels(): expected %d leaf datas, got %d",
+			len(OPsToProve), len(ud.LeafDatas))
+	}
+
 	// Make slice of hashes from the LeafDatas. These are the hash commitments
 	// to be proven.
 	//
@@ -320,9 +327,7 @@ func ExtractAccumulatorDels(block *btcutil.Block, bestChain *chainView) (
 		}
 	}
 
-	// Grab the outpoints that need their existence proven and check that
-	// the udata matches up.
-	OPsToProve := BlockToDelOPs(block)
+	// Check that the reconstructed udata matches the outpoints.
 	err := ProofSanity(ud, OPsToProve)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Store the block and its Utreexo proof in the same database transaction so a proof store failure permits another submission.

Validate proofs and TTL leaf data before storage. Check leaf data counts before reconstruction indexes the supplied slice.

Cover storage failures, successful retries, and invalid data under normal validation, fast-add, and side-chain processing.

Validation: go test ./blockchain ./blockchain/indexers ./netsync