### PR TITLE
main: update utreexo library to v0.19.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23
 	github.com/stretchr/testify v1.11.1
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/utreexo/utreexo v0.18.0
+	github.com/utreexo/utreexo v0.19.0
 	golang.org/x/crypto v0.25.0
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 	pgregory.net/rapid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -334,6 +334,8 @@ github.com/utreexo/utreexo v0.17.3-0.20260620070342-aef53b466e55 h1:dZiqFeV0765g
 github.com/utreexo/utreexo v0.17.3-0.20260620070342-aef53b466e55/go.mod h1:7BbTQYp48IyyfSmPG+QoWxldLfyO0+5zOqKw1lF27WE=
 github.com/utreexo/utreexo v0.18.0 h1:Wn9zFyz1gS9OyZKBjF4HKBMDp7DQ4D0F9wrfMmAChmE=
 github.com/utreexo/utreexo v0.18.0/go.mod h1:7BbTQYp48IyyfSmPG+QoWxldLfyO0+5zOqKw1lF27WE=
+github.com/utreexo/utreexo v0.19.0 h1:lWdrH4tutP16SqhjQwNB7lJIcT/AOl3dnFneCwVxftg=
+github.com/utreexo/utreexo v0.19.0/go.mod h1:7BbTQYp48IyyfSmPG+QoWxldLfyO0+5zOqKw1lF27WE=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Use v0.19.0 for MapPollardView, PrepareModify, and PrepareUndo. These APIs allow accumulator changes to be prepared before a database transaction and committed after it succeeds.

Validation: go test ./...